### PR TITLE
chore: run `companion_translations`

### DIFF
--- a/companion/src/translations/companion_cs.ts
+++ b/companion/src/translations/companion_cs.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>Ne</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ano, ovládané jedním kanálem</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ano, ovládané dvěma kanály</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;První kanál křidélek:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>&lt;br&gt;Druhý kanál křidélek:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>Ne</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ano, ovládané jedním kanálem</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ano, ovládané dvěma kanály</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;První kanál brzdících klapek:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>&lt;br&gt;Druhý kanál brzdících klapek:</translation>
     </message>
@@ -60,23 +60,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation>Nelze uložit nastavení aplikace do souboru &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation>protože soubor nemůže být uložen (zkontrolujte přístupová práva)</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation>z neznámého důvodu.</translation>
     </message>
@@ -169,22 +169,22 @@
         <translation>Profil rádia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>Výchozí pořadí kanálů</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>Výchozí mód vysílačky</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>Vybrat obrázek</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -225,662 +225,657 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Mód1 (Směr.Výšk.Plyn.Křid)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Mód2 (Směr.Plyn.Výšk.Křid)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Mód3 (Křid.Výšk.Plyn.Směr)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Mód4 (Křid.Plyn.Výšk.Směr)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>Úvodní logo</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>Specifická složka profilu, pokud je nastavena, bude použita místo výchozí složky z nastavení aplikace</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>Složka pro zálohy</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>Pokud je nastavena, bude použita místo výchozí složky z nastavení aplikace</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>Pokud je nastaveno, bude použito místo výchozí volby z nastavení aplikace</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pořadí kanálů&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Definuje výchozí pořadí kanálů použité při vytvoření nového modelu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>S V P K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>S V K P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>S P V K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>S P K V</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>S K V P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation>S K P V</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>V S P K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>V S K P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>V P S K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>V P K S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>V K S P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>V K P S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>P S V K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>P S K V</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>P V S K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>P V K S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>P K S V</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>P K V S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>K S V P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>K S P V</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>K V S P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>K V P S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>K P S V</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>K P V S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>Vybrat složku</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>Vybrat</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished">Profily rádia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation>Kanál vydání</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>Zisk hlasitosti simulátoru</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>Název profilu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>Odstranit</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>Typ rádia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>Ostatní volby</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>Obecná nastavení</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>Cesta k obsahu SD karty</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>Nastavení aplikace</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>Automatická záloha před zápisem firmwaru</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>Knihovna s úvodními logy</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Spustitelný soubor Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>Zobrazit jen vlastní loga</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>Zobrazit vlastní loga i loga Companion</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>Cesta k vlastním souborům</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>Složka pro automatické zálohy</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>Nastavení simulátoru</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>Barva podsvětlení Simu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>Povolit</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation>Vytvoření nového modelu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Tato možnost zachovává chování ze starších verzí OpenTx, kde jsou prázdné pozice modelů zachovány při vymazání nebo přesunutí modelu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation>naposledny použité soubory</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation>Nastavení zapnutí</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation>Zapamatovat</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation>Výstupní složka pro záznamy</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation>Záznam pro režim ladění</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation>Použití (Companion/Simulátor)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation>Firmware vysílače (v simulátoru)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>Modrá</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>Zelená</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>Červená</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>Oranžová</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>Žlutá</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation>Složka pro snímky obrazovky</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>Joystick</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>Kalibrovat</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>Kopírovat pouze do schránky</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Moje rádio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Vybrat složku pro snímky obrazovky simulátoru</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Joystick nenalezen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>PRÁZDNÉ: V profilu nejsou uložena žádná nastavení rádia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>DOSTUPNÉ: Nastavení rádia jsou neznámého stáří</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>DOSTUPNÉ: Nastavení rádia jsou uložena %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Vyberat složkus s logy</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Zvolit složku pro automatické zálohy modelů a nastavení</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation>Vybrat složku pro záznamy aplikace</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Zvolit spustitelnou binárku aplikace Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Vybrat složku, která představuje obsah SD karty rádia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Otevřít soubor s logem</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Obrázky (%1)</translation>
     </message>
@@ -888,31 +883,31 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation>Chyba čtení %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation>Nelze uložit do EEPROM</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Nelze otevřít soubor %1:
 %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Chyba při zápisu souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation>Neplatný binární EEPROM soubor %1</translation>
     </message>
@@ -950,33 +945,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -987,255 +982,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation>Levá horizontální</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation>Levá vertikální</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation>Pravá vertikální</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation>Pravá horizontální</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished">Spínač</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">Let</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Pot s aretací</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2 pozice bez aretace</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 pozice</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 pozice</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Funkce</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">Rastr-X</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">Malá</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">Obě</translation>
     </message>
@@ -1243,17 +1248,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation>Záporný rozsah</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation>Střední hodnota</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation>Kladný rozsah</translation>
     </message>
@@ -1261,132 +1266,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished">Subtrim</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished">Invertovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">Křivka</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished">Střed</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished">Symetrický</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished">Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished">Vyjmout</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished">Vymazat</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished">Odstranit</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished">Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished">Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished">Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1429,58 +1434,58 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Nelze zapsat soubor %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished">Nelze otevřít soubor %1:
 %2</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1496,12 +1501,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1509,173 +1514,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished">Varování</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished">Chyba</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished">Nastavení aplikace</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation>soubory</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation>Nastavení rádia a modelů</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished">Simulátor pro tuto verzi firmware zatím není dostupný</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished">Neznámá chyba během spuštění simulace.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1713,22 +1728,22 @@ Do you want to import settings from a file?</source>
         <translation>Tisk do souboru</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation>Nepojmenovaný model %1</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation>Kliněte pro odstranění tohoto modelu.</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Vytisknout dokument</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>Vyberte cílový PDF soubor</translation>
     </message>
@@ -1754,7 +1769,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>OK, rozuměl jsem.</translation>
     </message>
@@ -1762,17 +1777,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>Chyba zápisu</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>Nelze zapsat %1 (důvod: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation>Nelze otevřít %1 (důvod: %2)</translation>
     </message>
@@ -1780,22 +1795,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished">Rastr-X</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished">%1 bodů</translation>
     </message>
@@ -1878,32 +1893,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">Lineární</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">Expo</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">Symetrická f(x)=-f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">Symetrická f(x)=f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1911,7 +1926,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1919,22 +1934,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished">Diferenciace</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished">Exponenciála</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished">Funkce</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,113 +1957,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished">Součet</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">Úpravy</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished">Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished">Vyjmout</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished">Vymazat</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished">Odstranit</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished">Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished">Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished">Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2056,343 +2071,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished">Zámek %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished">Trenér - směrovka</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished">Trenér - výškovka</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished">Trenér - plyn</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished">Trenér - křidélka</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished">Přehrát zvuk</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished">Vibrovat</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>Vypnutí zesilovače zvuku</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished">Hrát jednou, ne při výběru modelu</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished">Neopakovat</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation type="unfinished">Zdroj</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation>Přehrát stopu</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation>Přehrát oboje</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation>Přehrát hodnotu</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation>SD záznamy</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished">Hlasitost</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation>Podsvětlení</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation>Snímek obrazovky</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation>Hudba na pozadí</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation>Hudba na pozadí -pozastavit</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation>Upravit %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished">Bind vnitř. modulu</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished">Bind ext. modulu</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished">Let</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished">ZAKÁZÁN</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2400,123 +2435,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Spínač</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Akce</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished">Povolit</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished">GP</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished">Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished">Vyjmout</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished">Vymazat</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished">Odstranit</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished">Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished">Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished">Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2524,22 +2559,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished">Hodnoty</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">Ukazatele</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished">Skript</translation>
     </message>
@@ -2547,47 +2582,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">Letový režim</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2644,82 +2679,82 @@ Do you want to import settings from a file?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished">Obr: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished">Obrázek profilu</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>Otevřít soubor firmwaru</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>Nelze načíst vložený obrázek ze souboru firmwaru %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>Otevřít soubor s logem</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>obrázky (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>Nelze načíst obrázek %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>Nelze načíst obrázek profilu %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>Nelze načíst obrázek z knihovny %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>Soubor byl uložen</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>Obrázek byl uložen do souboru %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>Chyba čtení obrázku</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>Nelze číst obrázek ze souboru %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>Nelze uložit</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>Nelze uložit obrázek do %1</translation>
     </message>
@@ -2727,22 +2762,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation></translation>
     </message>
@@ -2750,53 +2785,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished">Spínač</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished">Spínač </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished">-na této desce nelze exportovat!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished">Zdroj</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished">Zdroj %1 nelze na této desce exportovat!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished">V OpenTX je možné zadat pouze %1 bodů dohromady ve všech křivkách</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished">V OpenTX je možné zadat pouze %1 bodů dohromady ve všech křivkách</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished">OpenTX nepodporuje tuto funkci na této zákl. desce</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished">OpenTX nepodporuje tento protokol</translation>
     </message>
@@ -2804,52 +2839,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished">Zap</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished">Ne</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished">Ano</translation>
     </message>
@@ -2929,101 +2964,82 @@ Pro &lt;b&gt;odstranění uloženého záznamu&lt;/b&gt; ze seznamu filtrů, zá
         <translation>Zapne / vypne filtr.</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation>Nápověda k filtru ladící konzole</translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished">Stahuji: </translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation type="unfinished">Stažení se nezdařilo: %1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished">Možné příčiny:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished">- eeprom pochází z novější verze OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished">- eeprom nepochází z OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished">- eeprom nepochází z Ersky9X</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished">- velikost eeprom není platná</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished">- eeprom struktura souboru je poškozená</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished">- eeprom pochází z neznámé hw platformy</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished">- eeprom pochází z jiné desky</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished">- záloha eeprom není podporována</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished">- problém který neumíme určit, bohužel</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished">Varování:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished">Vaše rádio možná používá jiný firmware než by mělo, velikost eeprom je 4096, ale jen polovina je používána</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3032,12 +3048,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,12 +3061,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3058,12 +3074,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;První kanál elevonů:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>&lt;br&gt;Druhý kanál elevonů:</translation>
     </message>
@@ -3071,42 +3087,42 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Chyba při otevírání souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Chyba při zápisu souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3114,23 +3130,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">Zap</translation>
     </message>
@@ -3138,111 +3154,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Váha</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Křivka</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Ofset</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>Zdroj pro mix</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation>GP</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Letové režimy</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Spínač</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>Měřítko</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Použít trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>Zdroj</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Strana páky</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>Zdroj pro mixer.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Spínač aktivující tento vstup.
-Pokud není použito, vstup je AKTIVNÍ stále.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation>x&lt;0(Negativní)</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation>x&gt;0(Pozitivní)</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>Obě</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>Křivka která se aplikuje na zdroj.</translation>
     </message>
@@ -3252,22 +3252,22 @@ Pokud není použito, vstup je AKTIVNÍ stále.</translation>
         <translation>Upravit %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation>Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation>Nastavit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation>Invertovat vše</translation>
     </message>
@@ -3275,22 +3275,22 @@ Pokud není použito, vstup je AKTIVNÍ stále.</translation>
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>Kanál plynu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>Kanál bočení:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>Kanál klopení:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>Kanál klonění:</translation>
     </message>
@@ -3298,262 +3298,262 @@ Pokud není použito, vstup je AKTIVNÍ stále.</translation>
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished">Jak naložit s přepisem souborů, které již existují v cílové složce.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished">Kopírovat pouze v případě, že je novější a odlišné (porovnání obsahu)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished">Kopírovat pouze v případě, že je novější (neporovnává obsah)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished">Kopírovat pouze v případě, že jsou odlišné (ignoruje časové razítko)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished">Vždy kopíruje (vymaže existující soubory)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished">Jakákoliv</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished">Přeskočí soubory větší než tato velikost. Zadejte nulu pro neomezené.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished">Pouze testování</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished">Běží jako normálně, ale nic nekopíruje. Užitečné pro ověření výsledků před reálnou synchronizací.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished">Zavřít</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished">Směr synchronizace:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished">Existující soubory:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished">Max. velikost souboru:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished">První kanál</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3561,315 +3561,354 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished">Funkce Zámek kanálu není dostupná</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished">Možnost povolit FAI MODE v menu rádia.
 FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a funkce hlasového hlášení.</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished">FAI MODE vždy aktivní (nelze vypnout v menu rádia)
 FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a funkce hlasového hlášení.</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Odstranit funkce pro heli a nastavení typu mechaniky</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">Odstranit Globální proměnné</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished">Použít alternativní znakovou sadu písma (jiný font)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished">Moznost zadávat hodnoty
 a pohybovat se v menu
 pomocí potenciometrů</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">Podpora pro vibrační modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished">Přidá potvrzování před vypnutím rádia</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Funkce pro heli, nastavení typu mechaniky</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished">Aktivuje Globální Proměnné
 Jsou to proměnné, které lze použít pro konfiguraci místo některých pevných číselných hodnot.
@@ -3878,29 +3917,29 @@ Jejich hodnoty naleznete u originální 9x desky v seznamu křivek. U ostatních
 Nastavení hodnoty se provádí přímo v seznamu proměnných, nebo pomocí Funkce</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished">Výběr spínače v mixu atd.
 se provádí jeho sepnutím</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished">Výběr spínače v mixu atd.
 se provádí jeho sepnutím</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished">Nahrazeni posuvníku a zatržítek (checkboxu) textem</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished">Grafické znázornění stavu baterie</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished">Vypnout zvýraznění aktivních mixů/spínačů tučným písmem.
 Pokud není tato volby vybrána,
@@ -3909,33 +3948,38 @@ zobrazovány tučným pismem. Neaktivní mixy/spínače budou
 zobrazeny normálním písmem</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished">Rychlé nastavení hodnoty současným stiskem dvou tlačítek.
 (+) a (-) invertuje hodnotu
@@ -3947,27 +3991,27 @@ zobrazeny normálním písmem</translation>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>Ne</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ano, ovládané jedním kanálem</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ano, ovládané dvěma kanály</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;První kanál klapek:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>&lt;br&gt;Druhý kanál klapek:</translation>
     </message>
@@ -3976,7 +4020,7 @@ zobrazeny normálním písmem</translation>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Zapsat modely a nastavení do rádia</translation>
     </message>
@@ -4041,51 +4085,51 @@ zobrazeny normálním písmem</translation>
         <translation>Zapsat do rádia</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>Současný profil: %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>Vyberte soubor se zálohou rádia</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>Profil neobsahuje platná kalibrační data, nastavení nebyla upravena</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>Profil neobsahuje platná data nastavení rádia, nastavení nebyla upravena</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Nelze zapsat soubor %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Chyba při zápisu souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>Firmware rádia je z jiné rodiny produktů , zkontrolujte nastavení předvoleb!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>Firmware rádia je zastaralý, aktualizujte ho prosím!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>Nelze ověřit kompatibilitu dat modelů a nastavení! Chcete přesto pokračovat?</translation>
     </message>
@@ -4163,103 +4207,103 @@ zobrazeny normálním písmem</translation>
         <translation>Zapsat do rádia</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>Otevřít soubor firmwaru</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 nemusí být platný soubor firmwaru</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>Soubor firmwaru není platný.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>Soubor firmware neobsahuje žádné logo.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>Obrázek profilu %1 není platný.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>Otevřít soubor obrázku pro použití jako úvodní logo</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>Obrázky (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>Nelze načíst obrázek z %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>Nelze načíst obrázek z knihovny</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>Obrázek loga nebyl nalezen</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>Nelze uložit upravený firmware</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>Zapsat firmware do rádia</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>Kontrola firmwaru selhala</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>Nelze ověřit firmware v rádiu</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>Nový firmware není kompatibilní s verzí instalovanou v rádiu!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>Převod selhal</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>Nemohu převést modely a nastavení pro použití s tímto firmwarem, budou použita původní data</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>Obnovení selhalo</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>Nelze obnovit modely a nastavení rádia. Data modelů a nastavení naleznete v %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>Zápis firmware je dokončen</translation>
     </message>
@@ -4267,47 +4311,47 @@ zobrazeny normálním písmem</translation>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation>Spustitelný soubor %1 nebyl nalezen</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation>Zápis...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation>Načítání...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation>Ověřování...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation>neznámý</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>ie: OpenTX pro desku 9X nebo OpenTX pro 9XR</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>ie: OpenTX pro M128 / 9X nebo OpenTX pro 9XR s čipem M128</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>ie: OpenTX pro desku Gruvin9X</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4316,7 +4360,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 Zkontrolujte prosím rozšířená nastavení programátoru a nastavte správný typ CPU.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4325,7 +4369,7 @@ Please select an appropriate firmware type to program it.</source>
 Vyberte prosím správný typ firmwaru.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4334,22 +4378,22 @@ Nyní používáte:
  %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>Vaše rádio není připojeno k USB nebo není inicializován ovladač!.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>Zápis je dokončen (exit code = %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>Zápis byl dokončen s chybami</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>POJISTKY MCU: Low=%1 High=%2 Ext=%3</translation>
     </message>
@@ -4357,7 +4401,7 @@ Nyní používáte:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
@@ -4408,225 +4452,240 @@ Nyní používáte:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>Otočný enkodér %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>Zdroj hodnot</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>GP%1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Vyskakovací okno povoleno</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished">Trim zakázán</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished">Vlastní trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished">Použít trim z letového režimu %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished">Použít hodnotu trimu z letového režimu %1 + vlastní trim jako ofset</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished">Jednotky</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">GP%1</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Vlastní hodnota</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished">Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished">Vyjmout</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished">Odstranit</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished">Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished">Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished">Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>Vymazat</translation>
     </message>
@@ -4634,17 +4693,17 @@ Nyní používáte:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>Letový režim %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (výchozí)</translation>
     </message>
@@ -4652,17 +4711,17 @@ Nyní používáte:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>Má stabilizátor(Flybar)</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>Bez stabilizátoru (Flybarless)</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>Stabilizátor:</translation>
     </message>
@@ -4670,17 +4729,17 @@ Nyní používáte:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished">Žlutá</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished">Oranžová</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished">Červená</translation>
     </message>
@@ -4688,13 +4747,13 @@ Nyní používáte:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4712,17 +4771,18 @@ Nyní používáte:
         <translation>Nastavitelné přepínače</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished">První kanál</translation>
     </message>
@@ -4732,7 +4792,12 @@ Nyní používáte:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4740,8 +4805,13 @@ Nyní používáte:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4846,13 +4916,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Provádějte pouze pokud opravdu víte co děláte.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4860,44 +4930,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">GP</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished">Vlastní hodnota</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation type="unfinished">Hodnota režimu LR%1</translation>
     </message>
 </context>
 <context>
@@ -4925,57 +4985,57 @@ These will be relevant for all models in the same EEPROM.</source>
 Tyto volby jsou platné pro všechny modely v jedné EEPROM.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Nastevní</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Trenér</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>Globální funkce</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation>Kalibrace</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>Špatná data v profilu, není možné získat parametry kalibrace</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>Špatná data v profilu, není možné získat nastavení Přepínač/Potenciometr</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>Špatná data v profilu, není možné získat HW parametry</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>Chcete uložit kalibraci do profilu %1&lt;br&gt;Přepsat existující kalibraci?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>Kalibrace a HW parametry byly uloženy.</translation>
     </message>
@@ -5014,8 +5074,8 @@ Tyto volby jsou platné pro všechny modely v jedné EEPROM.</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Letové režimy</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5051,185 +5111,208 @@ Tyto volby jsou platné pro všechny modely v jedné EEPROM.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished">Spínač</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished">Interní</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">Trenér</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">SBUS trenér</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished">Normální</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished">Pouze trimy</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished">Pouze tlačítka</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished">Přepinatelné</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished">Globální</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">Mód1 (Směr.Výšk.Plyn.Křid)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished">Mód2 (Směr.Plyn.Výšk.Křid)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">Mód3 (Křid.Výšk.Plyn.Směr)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">Mód4 (Křid.Plyn.Výšk.Směr)</translation>
     </message>
 </context>
 <context>
@@ -5245,201 +5328,199 @@ Tyto volby jsou platné pro všechny modely v jedné EEPROM.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Časový posun od UTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Jazyk hlasových zpráv</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Kód země</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Revers os kniplů</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>FAI mód</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Nastavit RTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Tón varia na maximu</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Hlasitost reproduktoru</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>Spínač podsvětlení</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Mód zvuku</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>Barva 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>Barva 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>Tón zvuku (pouze spkr)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Pokud tato hodnota není nula, každé stisknutí klávesy zapne podsvétlení a vypne ho až po uplynutí nastaveného počtu sekund.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>Barva podsvětlení</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>Bzučák</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Reproduktor</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>Bzučák+Hlas</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>Repro+Hlas</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Upozornění</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Wav soubor</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Vario</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Zvuk v pozadí</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>Auto. vypnutí podsvětlení po</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>Blik. podsvětlením při alarmu</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Tón varia na nule</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Opakování varia na nule</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5447,7 +5528,7 @@ Tyto volby jsou platné pro všechny modely v jedné EEPROM.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5462,42 +5543,42 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Hodnoty mohou být 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>Jas podsvětlení</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Navigace otočným enkodérem</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>Automaticky nastaví hodiny rádia, pokud je k telemetrii připojen GPS.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>Amerika</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Japonsko</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>Evropa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>Jas vypnutého podsvětlení</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5538,252 +5619,112 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>Mód1 (Směr.Výšk.Plyn.Křid)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>Mód2 (Směr.Plyn.Výšk.Křid)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>Mód3 (Křid.Výšk.Plyn.Směr)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>Mód4 (Křid.Plyn.Výšk.Směr)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pořadí kanálů&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Definuje výchozí pořadí kanálů použité při vytvoření nového modelu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation>S V P K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation>S V K P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation>S P V K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation>S P K V</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation>S K V P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation>S K P V</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation>V S P K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation>V S K P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation>V P S K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation>V P K S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation>V K S P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation>V K P S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation>P S V K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation>P S K V</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation>P V S K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation>P V K S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation>P K S V</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation>P K V S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation>K S V P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation>K S P V</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation>K V S P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation>K V P S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation>K P S V</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation>K P V S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5792,320 +5733,353 @@ Acceptable values are 3v..12v</source>
 Použitelné hodnoty jsou 3v..12v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished">Trenér</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>Režim kloboučků</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Výchozí mód vysílačky</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Metrické</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Imperiální</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Výchozí pořadí kanálů</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>Souřadnice GPS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Časovač nečinnosti</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Zobrazit úvodní logo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>Kontrast</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Rozsah ukazatele baterie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Síla vibrací</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>Typ LCD zobrazovače</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Upozornění na vypnutý zvuk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Alarm baterie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Délka vibrací</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>Přenosová rychlost MAVLink</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Tichý</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Jen alarm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>Bez kláves</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>Vše</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Pokud není nastaveno na nulu, bude zapnuto zvukové upozornění, že jste rádio nechali bez povšimnutí nastavený počet minut.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6120,67 +6094,67 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>Extra krátký</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Krátký</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>Dlouhý</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>Extra dlouhý</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Filtr poloh přepínače</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Měrné jednotky</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Mód vibrací</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Délka zvuku</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Mód zvuku</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6197,12 +6171,14 @@ p, li { white-space: pre-wrap; }
 4 - Extra Hlasitý.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Jen alarmy</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6210,179 +6186,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished">Klávesy</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished">Páky</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished">Klávesy i páky</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished">Zap</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished">Ne</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished">Otočný enkodér :A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">Otočný enkodér :B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">Otočný enkodér :C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">Otočný enkodér :D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">Otočný enkodér :E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished">Normální</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6390,17 +6366,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>Ne</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Ano, ovládané spínačem</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Ano, ovládané potenciomerem</translation>
     </message>
@@ -6408,118 +6384,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished">Název zařízení:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished">ADC filtr</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>Ztlumení, pokud není slyšet zvuk</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished">Ofset proudu</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Invertovat</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6600,22 +6586,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>Kanál plynu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>Kanál bočení:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>Kanál klopení:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>Kanál klonění:</translation>
     </message>
@@ -6623,19 +6609,19 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished">Neplatný soubor EEPROM %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished">Nelze otevřít soubor %1:
 %2</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Chyba při zápisu souboru %1:
@@ -6645,160 +6631,160 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translatorcomment>Ctrl+Nahoru</translatorcomment>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Vymazat všechny vstupy</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished">Čáry</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;Přidat</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;Upravit</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>V&amp;ymazat</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>Vyj&amp;mout</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>&amp;Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;Duplikovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished">Vstup</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished">Vymazat</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished">Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6839,96 +6825,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished">Chyba při načítání modelů</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6936,17 +6922,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6954,7 +6940,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">GP</translation>
     </message>
@@ -6962,122 +6948,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished">Neznámý</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7085,112 +7071,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>Trvání</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>Zpoždění</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>Funkce</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>AND spínač</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">Trvalé</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished">Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished">Vyjmout</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished">Vymazat</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished">Odstranit</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished">Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished">Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished">Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7243,52 +7234,52 @@ Are you sure ?</source>
         <translation>Lety</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>Logy telemetrie</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>Změna názvu</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>Nový název:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>Změna popisu osy</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>Nový název osy:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>Zména názvu grafu</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>Nový název grafu:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7297,74 +7288,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 Sloupce pro nadmořskou výšku &quot;GAlt&quot; a pro rychlost &quot;GSpd&quot; jsou volitelné</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Nelze zapsat soubor %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>Kurzor A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>Kurzor B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>Rozdíl času: %1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>Rychlost stoupání: %1 m/s</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>Vyberte soubor logu</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>Dostupná pole</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>Zvolený soubor logu obsahuje %1neplatných řádků z celkových %2</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>trvání </translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation></translation>
     </message>
@@ -7372,736 +7363,736 @@ Sloupce pro nadmořskou výšku &quot;GAlt&quot; a pro rychlost &quot;GSpd&quot;
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Soubor byl načten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Soubor byl uložen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>Nové téma bude použito při příštím spuštění Companion.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Otevřít soubor modelů a nastavení</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Načíst modely a nastavení z rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>Uložit zálohu rádia do souboru</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Načíst firmware rádia do souboru</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>Pokud vám byl tento program užitečný, podpořte jej &lt;a href=&apos;%1&apos;&gt;darem&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>O aplikaci Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Nový</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation type="unfinished">Otevřít</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Uložit jako...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Porovnat modely</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Ukončit aplikaci</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>Synchronizace SD</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>Černé mono téma</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>Bílé mono téma</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>Modré mono téma</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation>Vytvořit nový profil nastavení rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation>Kopírovat současný profil rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation>Duplikovat současný profil rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation>Odstranit současný profil rádia...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation>Odstranit současný profil nastavení rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation>Okna se záložkami</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation>Pomocí záložek můžete uspořádat otevřená okna.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation>Dlaždice</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation>Uspořádá otevřená okna napříč celým volným prostorem.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation>Kaskádová okna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation>Uspořádá všechna otevřená okna do kaskády.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation>Zavřít všechna okna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation>Zavře všechny otevřené soubory (v případě potřeby vás požádá o uložení).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Malá</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>Použít malé ikony nástrojové lišty</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>Použít normální velikost ikon nástrojové lišty</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Normální</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>Použít velké ikony nástrojové lišty</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Velká</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>Použít největší ikony nástrojové lišty</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Největší</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Vytvořit nový soubor modelů a nastavení</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Uložit soubor modelů a nastavení</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Ukončit</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>Klasik9x</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>Původní téma companion9x</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Žluté medové téma</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>Mono</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>Mono-bílé</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>Mono-modré</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>Výchozí jazyk prostředí</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation type="unfinished">Zobrazit Log</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Otevře a zobrazí soubor logu rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Předvolby...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Upravit nastavení předvoleb</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Porovnat modely...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Upravit úvodní logo rádia...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>Upravit úvodní grafické logo rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Načíst firmware z rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>Načíst firmware z rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Zapsat firmware do rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Zapsat firmware do rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Nový profil rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Zapsat modely a nastavení do rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Zapsat modely a nastavení do rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation>Některé texty nebudou přeloženy dokud nerestartujete Companion. Upozorňujeme, že některé překlady nemusí být kompletní.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Načíst modely a nastavení z rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation>Žádná cesta k místní struktuře SD karty není nakonfigurována!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation>Rádio ani SD karta nebyla nalezena!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation>Modely a nastavení byly přečteny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation>Tato funkce ještě není implementována</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation>Zavřít soubor modelů a nastavení</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation>Seznam nedávno použitých souborů</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation>Profily rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation>Vytvořit nebo vybrat profil nastavení rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation type="unfinished">Nastavení propojení</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>Nastavení softwaru pro komunikaci s rádiem</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Zapsat zálohu do rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Zapsat zálohu ze souboru do rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Zálohovat rádio do souboru</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>Uložit kompletní zálohu modelů a nastavení rádia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation>.-.Kopírovat</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation>Není možné odebrat profil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation>Výchozí profil nemůže být odstraněn.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation>Potvrďte odstranění profilu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation>Opravdu chcete smazat profil &quot;%1&quot;? Neexistuje žádný způsob, jak tuto akci vrátit!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>Syncronizace SD karty se složkou s daty</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation>Použít výchozí systémový jazyk.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation>Použije jazyk %1 (některé překlady nemusí být kompletní).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>Nedávné soubory</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Téma ikon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Velikost ikon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>Zápis</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>O aplikaci Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Jazyka</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Soubor</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Úpravy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Čtení/Zápis</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Nápověda</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Připraven</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation></translation>
     </message>
@@ -8109,76 +8100,76 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Editace modelu %1: </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Nemohu nalézt soubor %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Chyba při otevírání souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Chyba při otevírání souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Uložit jako</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8188,7 +8179,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8198,242 +8189,242 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation>Nic nevybráno</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation>Upravit model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation>Vyjmout</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation>Kopírovat</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation>Vložit</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation>Upravit nastavení rádia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translatorcomment>Kopírovat nastavení rádia</translatorcomment>
         <translation>Edit Radio Settings</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation>Vložit nastavení rádia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation>Simulace Rádia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Úpravy</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation>Přidat model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation>Obnovit ze zálohy</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation>Průvodce nastavením modelu</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation>Nastavit jako výchozí</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation>Vytisknout model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation>Simulovat model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation>Duplikovat model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation>Zobrazit panel nástrojů Rádia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation>Zobrazit panel nástrojů Modelů</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation>Nelze vložit model, poslední model v seznamu by byl smazán.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation>Nelze přidat model, nelze najít dostupný volný slot.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation>Model nelze vložit, není dostupný volný slot.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
             <numerusform>Odstranit %n vybraný model?</numerusform>
@@ -8442,130 +8433,130 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation>Nelze duplikovat model, nelze najít dostupný volný slot.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>Otevřít zálohu modelů a nastavení rádia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation>Odstranit</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished">Součet</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished">Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished">Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation>Chcete přepsat obecná nastavení rádia?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 byl upraven.
 Chcete změny uložit?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Nelze zapsat dočasný soubor!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>Neplatný binární soubor zálohy %1</translation>
     </message>
@@ -8573,143 +8564,148 @@ Chcete změny uložit?</translation>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8717,12 +8713,12 @@ Chcete změny uložit?</translation>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8735,201 +8731,167 @@ Chcete změny uložit?</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Zdroj</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>Zdroj pro mix</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Váha</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Ofset</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">Přesnost</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Použít trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation>GP</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>Ne</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Ano</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Křivka</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Křivka použitá pro mix</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Spínač aktivující mix.
-Pokud není uveden je mix aktivní pořád.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Spínač</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Varování</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>Zvukové upozornění mixu.
-Pokud je tato volba aktivní bude na aktivaci mixu upozorněno zvukovým signálem.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>Vypnuto</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1x pípnutí</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2x pípnutí</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3x pípnutí</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Matematická operace</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Multiplexer
-
-Toto určuje, jak bude hodnota mixu přidána.
-
-&quot;+&quot; znamená že hodnota bude přičtena k hodnotě předchozích mixů v kanálu.
-&quot;*&quot; znamená že hodnota bude násobena s hodnotou předchozích mixů v kanálu.
-&quot;R&quot; znamená že hodnota nahradí předchozí hodnoty.  Pokud je spínač vypnutý hodnota bude ignorována.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>Sečíst</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>Násobit</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>Zaměnit</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Letové režimy</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>Použít DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Zpoždění</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Zpomalení</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Při zapnutí mixu / (+)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Při vypnutí mixu / (-)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8954,27 +8916,27 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Pokud je nastaveno zpomalení, nastavená hodnota udává rychlost mixu -&amp;gt; hodnota udává počet sekund které trvá změna hodnoty z -100 na 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation>Klepnutím otevřete místní nabídku</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation>Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation>Nastavit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation>Invertovat vše</translation>
     </message>
@@ -8982,22 +8944,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9005,136 +8967,136 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Vymazat všechny mixy</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>Není k dispozici dostatek mixů!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;Přidat</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;Upravit</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>Přepnout &amp;zvýraznění</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;Odstranit</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>&amp;Vyjmout</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>&amp;Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;Duplikovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>Vymazat mixy?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>Opravdu vymazat všechny mixy?</translation>
     </message>
@@ -9142,19 +9104,24 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished">Stopa plynu</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation type="unfinished">Plyn</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9202,32 +9169,49 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
+        <translation type="unfinished">Vypnuto</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9245,63 +9229,58 @@ p, li { white-space: pre-wrap; }
         <translation>Simulace </translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Nastevní</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Vstupy(DR/Expo)</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Logické spínače</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Mixer</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Letové režimy</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>Výstupy</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Křivky</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Speciální funkce</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Telemetrie</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9355,8 +9334,8 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Letové režimy</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9392,585 +9371,595 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation>Exponenciální</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>Extra jemný</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>Jemný</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>Střední</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>Hrubý</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation>Neznámý</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished">Povolit</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished">Ano</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished">Ne</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished">Zap</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished">Mód</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished">Počet kanálů</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished">PPM zpoždění</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished">Polarita</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished">Protokol</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished">Zpoždění</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished">Dle nastavení přijímače</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished">Subtyp</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished">Volitelná hodnota</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished">Letové režimy</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished">Letový režim</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished">Vše</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished">Trvání</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished">Rozšířené limity (125%)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished">Zobrazit poznámky</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished">Globální funkce</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished">Režim Failsafe</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished">Držet hodnotu</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished">Žádné pulzy</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished">Nenastaveno</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished">Režim kloboučků</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished">Nikdy</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished">Vždy</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished">Pouze trimy</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished">Pouze tlačítka</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished">Přepinatelné</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished">Globální</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished">Zdroj</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished">Varování</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished">FrSky D (kabel)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished">Telem. vstup A1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished">Telem. vstup A2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished">Telem. vstup A3</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished">Telem. vstup A4</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished">Hodnoty</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished">Ukazatele</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished">Skript</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished">Soubor</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation>Vypnuto</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation>LR%1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation>LR%1%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation>LR%1+%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation>Žádný trim</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation>Bez DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation>Ofset(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>Zakázáno ve všech letových režimech</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>Volná-XY</translation>
     </message>
@@ -9978,27 +9967,27 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Letadlo</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Helikoptéra</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Název modelu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Typ modelu:</translation>
     </message>
@@ -10006,27 +9995,27 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Název</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10282,285 +10271,290 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished">Pozitivní</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished">Negativní</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished">Port Trenér</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished">Interní vysílací modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished">Externí vysílací modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished">Extra modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished">Vysílací modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10568,57 +10562,57 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished">profil</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>Držet hodnotu</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>Žádné pulzy</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10626,456 +10620,456 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>Vstup</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>Váha</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>Kolektiv</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>Letové režimy</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>Letový režim</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>Spínač</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished">Obrázek modelu</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished">Plyn</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished">Polohy spínačů</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished">Hodnoty potenciometrů</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished">Odečítat</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">Mód</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished">První kanál</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished">Helikoptéra</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Funkce</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished">Protokol</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished">Vario senzor</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished">Hodnoty na horní liště</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished">Zdroj napětí</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished">Zdroj výšky</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>Nastavitelné přepínače</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished">Hodnota</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished">Globální funkce</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation>GP%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>Kanál</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>Název</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished">Výstupy</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished">Subtrim</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished">Křivka</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished">Lineární</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetrie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>Globální proměnné</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>Vstupy(DR/Expo)</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>Mixy</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>Křivky</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>Logické spínače</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>Speciální funkce</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>Jednotky</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>RSSI Alarmy</translation>
     </message>
@@ -11083,7 +11077,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11091,22 +11085,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Kanál plynu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Kanál bočení:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Kanál klopení:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Kanál klonění:</translation>
     </message>
@@ -11114,22 +11108,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11137,17 +11131,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Zámek plynu (spínač THR)</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Stopky na plynu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Letové stopky</translation>
     </message>
@@ -11155,40 +11149,40 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Chyba při otevírání souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Chyba při zápisu souboru %1:
@@ -11218,17 +11212,17 @@ p, li { white-space: pre-wrap; }
         <translation>Tisk do souboru</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Vytisknout dokument</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11255,12 +11249,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>Zavřít</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation>Zrušit</translation>
     </message>
@@ -11276,22 +11270,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished">Zobrazit toto upozornění i při příštím spuštění?</translation>
     </message>
@@ -11299,24 +11293,24 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11324,97 +11318,107 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished">Akce</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished">Nový</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11422,30 +11426,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Nelze zapsat soubor %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished">Nelze odstarnit dočasný soubor: %1</translation>
     </message>
@@ -11453,12 +11457,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Hodnota (vstup): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation>Dvakrát klikněte pravým tlačítkem pro vynulování do středu.</translation>
     </message>
@@ -11554,12 +11558,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation type="unfinished">LR%1</translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished">GP%1</translation>
     </message>
@@ -11575,358 +11584,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation type="unfinished">Trim směrovky</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation type="unfinished">Trim výškovky</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation type="unfinished">Trim plynu</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation type="unfinished">Trim křidélek</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished">Otočný enkodér REa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished">Otočný enkodér REb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Zdroj</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">Žádný</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished">Otočný enkodér REa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished">Otočný enkodér REb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished">Zap</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished">Pln&gt;</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished">Pln%</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished">Pln*</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished">One(výběr modelu)</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished">Spínač</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">Žádný</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation>Ne</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>Ano</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;Kanál směrovky:</translation>
     </message>
@@ -11934,20 +12043,20 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Chyba při otevírání souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11955,319 +12064,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished">Výška</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished">Jednotky</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished">Přesnost</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished">Ofset</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished">Auto ofset</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished">Násobitel</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished">Filtr</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished">Pozitivní</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished">Vypočtený</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished">Součet</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished">Průměr</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished">Násobení</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished">Článek</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished">Spotřeba</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished">Nejnižší</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished">Článek %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished">Nejvyšší</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished">Jednotky (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12490,87 +12614,87 @@ Funkce trimu bude opačná, stejně tak i varování polohy páky plynu.
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>Stopky %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished">Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished">Vyjmout</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished">Vymazat</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished">Odstranit</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished">Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished">Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished">Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12578,7 +12702,7 @@ Funkce trimu bude opačná, stejně tak i varování polohy páky plynu.
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Kanál výškovky:</translation>
     </message>
@@ -12586,204 +12710,204 @@ Funkce trimu bude opačná, stejně tak i varování polohy páky plynu.
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12791,115 +12915,115 @@ Funkce trimu bude opačná, stejně tak i varování polohy páky plynu.
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation>Dostupné profily:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation>Název: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation>Dostupná rádia:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation>ID profilu rádia nebo jméno, které chcete použít pro simulátor.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation>profil</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation>Typ rádia pro simulaci (obvykle definovaný v profilu).</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation>rádio</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation>Adresář obsahující obsak karty SD, který chcete použít. Výchozí nastavení je nakonfigurováno ve zvoleném profilu rádia.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation>cesta</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation>typ</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished">zdroj-dat</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished">[zdroj-dat]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation>Chyba: Profil ID %1 nebyl nalezen.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation>Nerozpoznaný typ zdroje dat pro spuštění: %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation>VAROVÁNÍ: SDL nelze inicializovat:
 %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation>CHYBA: K dispozici nejsou knihovny simulátoru.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
@@ -12908,7 +13032,7 @@ Data File: [%3]</source>
 Datový soubor: [%3]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation>Chyba: Nebyl nalezen profil rádia nebo firmware simulátoru.
@@ -12919,7 +13043,7 @@ Profil ID: [%1]; Rádio ID: [%2]</translation>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13068,74 +13192,74 @@ Profil ID: [%1]; Rádio ID: [%2]</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished">Výstup ladění</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13260,32 +13384,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13298,68 +13422,73 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished">Companion Simulátor</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation>Nelze otevřít joystick, není povolený</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13385,17 +13514,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>Knihovna s logy - strana %1 z %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>Neplatné logo v knihovně %1</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>Nebylo nalezenožádné použitelné logo v knihovně, zkontrolujte nastavení</translation>
     </message>
@@ -13403,7 +13532,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>Kanál %1</translation>
     </message>
@@ -13411,7 +13540,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished">Nemohu nalézt soubor %1!</translation>
     </message>
@@ -13420,9 +13549,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13447,19 +13576,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13468,47 +13597,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13516,141 +13645,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13658,17 +13787,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>Kanál směrovky:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Kanál výškovky:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>Pouze jeden kanál je k dispozici ! &lt;br&gt; Pravděpodobně budete muset nastavit model bez použití průvodce.</translation>
     </message>
@@ -13676,22 +13805,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Výškovka a směrovka</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Jen výškovka</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>Ocas - V</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Typ ocasu:</translation>
     </message>
@@ -14023,7 +14152,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">Stránka telemetrie %1</translation>
     </message>
@@ -14031,28 +14160,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Nízký alarm</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Kriticky alarm</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (nepodporován)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">Proud</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Výška</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished">Telem. vstup A4</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished">Otáčky (ot/min)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished">Telem. vstup A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished">Telem. vstup A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished">Telem. vstup A3</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Palivo</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">Proud</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Výška</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Palivo</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished">Otáčky (ot/min)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished">Telem. vstup A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished">Telem. vstup A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Výška</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">Proud</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14169,72 +15231,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished">Kopírovat</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished">Vyjmout</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished">Vymazat</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished">Odstranit</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished">Posunout nahoru</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished">Posunout dolů</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished">Vyčistit vše</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14247,355 +15309,124 @@ Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation type="unfinished">Telem. vstup A1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation type="unfinished">Telem. vstup A2</translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
         <translation>Simulace </translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Žádný</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation type="unfinished">Telem. vstup A3</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation type="unfinished">Telem. vstup A4</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>Palivo</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation type="unfinished">Výška</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation type="unfinished">Proud</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation type="unfinished">Otáčky (ot/min)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
@@ -14603,78 +15434,35 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Ano</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>Ne</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;Kanál plynu:</translation>
     </message>
@@ -14700,138 +15488,138 @@ hh:mm:ss</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished">Stopky %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished">Tichý</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">Zvuk</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">Hlas</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">Vibrovat</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">Neukládat</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">Trvalý (v rámci letu)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished">Let</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">Trvalý (reset ručně)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">Zap</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished">První kanál</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished">Pln&gt;</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished">Pln%</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished">Pln*</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14839,22 +15627,22 @@ hh:mm:ss</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Sečíst)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Nahradit)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14862,27 +15650,27 @@ hh:mm:ss</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">Mód</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Váha</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Zdroj</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished">Násobitel</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished">Kalibrace</translation>
     </message>
@@ -14892,6 +15680,210 @@ hh:mm:ss</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">neznámý</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14919,47 +15911,47 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14972,22 +15964,42 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14995,285 +16007,317 @@ hh:mm:ss</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished">neznámý</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15289,63 +16333,90 @@ hh:mm:ss</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15438,32 +16509,32 @@ hh:mm:ss</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15476,22 +16547,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15504,22 +16575,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15543,17 +16614,17 @@ hh:mm:ss</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15561,37 +16632,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15707,32 +16778,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15740,32 +16811,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished">Hodnoty na horní liště</translation>
     </message>
@@ -15773,12 +16844,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>První kanál:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>Druhý kanál:</translation>
     </message>
@@ -15786,55 +16857,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation type="unfinished">Fixovat Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation type="unfinished">Fixovat X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Běžné křídlo</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Samokřídlo / Delta</translation>
     </message>
@@ -15842,22 +16913,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15865,273 +16936,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Průvodce nastavením modelu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Typ modelu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Zvolte název a typ modelu.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Plyn</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>Má váš model motorový pohon?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Typ křídla</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>Je váš model samokřídlo/delta, nebo má běžnou konfiguraci křídla?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>Křidélka</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>Má váš model křidélka?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Klapky</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>Má váš model vztlakové klapky?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Brzdy</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>Má váš model brzdící klapky?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Samokřídlo / Delta křídlo</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Zvolte kanál elevonů</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Směrovka</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>Má váš model ovládanou směrovku?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Typ ocasu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Vyberte jaký typ ocasu má váš model.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Ocas</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Zvolte kanály pro ovládání ocasních ploch.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>Ocas typu V</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Zvolte kanál výškovky.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>Cyklika</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation type="unfinished">Jaký typ desky cykliky je instalován?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>Gyro ocasu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>Má vaše heli gyro ocasu s nastavitelným ziskem?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>Typ rotoru</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>Má vaše heli flybar(pádla na hlavě)?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Helikoptéra</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Zvolte ovládací kanály vaší multikoptéry</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Užitečné funkce</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Vyberte další položky</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>Uložit změny</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Ručně zkontrolujte směr každé řídicí plochy a nastavte revers těch co se pohybují v opačném směru. Raději odstraňte vrtuli / vrtule, než se poprvé pokusíte ovládat svůj model.&lt;br&gt;Vezměte prosím na vědomí, že pokud budete pokračovat, dojde k odstranění všech starých nastavení tohoto modelu!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Zvolte název a typ modelu.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Zvolte kanál přijímače, který je připojen k ESC, nebo servu plynu.&lt;br&gt;&lt;br&gt;Spektrum: CH1, Futaba: CH3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>Většina letadel má hlavní křídlo a ocas s ovládacími plochami. Samokřídla a delty mají jen jedno křídlo. Hlavní řídicí plochy na standardním křídle ovládájí klonění letadla. Tyto plochy se nazývají křidélka. &lt;br&gt; Ovládací plochy delta křídla řídí podélný i příčný náklon. Tyto plochy se nazývají elevony.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>Modely používají jeden, nebo dva kanály pro ovládání křidélek.&lt;br&gt;Tzv. Y-kabel lze použít pro připojení dvou samostatných serv křidélek do jednoho kanálu přijímače. Pokud jsou vaše serva spojeny Y-kabelem, měli byste zvolit možnost &quot;jeden kanál&quot;&lt;br&gt;&lt;br&gt;Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>Tento průvodce předpokládá, že vaše klapky jsou ovládány spínačem. Pokud jsou vaše klapky řízeny potenciometrem můžete toto změnit později ručně.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>Vzduchové brzdy se používají ke snížení rychlosti moderních kluzáků.&lt;br&gt;Na jiných typech letadel nejsou příliš obvyklé.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>Modely používají dva kanály pro ovládání elevonů.&lt;br&gt;Vyberte je</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Zvolte kanál přijímače, který je připojen k vaší směrovce.&lt;br&gt;Spektrum:. CH4, Futaba: CH4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Zvolte typ ocasu vašeho modelu.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Zvolte kanály směrovky a výškovky.&lt;br&gt;&lt;br&gt;Směrovka - Spektrum: CH4, Futaba: CH4&lt;br&gt;Výškovka - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Zvolte kanál výškovky.&lt;br&gt;&lt;br&gt;Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Zvolte ovládací kanály vaší multikoptéry.&lt;br&gt;&lt;br&gt;Plyn - Spektrum: CH1, Futaba: CH3&lt;br&gt;Bočení - Spektrum: CH4, Futaba: CH4&lt;br&gt;Klopení - Spektrum: CH3, Futaba: CH2&lt;br&gt;Klonění - Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>Pro tuto stránku není dostupná žádná nápověda.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Nápověda průvodce nastavením modelu</translation>
     </message>
@@ -16139,37 +17210,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>Letadlo</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>Multikoptéra</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>Helikoptéra</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>Název modelu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>Typ modelu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>Volby: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>Kanál %1: </translation>
     </message>
@@ -16177,46 +17248,46 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Chyba při otevírání souboru %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16224,16 +17295,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16242,10 +17316,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16354,18 +17443,18 @@ m2560 pro V4 desky</translation>
         <translation>sériový port sam-ba</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>Konfigurace DFU-UTIL</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>Konfigurace SAM-BA</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Procházet umístění</translation>
     </message>
@@ -16403,7 +17492,7 @@ m2560 pro V4 desky</translation>
         <translation type="unfinished">První kanál</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>Další</translation>
     </message>
@@ -16413,59 +17502,59 @@ m2560 pro V4 desky</translation>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation>Joystick nenalezen</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>Nemohu otevřít joystick.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_da.ts
+++ b/companion/src/translations/companion_da.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ja, styret af 1 kanal</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ja, styret af 2 kanaler</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br &gt;Første sideror kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>Anden sideror kanal:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ja, styret af 1 kanal</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ja, styret af 2 kanaler</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;Første luftbremse kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>Anden luftbremse kanal:</translation>
     </message>
@@ -60,97 +60,97 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation>Program indstillinger kan ikke gemmes i filen &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation>når filen ikke kan gemmes (kontroller skrive rettigheder).</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation>af ukendte årsager.</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="656"/>
+        <location filename="../storage/appdata.h" line="657"/>
         <source>Manual</source>
         <translation>Manuel</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="656"/>
+        <location filename="../storage/appdata.h" line="657"/>
         <source>Startup</source>
         <translation>Ved programstart</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="656"/>
+        <location filename="../storage/appdata.h" line="657"/>
         <source>Daily</source>
         <translation>Dagligt</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="656"/>
+        <location filename="../storage/appdata.h" line="657"/>
         <source>Weekly</source>
         <translation>Ugenligt</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="656"/>
+        <location filename="../storage/appdata.h" line="657"/>
         <source>Monthly</source>
         <translation>Månedsvis</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="658"/>
+        <location filename="../storage/appdata.h" line="659"/>
         <source>Debug</source>
         <translation>Fejlsøg</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="658"/>
+        <location filename="../storage/appdata.h" line="659"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="658"/>
+        <location filename="../storage/appdata.h" line="659"/>
         <source>Information</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="658"/>
+        <location filename="../storage/appdata.h" line="659"/>
         <source>Critical</source>
         <translation>Kritisk</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="658"/>
+        <location filename="../storage/appdata.h" line="659"/>
         <source>Fatal</source>
         <translation>Fatal</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="655"/>
+        <location filename="../storage/appdata.h" line="656"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="655"/>
+        <location filename="../storage/appdata.h" line="656"/>
         <source>Wizard</source>
         <translation>Guide</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="655"/>
+        <location filename="../storage/appdata.h" line="656"/>
         <source>Editor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="655"/>
+        <location filename="../storage/appdata.h" line="656"/>
         <source>Template</source>
         <translation>Skabelon</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="655"/>
+        <location filename="../storage/appdata.h" line="656"/>
         <source>Prompt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation>Program indstillinger er gemt i
@@ -527,64 +527,64 @@ Mode 4:
         <translation>Gem position på alle kontakter/pinde ved afslutning af simulator</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="169"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Min radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="213"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Vælg katalog til snapshots af Tx-simulering</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="278"/>
-        <location filename="../apppreferencesdialog.cpp" line="598"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Joystik er ikke fundet</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="327"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>TOM: Der er ingen radio indstillinger i profilen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="332"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>MULIGHED: Radio indstillinger af ukendt alder</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>MULIGHED: Radio indstillinger gemt %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="529"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Vælg biblioteks katalog</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="553"/>
-        <location filename="../apppreferencesdialog.cpp" line="563"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Vælg katalog til automatisk sikkerhedskopier</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="581"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Sti til Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="632"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Vælg katalog til en kopi af SD struktur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="663"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Åbn billede</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="663"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Billeder (%1)</translation>
     </message>
@@ -688,12 +688,12 @@ Mode 4:
         <translation>Katalog til skærmdumps</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="179"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Du kan ikke skifte radio type eller byg tilvalg med ændringer som ikke er gemt. Hvad skal der ske?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Gem alt&lt;/i&gt; - Gem de åbne filer før indstillinger gemmes.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Genskab til den forrige radio type og byg parametre før indstillinger gemmes.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Gå tilbage til redigering af indstillinger.&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="573"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation>Vælg katalog til logge fra program</translation>
     </message>
@@ -730,7 +730,7 @@ Mode 4:
     <message>
         <location filename="../apppreferencesdialog.ui" line="83"/>
         <location filename="../apppreferencesdialog.ui" line="1560"/>
-        <location filename="../apppreferencesdialog.cpp" line="468"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation>Alternativer</translation>
     </message>
@@ -786,12 +786,12 @@ Mode 4:
         <translation>Komponenter</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="437"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation>Søg opdatering</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="440"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation>Release kanal</translation>
     </message>
@@ -806,27 +806,27 @@ Mode 4:
         <translation>Forvalg internt modul</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="354"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation>Nulstiller alle opdateringsværdier til standard. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="358"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation>Indstilling for opdateringer er ændret. Afslut venligst Companion for at undgå uønskede problemer!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="398"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation>Vælg katalog til hentede filer</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="405"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation>Vælg katalog til dekomprimering</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="412"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation>Vælg katalog til opdateringer</translation>
     </message>
@@ -841,22 +841,22 @@ Mode 4:
         <translation>Slet dekomprimerede filer</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation>Opdateringsindstillinger: Katalog til hentede filer er ikke valgt!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation>Opdateringsindstillinger: Katalog til dekomprimering er ikke valgt!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation>Opdateringsindstillinger: Katalog til opdateringer er ikke valgt!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation>Opdateringsindstillinger: Katalog til dekomprimering og hentning af filer er ens!</translation>
     </message>
@@ -884,31 +884,31 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation>Fejl ved læsning af %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation>Kan ikke gemme EEPROM</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Kan ikke åbne fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Fejl ved skrivning til fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation>Ugyldig EEPROM-fil: %1</translation>
     </message>
@@ -946,33 +946,33 @@ Mode 4:
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="807"/>
-        <location filename="../firmwares/boardjson.cpp" line="813"/>
-        <location filename="../firmwares/boardjson.cpp" line="822"/>
-        <location filename="../firmwares/boardjson.cpp" line="832"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation>Indlæs hardware specifikation</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="808"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation>Hardware: %1 fejl: Kan ikke indlæse fil %2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation>Hardware: %1 fejl: Kan ikke åbne fil %2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="823"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation>Hardware: %1 fejl: Kan ikke læse fil %2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="833"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -983,255 +983,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation>Venstre horisontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="354"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation>Venstre vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="355"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation>Højre vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="356"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation>Højre horisontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="357"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="358"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="374"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="375"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="376"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="386"/>
-        <location filename="../firmwares/boards.cpp" line="388"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="387"/>
-        <location filename="../firmwares/boards.cpp" line="389"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="403"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="470"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="402"/>
-        <location filename="../firmwares/boards.cpp" line="441"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="404"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="471"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="442"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="581"/>
-        <location filename="../firmwares/boards.cpp" line="780"/>
-        <location filename="../firmwares/boards.cpp" line="810"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="589"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation>Funktion</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="812"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation>Drejekontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="814"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation>Drejekontakt med midtklik</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="816"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation>Skyder</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="818"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation>Multipos kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="820"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation>Akse X</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="822"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation>Akse Y</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="824"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation>Kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="583"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">Flyvning</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation>2 position skifter</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="585"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation>2 positioner</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="587"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation>3 positioner</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="415"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="430"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="448"/>
-        <location filename="../firmwares/boards.cpp" line="456"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="431"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="449"/>
-        <location filename="../firmwares/boards.cpp" line="457"/>
-        <location filename="../firmwares/boards.cpp" line="469"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="417"/>
-        <location filename="../firmwares/boards.cpp" line="432"/>
-        <location filename="../firmwares/boards.cpp" line="440"/>
-        <location filename="../firmwares/boards.cpp" line="450"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="383"/>
-        <location filename="../firmwares/boards.cpp" line="385"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="782"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="784"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation>Små</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="786"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation>Begge</translation>
     </message>
@@ -1239,17 +1249,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation>Laveste værdi</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation>Center værdi</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation>Højste værdi</translation>
     </message>
@@ -1257,132 +1267,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation>Subtrim</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation>Retning</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation>PPM-centrum</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation>Linær subtrim</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation>KA%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation>Popmenu mulig</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation>Klip ud</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation>Sæt ind</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation>Slet kanal. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation>Slet kanal. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation>Slet alle kanaler. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation>Klip ud kanal. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation>Udseende</translation>
     </message>
@@ -1420,54 +1430,54 @@ Error description: %4</source>
         <translation>Fil: ukendt</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation>Åbn checkliste</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation>Checklister (*.txt)</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation>Model checkliste</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation>Kan ikke åbne fil for skrivning %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation>Kan ikke skrive i fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kan ikke skrive i fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Kan ikke åbne fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kan ikke læse fil %1:
@@ -1479,7 +1489,7 @@ Error description: %4</source>
         <translation>Rad nn, Kol nn</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation>Rad %1, Kol %2</translation>
     </message>
@@ -1495,12 +1505,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation>Bruger dialog</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation>Hoved billede %1</translation>
     </message>
@@ -1508,184 +1518,184 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation>EdgeTX simulator</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="64"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="66"/>
         <source>Accept</source>
         <translation>Godkend</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="67"/>
         <source>Decline</source>
         <translation>Afvis</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="68"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation>filer</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="69"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation>Radio- og model indstillinger</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation>Der er endnu ikke en simulator for denne firmware</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation>Ukendt fejl ved start af simulator.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation>Simuator Fejl</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation>Fejl ved indlæsning</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation>En fejl opstod ved start af simulatorn.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation>Gemte indstillinger kunne ikke indlæses. Forsøg igen eller fortsæt med nuværende indstillinger.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation>Hent fra fil</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation>Hent ikke</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation>Der er mulige sikkerhedskopier med Companion indstillinger.
 Vil du indlæse indstillinger fra en fil?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation>Indlæs indstillinger fra fil, eller start med nuværende værdier.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation>Vælg %1:</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation>Gem programindstillinger...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation>Hent programindstillinger fra fil eller tidligere version...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation>Genskab ALLE programindstillinger til standard værdier og fjern radioprofiler...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation>Forlad program inden initialisering og program start.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation>Skriv versionsnummer og afslut.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation>Udkriv denne hjælp.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation>Genskab ALLE programindstillinger til standard værdier og fjern radioprofiler - er du sikker?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation>Vil du sikkerhedskopiere først?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation>Program indstillinger er nulstillet og gemt.</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="84"/>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation>Program indstillinger</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation>Vælg eller opret fil til eksport af indstillinger:</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation>Tryk på &quot;Prøv igen&quot; at vælge anden fil.</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation>indstillinger</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Type af sender i valgt profil mangler. Bruger standard indstillinger.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Opdater venligst dine profil indstillinger!&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation>&lt;p&gt;&lt;b&gt;Velkommen til EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Din første opgave er at konfigurere din første radio profil, ved at vælge radio type, menu sprog og release tilvalg.&lt;/p&gt;&lt;p&gt;Du bør oogså bruge tid på at undeersøge de andre tilvalg under indstillinger.&lt;/p&gt;&lt;p&gt;Efter du har gemt dine indstilllinger, anbefaler vi at du henter den nyeste firmware til din radio ved at anvende &lt;i&gt;Hent/Send -&amp;gt; Hent radio firmware&lt;/i&gt; menu punkt.&lt;/p&gt;&lt;p&gt;Besøg også &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for at læse release beskrivelse og andre dokumenter (engelsk). Tak for at dit valg af EdgeTX!&lt;/p&gt;- EdgeTX Team.</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation>&lt;p&gt;&lt;b&gt;Tak for at du opgraderer til EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Dette er en major release som tilføjer og ændrer mange ting, så læs omhyggeligt release beskrivelse for at kende ændringer, og gennemgå omhyggeligt at hver af dine modeller fungerer som forventet.&lt;/p&gt;&lt;p&gt;Besøg venligst &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for at læse release beskrivelse og andre dokumenter (engelsk).&lt;/p&gt;- EdgeTX Team.</translation>
     </message>
@@ -1713,12 +1723,12 @@ Vil du indlæse indstillinger fra en fil?</translation>
         <translation>Skriv til fil</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Udskriv dokument</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>Vælg PDF-fil som skal skrives til</translation>
     </message>
@@ -1728,12 +1738,12 @@ Vil du indlæse indstillinger fra en fil?</translation>
         <translation>For at sammenligne modeller, træk hertil og slip indenfor vindue.</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation>Model ikke navngivet %1</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation>Klik for at slette denne model.</translation>
     </message>
@@ -1746,17 +1756,17 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>ComponentData</name>
     <message>
-        <location filename="../storage/appdata.h" line="589"/>
+        <location filename="../storage/appdata.h" line="590"/>
         <source>Releases</source>
         <translation>Release</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="589"/>
+        <location filename="../storage/appdata.h" line="590"/>
         <source>Pre-release</source>
         <translation>Test release</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="589"/>
+        <location filename="../storage/appdata.h" line="590"/>
         <source>Nightly</source>
         <translation>Natlig byg (måske ustabile)</translation>
     </message>
@@ -1764,7 +1774,7 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>OK, jeg forstår.</translation>
     </message>
@@ -1772,17 +1782,17 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>Skrive Fejl</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>Kan ikke skrive til %1 (kode: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation>Kan ikke åbne %1 (kode: %2)</translation>
     </message>
@@ -1790,22 +1800,22 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation>KU</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation>Tilpasset</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation>%1 punkter</translation>
     </message>
@@ -1863,22 +1873,22 @@ Vil du indlæse indstillinger fra en fil?</translation>
         <translation>Punkt størrelse</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation>Linær</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation>Enkel expo</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation>Symmetrisk f(x)= -f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation>Symmetrisk f(x)= f(-x)</translation>
     </message>
@@ -1903,7 +1913,7 @@ Vil du indlæse indstillinger fra en fil?</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation>Der er ikke nok ledig plads i hukommelsen til at gemme kurven.</translation>
     </message>
@@ -1913,7 +1923,7 @@ Vil du indlæse indstillinger fra en fil?</translation>
         <translation>Y ved X=0</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation>Rediger kurve %1: %2</translation>
     </message>
@@ -1921,7 +1931,7 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation>Dobbeltklik for at redigere</translation>
     </message>
@@ -1929,22 +1939,22 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation>Diff</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation>Expo</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation>Funk</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation>Tilpasset</translation>
     </message>
@@ -1952,113 +1962,113 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation>Bemærk: For at oprette en kurve, højreklik på kurve række (KU#)</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation>KU%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation>Popup menu mulig</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation>Klip ud</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation>Sæt ind</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation>Navn:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation>Type:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation>Punkter:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation>Blød:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation>Rediger</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation>Nulstil kurve %1:%2. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation>Nulstil alle kurver. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation>Klip ud kurve %1:%2. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation>Slet kurve %1:%2. Er du sikker?</translation>
     </message>
@@ -2066,343 +2076,363 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation>GF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation>Overskriv %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation>Træner Akse</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation>Træner SIDEROR</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation>Træner HØJDEROR</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation>Træner GAS</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation>Træner KRÆNGROR</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation>Øjeblilkkelig trim</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation>Afspil lyd</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation>Vibration</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation>Nulstil</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation>Variometer</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation>Afspil lydfil</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation>Afspil begge</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation>Afspil værdi</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation>Log data til SD</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation>Belysning</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation>Tag skærmbillede</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation>Baggrundsmusik</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation>Pauser baggrundsmusik</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation>Juster %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation>Tilslutning til int. modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation>Tilslutning til ext. modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation>RGB led</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation>Flyvning</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished">Trim</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation>Bip 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation>Bip 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation>Bip 3</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation>Advarsel 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation>Advarsel 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation>Alarm klokke</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation>Global variabel</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation>Tæl op/ned</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation>Kør en gang, ikke ved opstart</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation>Gentag (efter %1s)</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation>INAKTIV</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation>CFN</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation>indstil fejlsikring</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation>Gentag ikke</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation>Lua skript</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation>Indstil %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation>Kilde</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation>Ræs tilstand</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation>Deaktiver touch</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation>Træner kanaler</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation>Kontroller rækkevidde Intern modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation>Kontroller rækkevidde Ekstern modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation>Indstil hoved billede</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>Sluk audio amplifier</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation>Værdi</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation>!1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation>1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation>%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation>Til</translation>
     </message>
@@ -2410,124 +2440,124 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Udløser</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Parametre</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Handling</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation>Popupmenu mulig</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation>Fejl ved afspilning af lyd, lyd fil er muligvis allerede åbnet. (Fejl: %1 [%2])</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation>Kan ikke finde eller åbne lyd fil:
 %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation>GV</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation>Gentag</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation>Aktiver</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation>Slet funktion. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation>Klip ud specialfunktion. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation>Klip ud</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation>Sæt ind</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation>Nulstil specialfunktion. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="742"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation>Nulstil alle specialfunktioner. Er du sikker?</translation>
     </message>
@@ -2535,22 +2565,22 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation>Cifre</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation>Bjælke</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
@@ -2558,47 +2588,47 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation>Øverste bjælke</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation>Flyve tilstand</translation>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
+        <source>%1 mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
         <source>Sliders</source>
         <translation>Skydere</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
         <source>Trims</source>
         <translation>Trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
         <source>Mirror</source>
         <translation>Spejle</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation>Tilvalg #%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation>Widget:</translation>
     </message>
@@ -2647,67 +2677,67 @@ Vil du indlæse indstillinger fra en fil?</translation>
         <translation>Åbn billed bibliotek</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>Åbn firmware fil</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>Det lykkes ikke at indlæse billede fra firmware fil %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>Det lykkes ikke at indlæse billede fil %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>Det lykkes ikke at indlæse profil billede %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>Det lykkes ikke at indlæse billede %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>Fil gemt</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>Bilden sparades till filen %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>Fejl ved genindlæse billede</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>Fejl ved genindlæsning af billede fra fil %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>Fejl ved skrivning af fil</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>Billede kunne ikke gemmes i %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>Åbn billede for indlæsnig</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>Billeder (%1)</translation>
     </message>
@@ -2720,17 +2750,17 @@ Vil du indlæse indstillinger fra en fil?</translation>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation>FW: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation>Billede: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation>Profil billede</translation>
     </message>
@@ -2738,22 +2768,22 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2761,53 +2791,53 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation>Konverterings fejl i felt %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation>Kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation>Kontakt </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation> kan ikke eksporteres for denne radio!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="656"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="656"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation>Information fra %1 mangler foor denne radio!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1383"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation>EdgeTX accepterer kun %1 punkter i alle kurver</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation>EdgeTX accepterer kun %1 punkter i alle kurver</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1702"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1706"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation>EdgeTX understøtter ikke funktionen for denne radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2443"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation>EdgeTX understøtter ikke denne radio protokol</translation>
     </message>
@@ -2815,52 +2845,52 @@ Vil du indlæse indstillinger fra en fil?</translation>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation>Deaktiveret</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation>Aktiveret</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation>TIL</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation>Falsk</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation>Sand</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation>J</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
@@ -2940,12 +2970,12 @@ For at &lt;b&gt;slette en gemt række&lt;/b&gt; i filterlisten, marker og tryk &
         <translation>Filter til/fra.</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;Filter anvender to typer af syntaks: basis match med almindelige søgetegn og fuld Perl stil (&lt;code&gt;pcere&lt;/code&gt;) med egelmæssige udtryk.&lt;/p&gt;&lt;p&gt;Som standard vil et filer vise linjer som har et match (&lt;b&gt;inklusiv&lt;/b&gt;). For at oprette et &lt;b&gt;eksklusiv&lt;/b&gt; filter som fjerner linjer der har et match, prefix dit filter med et &lt;kbd&gt;!&lt;/kbd&gt; (udråbstegn).&lt;/p&gt;&lt;p&gt;For at anvende &lt;b&gt;regelmæssige udtryk&lt;/b&gt; (RegEx), prefix filter med et &lt;kbd&gt;/&lt;/kbd&gt; (skråstreg) eller &lt;kbd&gt;^&lt;/kbd&gt; (hat). &lt;ul&gt;&lt;li&gt;Anbring &lt;kbd&gt;/&lt;/kbd&gt; eller &lt;kbd&gt;^&lt;/kbd&gt; efter eksklusiv &lt;kbd&gt;!&lt;/kbd&gt; indikering hvis du &apos; bruger den.&lt;/li&gt;&lt;li&gt;Som standard er der match på små og store tegn. Skal det ændres, skriv &lt;kbd&gt;/i&lt;/kbd&gt; (skråstreg og i) operator i enden af det regelmæssige udtryk.&lt;/li&gt;&lt;li&gt;Hvis du bruger en (^) til at betegne et regelmæssigt udtryk, bliver det tegn del af udtrykket. Fx. (husk et match begynder ved starten af en linje).&lt;/li&gt;&lt;li&gt;Hvis det regelmæssige udtryk har forkert udtryk, vises redigerings felt med en rød ramme og du kan rette udtrykket.&lt;/li&gt;&lt;li&gt;En god mulighed for at teste dit udtryk findes på &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;For at bruge &lt;b&gt;basis match&lt;/b&gt; kan du skrive enhver tekst.&lt;ul&gt;&lt;li&gt;Søgetegn: &lt;kbd&gt;*&lt;/kbd&gt; (stjerne) har match for 0 eller flere af alle tegn, og &lt;kbd&gt;?&lt;/kbd&gt; (spørgsmål) har match på alle enkelt tegn.&lt;/li&gt;&lt;li&gt;Match er altid på små og store tegn.&lt;/li&gt;&lt;li&gt;Match gælder altid fra start af en linje. For at ignore tegn i starten af linjen, brug i starten et &lt;kbd&gt;*&lt;/kbd&gt; søgetegn.&lt;/li&gt;&lt;li&gt;Et &lt;kbd&gt;*&lt;/kbd&gt; er altid underforstået (altså at resten af en linje har et match). Ønskes dette ikke, brug et regelmæssigt udtryk.&lt;/li&gt;&lt;li&gt;Du kan matche et søgetegn ved at prefixe med &lt;kbd&gt;\&lt;/kbd&gt; (backslash) (eg. &quot;foo\*bar&quot; matcher &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;Efter &lt;b&gt;redigering af tekst&lt;/b&gt;, tryk ENTER, TAB eller klik udenfor redigerings felt for at anvende filter.&lt;/p&gt;&lt;p&gt;For at &lt;b&gt;slette et filter &lt;/b&gt; fra listen af filte, vælg først filteret, og mens filteret er i editor feltet tryk &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (eller &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;). Standard filtre kan ikke slettes. Op til 50 filtre kan gemmes.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation>Hjælp til debugkonsol filter</translation>
     </message>
@@ -2953,70 +2983,70 @@ For at &lt;b&gt;slette en gemt række&lt;/b&gt; i filterlisten, marker og tryk &
 <context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation>Mulige årsager:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation>- EEPROM er fra en nyere version af EdgeTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation>- EEPROM er ikke fra EdgeTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation>- EEPROM er ikke fra ErSkyTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation>- EEPROM lager størrelse er ugyldig</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation>- EEPROM filsystem er ugyldigt</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation>- EEPROM er ukendt</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation>- EEPROM har fejl</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation>- EEPROM sikkerhedskopiering understøttes ikke</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation>- Ukendt problem; beklager :(</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation>Advarsel:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation>- Din radio har sandsynligvis fejl i firmware,
 EEPROM lager er på 4096 bytes, men kun de første 2048 bytes er i brug</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation>- Din EEPROM er fra en ældre version af EdgeTX, du skal opgradere!
@@ -3026,12 +3056,12 @@ EEPROM lager er på 4096 bytes, men kun de første 2048 bytes er i brug</transla
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation>Fejl i checksum på fil med radio indstillinger. Det anbefales at kontrollere indstillingerne</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation>Companion understøtter ikke version af indstillinger: %1!</translation>
     </message>
@@ -3039,12 +3069,12 @@ EEPROM lager er på 4096 bytes, men kun de første 2048 bytes er i brug</transla
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation>Kan ikke åbne %1:%2</translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation>Ugyldig EEPROM-fil %1</translation>
     </message>
@@ -3052,12 +3082,12 @@ EEPROM lager er på 4096 bytes, men kun de første 2048 bytes er i brug</transla
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;Første ror kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>Anden ror kanal:</translation>
     </message>
@@ -3065,43 +3095,43 @@ EEPROM lager er på 4096 bytes, men kun de første 2048 bytes er i brug</transla
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Fejl ved åbning af fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation>Fejl ved åbning af EdgeTX arkiv %1</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation>Fejl ved initialisering af EdgeTX arkiv skriver</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Fejl ved skrivning af fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation>Fejl ved oprettelse af EdgeTX fil: %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation>Fejl ved oprettelse af EdgeTX arkiv</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation>Fejl ved tillæg af %1 til EdgeTX arkiv</translation>
     </message>
@@ -3109,23 +3139,23 @@ EEPROM lager er på 4096 bytes, men kun de første 2048 bytes er i brug</transla
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation>INP</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation> (@%1)</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation>TIL</translation>
     </message>
@@ -3133,101 +3163,85 @@ EEPROM lager er på 4096 bytes, men kun de første 2048 bytes er i brug</transla
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Kontakt</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>Mix kilde.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Kontakter som styrer indgange.
-Er felte tomt, er indgangen aktiv hele tiden.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>Skala</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Inkluder trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>Kurve som dynamisk tilpasses kilde.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Linje navn</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation>Negativ</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Offset</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>Mixer kilde</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Indgang navn</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation>Positiv</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Vægt</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Flyve tilstand</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Pind værdi</translation>
     </message>
@@ -3237,32 +3251,32 @@ Er felte tomt, er indgangen aktiv hele tiden.</translation>
         <translation>Rediger %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="247"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation>Sæt alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="248"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation>Alt omvendt (INV)</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation>Popop menu mulig</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation>enhed</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation>billede</translation>
     </message>
@@ -3270,22 +3284,22 @@ Er felte tomt, er indgangen aktiv hele tiden.</translation>
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>Gas kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>Sideror kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>Højderor kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>Krængeror kanal:</translation>
     </message>
@@ -3293,99 +3307,99 @@ Er felte tomt, er indgangen aktiv hele tiden.</translation>
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation>Synkroniser filer</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation>Er du sikker på, at du vil afbryde synkroniseringen?</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation>Hvad der skal ske, hvis der er eksisterende filer som kan risikere at blive overskrevet.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation>Kopier kun nye og ændrede (ift. indhold)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation>Kopier kun hvis nyere (ikke ift. indhold)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation>Kopier kun hvis der er ændringer (tag ikke højde for fil dato)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation>Kopier altid (overskriv)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation>Alle størrelser</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation>Overspring filer større end. Angiv 0 for ingen grænse.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation>Mindste rapport niveau. Hændelser på dette og højre niveau vises.
 Advarsel: Høj logningsfrekvens kan give et program som til tider virker langsomt.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation>Sprunget over</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation>Oprettet</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation>Opdateret</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation>Vis kun fejl</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation>Kun testkørsel</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation>Kør normalt, men kopier ikke noget. Kan bruges til at verificere resultatet for end egentlig synkronisering.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation>Log niveau:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation>Filter:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
@@ -3394,166 +3408,166 @@ The Include filter is evaluated first.</source>
 Inkluder filter anvendes først.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation>En eller flera mønstre for eskludering, kommasepereret.
 Tomt betyder ekskludere ingenting. ?, * and [...] søgetegn kan anvendes.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>En eller flera mønstre for inkluderes, kommasepereret.
         Tomt betyder inkluder alt. ?, * and [...] søgetegn kan anvendes.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation>Inkluder:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation>Ekskluder:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation>Type afhænig</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation>Følg genveje</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation>Inkluder skjulte</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation>Rekursivt</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation>Overspring tomme</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation>Gem filter</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation>Filter tilvalg:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation>Katalog tilvalg:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation>Tilvalg</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation>Vis ekstra tilvalg</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation>Genstil til standard værdier</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation>Luk</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation>Synk.retning:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation>Eksisterende filer:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation>Max. fil størrelse:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation>Afbryd</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation>Totalt: &lt;b&gt;%1&lt;/b&gt;; Oprettet: &lt;b&gt;%2&lt;/b&gt;; Opdateret: &lt;b&gt;%3&lt;/b&gt;; Sprunget over: &lt;b&gt;%4&lt;/b&gt;; Fejl: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation>Status: &lt;b&gt;%1&lt;/b&gt; for </translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation>Mappe A</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation>Mappe B</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation>%1 ikke fundet.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation>Kataloger er ens.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation>%1%2 begge retninger, først til %3</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation> %1 kun fra %2 til %3</translation>
     </message>
@@ -3561,275 +3575,300 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation>Ingen kanal overskrivnings funktion findes</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1178"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation>Muligt at styre FAI TILSTAND (ingen telemetri) på feltet</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation>FAI TILSTAND (ingen telemetri) altid aktiv</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1195"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation>Fjerner understøttelse af FrSky D8-protokol, som ikke er lovlig i EU, efter 1. januar 2015</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1260"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1503"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1514"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1524"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1544"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Aktiver helikopter menu og søtte til rotor mix</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1261"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1504"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1515"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1545"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation>Deaktiver globale variable</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1536"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation>Intern GPS-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1262"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1495"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1505"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1516"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1526"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1546"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Aktiver tilpasning af Lua script</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1215"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation>Anvend SQT5 font</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation>Brug drejekontakter til at rulle i menu</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation>FrSky Taranis X9D+</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1348"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation>Aktiver RAS (SWR)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation>FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1349"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation>Vibratormodul er installeret</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1368"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation>FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1369"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Bekræft før radio slukkes</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1370"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1310"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation>FrSky Taranis X7 / X7S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation>FrSky Taranis X-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation>FrSky Horus X10 / X10S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation>FrSky Horus X12S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation>Jumper T20</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation>Aktiver helikoptermenu og støtte for rotor mix</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1236"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation>Globale variabler</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1238"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation>I model setup vælges automatisk en kilde ved at bevæge den</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1239"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation>I model setup vælges automatisk en kontakt ved at bevæge den</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1240"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation>Brug ikke grafiske kontroller</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation>Batteri graf</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation>Brug ikke fed font for at makere aktiv</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation>Tillad nulstilling af værdier ved at skubbe op- og ned knappen samtidigt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1282"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
         <source>Jumper T-Pro V2</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
         <source>Jumper T14</source>
         <translation>Jumper T14</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
         <source>Jumper T15</source>
         <translation>Jumper T15</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
         <source>Jumper T20 V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1196"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation>Tillad ikke certificeret firmware</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1362"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation>FrSky Taranis X9D+ 2019</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation>FrSky Taranis X9-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation>FrSky Taranis X-Lite S/PRO</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1304"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>Understøttelse af internt ACCESS modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1198"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation>Aktiver AFHDS3 support</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1197"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation>Aktiver AFHDS2A support</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1341"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
@@ -3840,105 +3879,107 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1454"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation>Understøttelse af MULTI internt modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1386"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1455"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1535"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation>Understøttelse af bluetooth modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1512"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1522"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1547"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation>Vælg hvis internt ELRS modul er installeret</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1509"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation>Tillad tilslutning med tilslut tast</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation>Understøttelse af hardware modul: FlySky Paladin EV Gimbals</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1460"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation>Jumper T18</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1268"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1275"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1376"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation></translation>
     </message>
@@ -3946,27 +3987,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ja, styret af 1 kanal</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ja, styret af 2 kanaler</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;Første flap kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>Anden flap kanal:</translation>
     </message>
@@ -3975,7 +4016,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Send modeller og indstillinger til radio</translation>
     </message>
@@ -4035,51 +4076,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Skriv til sender</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>Nuværende profil: %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>Vælg sikkerhedskopi</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>Fejlaktig information i profilen, radioens kalibrering kan ikke indlæses</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>Fejlaktig information i profilen, radioens indstillinger kan ikke indlæses</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Filen %1 kan ikke skrives:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Fejl ved skrivning af fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>Radioens firmware er en anden type end den valgte. Kontroller indstillinger!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>Firmware i radio er forældet. Overvej at opgradere radio firmware!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>Det kan ikke verficeres at modeller og indstillinger er kompatible. Fortsæt alligevel?</translation>
     </message>
@@ -4162,103 +4203,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Skriv till sender</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>Åbn firmware fil</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 er muligvis ikke en gyldige firmware fil</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>Firmware fil er ikke gyldig.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>Firmware fil indeholder ikke et start billede.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>Profil billede %1 er ugyldigt.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>Åbn billedfil som skal anvendes som start billede i radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>Billeder (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>Billede kunne ikke læses %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>Billed biblioteket kunne ikke åbnes</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>Billedfil kunne ikke findes</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>Den tilrettede firmware fil kunne ikke gemmes</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>Send firmware til radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>Verifieringen af firmware fil mislykkes</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>Kunde ikke verficere firmware fra radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>Den nye fil med firmware er ikke kompatibel med den allerede installerede!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>Konverteringen lykkes ikke</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>modeller og indstillinger kan ikke anvendes på denne firmware, ingen opdatering gennemført</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>Genskabning fejlede</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>Det lykkes ikke at genskabe modeller og indsillinger i radioen. Prøv evt. igen, filen kan findes her: %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>Brænding af firmware gennemført</translation>
     </message>
@@ -4266,42 +4307,42 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation>Programmet %1 kunne ikke findes</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation>Skriver...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation>Læser...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation>Verificerer...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>dvs: EdgeTX til 9X eller OpenTX for 9XR</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>dvs: EdgeTX til 9X eller 9XR med M128 processor</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>dvs: EdgeTX til 9X med Gruvin9X kort</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4310,7 +4351,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 Vælg CPU type i advancerede tilvalg i brænd firmware menu.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4319,7 +4360,7 @@ Please select an appropriate firmware type to program it.</source>
 Vælg det rette program for at indlæse firmware til din radio.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4328,27 +4369,27 @@ Du anvender aktuelt:
  %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>Brænding af firmware gennemført (kode = %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>Brænding af firmware har fejl</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>BESKYTTELSE: Lav=%1 Høj=%2 Ext=%3</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation>ukendt</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>Din radio er muligvis ikke tilsluttet via USB eller USB driver er ikke startet!!!.</translation>
     </message>
@@ -4356,7 +4397,7 @@ Du anvender aktuelt:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="625"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
@@ -4407,243 +4448,258 @@ Du anvender aktuelt:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
         <translation>FT</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>Indstillnings hjul %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>GV%1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Popup aktiv</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>Værdi kilde</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>Værdi</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">GV%1</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Egen værdi</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation>Trim inaktiv</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation>Egen trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation>Anvend trim fra flyve tilstand %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation>Anvend trim fra flyve tilstand %1 + eget trim som offset</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation>Enhed</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation>Prec</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation>0._</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation>Popupmenu mulig</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation>3POS til/fra kontakt</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
-        <translation>Advarsel: Global variabel peger tilbage til sig selv. Værdi fra Flyve tilstand 0 er anvendt.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
-        <translation>Advarsel: Drejehjul peger tilbage til sig selv. Værdi fra Flyve tilstand 0 er anvendt.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation>Kopi</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation>Klip ud</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation>Sæt ind</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
-        <translation>Nulstil flyve tilstand. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
-        <translation>Nulstil alle flyve tilstande. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
-        <translation>Klip ud flyve tilstand. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
-        <translation>Slet flyve tilstand. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Nulstil global variable på tværs af alle flyve tilstande. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation>Nulstil global variable. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation>Nulstil alle global variable for alle flyve tilstande. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation>Nulstil alle global variable for DENNE flyve tilstand. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Klip ud global variabel på tværs af alle flyve tilstande. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation>Klip ud global variabel. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation>Slet global variabel. Er du sikker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Sæt ind global variabel på tværs af alle flyve tilstande. Er du sikker?</translation>
     </message>
 </context>
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>Flyve tilstand %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation> (%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (standard)</translation>
     </message>
@@ -4651,17 +4707,17 @@ Du anvender aktuelt:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>Har flybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>Uden flybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>Flybar:</translation>
     </message>
@@ -4669,17 +4725,17 @@ Du anvender aktuelt:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation>Gul</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation>Rød</translation>
     </message>
@@ -4687,13 +4743,13 @@ Du anvender aktuelt:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation>---</translation>
     </message>
@@ -4745,12 +4801,12 @@ Du anvender aktuelt:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1296"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
         <translation>KO%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1340"/>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
         <source>Group %1</source>
         <translation>Gruppe %1</translation>
     </message>
@@ -4896,13 +4952,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Fortsæt kun hvis du ved hvad du gør.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>Nulstil radio beskyttelse</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>Indlæs beskyttelse fra radio</translation>
     </message>
@@ -4910,44 +4966,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation>0._</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation>?.?</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation>Egen værdi</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation>Værdi fra flyve tilstand %1</translation>
     </message>
 </context>
 <context>
@@ -4960,12 +5006,12 @@ These will be relevant for all models in the same EEPROM.</source>
 Disse indstillinger gælder for alle modeller.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Generelle indstillinger</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Træner</translation>
     </message>
@@ -4980,27 +5026,27 @@ Disse indstillinger gælder for alle modeller.</translation>
         <translation>Hent kalibrering og kontroller fra valgte profil</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>Fejlaktig information i profilen, radiokalibreringen kan ikke indlæses</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>Fejlaktig information i profilen, hardware indstillinger kan ikke indlæses</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>Vil du overskrive eksisterende kalibrering&lt;br&gt;i profilen %1 med de aktuelle?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>Kalibrering og kontroller gemt.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>Globale funktioner</translation>
     </message>
@@ -5010,22 +5056,22 @@ Disse indstillinger gælder for alle modeller.</translation>
         <translation>Radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation>Kontroller</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation>Kalibrering</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>Fejl data i profilen, indstillinger af kontakter og pinde og drejekontakter ikke indlæst</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation>Aktiverede funktioner</translation>
     </message>
@@ -5064,8 +5110,8 @@ Disse indstillinger gælder for alle modeller.</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation>Flyve tilstand</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5101,186 +5147,206 @@ Disse indstillinger gælder for alle modeller.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="379"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation>Radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="381"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation>Kontroller</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="382"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation>Internt modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation>Akse &amp; drejekontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="402"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation>Akse</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="402"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation>Drejekontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="431"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation>Kontakter</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="436"/>
-        <location filename="../firmwares/generalsettings.cpp" line="448"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation>Fleksibel kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="437"/>
-        <location filename="../firmwares/generalsettings.cpp" line="449"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation>Funktion kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="437"/>
-        <location filename="../firmwares/generalsettings.cpp" line="449"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation>Kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="466"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="520"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation>Intern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="522"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation>Spørg</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="524"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation>Per model</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="527"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation>Intern + Ekstern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="540"/>
-        <location filename="../firmwares/generalsettings.cpp" line="556"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="543"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation>Aktiveret</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="543"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="545"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation>Træner</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="558"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation>Telemetri spejlet</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation>Telemetri ind</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation>SBUS-træner</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation>LUA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation>CLI</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="568"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="570"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation>Debug</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="572"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation>SpaceMouse</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation>mA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="706"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="708"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation>OneBit</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="753"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation>Kun trim</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="755"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation>Kun knap</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="757"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation>Trim / Knap</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="759"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation>Global</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="527"/>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">Mode 1 (SID HØJ GAS KRÆ)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished">Mode 2 (SID GAS HØJ KRÆ)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">Mode 3 (KRÆ HØJ GAS SID)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">Mode 4 (KRÆ GAS HØJ SID)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation>Eksternt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="574"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation>Eksternt modul</translation>
     </message>
@@ -5293,132 +5359,132 @@ Disse indstillinger gælder for alle modeller.</translation>
         <translation>Form</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2178"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>GPS koordinater</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>Højttaler tone (kun højttaler)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2090"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Måleenheder</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2361"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation>NMEA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="563"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Stemme sprog</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="768"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Tidsdifferens til UTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2281"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Metrisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2286"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Imperiel</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Lande kode</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>Amerika</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Japan</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>Europa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1453"/>
-        <location filename="../generaledit/generalsetup.ui" line="1614"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>Ekstra kort</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1458"/>
-        <location filename="../generaledit/generalsetup.ui" line="1619"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1463"/>
-        <location filename="../generaledit/generalsetup.ui" line="1624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1468"/>
-        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1473"/>
-        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>Ekstra lang</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>Farve 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>Farve 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1433"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Længde af summetone</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="965"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>RotEnc navigering</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1654"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Bip tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="958"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Variometer tone ved nulpunkt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2489"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2494"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation>Optrex</translation>
     </message>
@@ -5428,12 +5494,12 @@ Disse indstillinger gælder for alle modeller.</translation>
         <translation>Fjern skrivebeskyttelse</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Lyd tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2037"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -5450,61 +5516,61 @@ Disse indstillinger gælder for alle modeller.</translation>
 4 - Ekstra højt.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1293"/>
-        <location filename="../generaledit/generalsetup.ui" line="2047"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Stille</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2052"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Kun alarm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1303"/>
-        <location filename="../generaledit/generalsetup.ui" line="2057"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>Ingen knap tryk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1308"/>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1298"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Kun alarm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1414"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Vibration tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="725"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>Summer</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="730"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Højttaler</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="735"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>Summe tone</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="740"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>Højttaler tone</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="857"/>
-        <location filename="../generaledit/generalsetup.ui" line="1695"/>
+        <location filename="../generaledit/generalsetup.ui" line="823"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5519,169 +5585,175 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Værdier mellem 20 og 45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation>SC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation>SE</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation>SA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation>SF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation>SH</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation>SD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation>SB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation>SG</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation> Hz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1503"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Batteri advarsel</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Variometer tone ved max højde</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Angiver antal sekunder som baggrundsbelysningen er tændt efter sidste tryk på knap.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation> sek</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1703"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation> ms</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>Lys styrke</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Gentagende variometer tone ved nul</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>Lys slukkes efter</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>Farve baggrundslys</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2104"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
         <source>Trainer Poweroff Warning</source>
         <translation>Træner: Advarsel ved sluk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2133"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>LCD-kontrast</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2409"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Efter det angivne antal minutter med inaktivitet lyder et advarselssignal. 0 slår fra.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2412"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation> min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1976"/>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation>4800 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1981"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation>9600 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1986"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation>14400 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1991"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation>19200 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1996"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation>38400 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2001"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation>57600 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2006"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation>76800 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2011"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation>115200 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>Lys aktivering</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Vis startbillede</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5690,15 +5762,15 @@ p, li { white-space: pre-wrap; }
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2171"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>LCD type</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1945"/>
-        <location filename="../generaledit/generalsetup.ui" line="2622"/>
-        <location filename="../generaledit/generalsetup.ui" line="2657"/>
-        <location filename="../generaledit/generalsetup.ui" line="2705"/>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5723,116 +5795,116 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Tavs advarsel - advarer om summer er i stille tilstand&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2083"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>MAVLink Baud Rate</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="820"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Højttaler volume</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1734"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Vibration tid</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Inaktivitets ur</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2530"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation>----</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1389"/>
-        <location filename="../generaledit/generalsetup.ui" line="1588"/>
-        <location filename="../generaledit/generalsetup.ui" line="2535"/>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation>2s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1394"/>
-        <location filename="../generaledit/generalsetup.ui" line="1593"/>
-        <location filename="../generaledit/generalsetup.ui" line="2540"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation>3s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2545"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation>4s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2550"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation>6s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2555"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation>8s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation>10s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2565"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation>15s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2603"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Advarsel for slukket lyd</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1328"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Vibration styrke</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="572"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Lyd volumen</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Lydstyrke Wav</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="618"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Lydstyrke variometer</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="641"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Lydstyrke baggrund</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2254"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Pind tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2584"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Kanal rækkefølge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>FAI tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5873,412 +5945,267 @@ Tilstand 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>Mode 1 (SID HØJ GAS KRÆ)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>Mode 2 (SID GAS HØJ KRÆ)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2335"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>Mode 3 (KRÆ HØJ GAS SID)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2340"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>Mode 4 (KRÆ GAS HØJ SID)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1747"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kanalordning&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Kanal rækkefølge på en ny model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="666"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation>Label valg tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="673"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation>Label match</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="701"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation>Stort billede (2 kolonner)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="706"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation>Lille billede ( 3 kolonner)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="711"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation>Kun navn ( 2 kolonner)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="716"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation>Kun navn ( 1 kollone)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation>Styring af model layout</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation>Farvorit match</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation>Multi valg</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation>Vælg een</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation>Match alle</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation>Match enhver</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation>Skal matche</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation>Valgfri match</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1259"/>
-        <source>Invert LCD</source>
-        <translation>Invers LCD</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1374"/>
-        <location filename="../generaledit/generalsetup.ui" line="1573"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
         <source>0s</source>
         <translation>0s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1379"/>
-        <location filename="../generaledit/generalsetup.ui" line="1578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
         <source>0.5s</source>
         <translation>0.5s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1754"/>
-        <source>R E T A</source>
-        <translation>S H G K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1759"/>
-        <source>R E A T</source>
-        <translation>S H K G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1764"/>
-        <source>R T E A</source>
-        <translation>S G H S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1769"/>
-        <source>R T A E</source>
-        <translation>S G K H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1774"/>
-        <source>R A E T</source>
-        <translation>S K H G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1779"/>
-        <source>R A T E</source>
-        <translation>S K G H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1784"/>
-        <source>E R T A</source>
-        <translation>H S G K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1789"/>
-        <source>E R A T</source>
-        <translation>H S K G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1794"/>
-        <source>E T R A</source>
-        <translation>H G S K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1799"/>
-        <source>E T A R</source>
-        <translation>H G K S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1804"/>
-        <source>E A R T</source>
-        <translation>H K S G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
-        <source>E A T R</source>
-        <translation>H K G S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1814"/>
-        <source>T R E A</source>
-        <translation>G S H K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1819"/>
-        <source>T R A E</source>
-        <translation>G S K H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1824"/>
-        <source>T E R A</source>
-        <translation>G H S K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>T E A R</source>
-        <translation>G H K S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>T A R E</source>
-        <translation>G K S H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>T A E R</source>
-        <translation>G K H S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>A R E T</source>
-        <translation>K S H G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>A R T E</source>
-        <translation>K S G H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>A E R T</source>
-        <translation>K H S G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>A E T R</source>
-        <translation>K H G S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>A T R E</source>
-        <translation>K G S H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>A T E R</source>
-        <translation>K G H S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2680"/>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
         <source>Power ON/OFF Haptic</source>
         <translation>Strøm TIL/FRA vibrator</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1516"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Indsæt forsinkelse (kontakt i midt position)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2111"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation>Afspil start lyd</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2247"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation>PPM enhed</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2369"/>
-        <location filename="../generaledit/generalsetup.ui" line="2373"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2378"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2383"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="782"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>Blinkende lys ved alarm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="754"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Inverteret pind</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Juster RTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2187"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2194"/>
-        <location filename="../generaledit/generalsetup.ui" line="2223"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation>v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2216"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2514"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Batteri måler grænseværdier</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>Radio klokke justeres automatisk hvis GPS enhed er tilsluttet telemetri.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="680"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>Lysstyrke baggrundslys: Fra</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation>Hvis du aktiverer FAI virker kun RSSI og RxBt-sensorer. Dette kan ikke ændres i radioen.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2152"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation>RSSI advarsel ved sluk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1913"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation>Advarsel for kun lidt plads i EEPROM</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1920"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation>USB tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1336"/>
-        <location filename="../generaledit/generalsetup.ui" line="1878"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation>Spørg ved tilslutning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1883"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation>Joystik (HID)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1888"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation>USB som lagerenhed</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1893"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation>Seriel USB (CDC)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2348"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>Joystik indstilling</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="827"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation>Ejer ID for registrering</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1481"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation>Forsinkelse ved opstart</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2435"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation>Stik tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1341"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1346"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation>Træner</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2356"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation>GMS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2070"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation>Forsinkelse ved sluk af radio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation>Baggrundslys på taster</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="834"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation>Drejekontakt tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1541"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -6289,19 +6216,19 @@ Dette er grænseværdien, hvor batteri advarsel lyder.
 Værdier mellem 5 og 12 volt accepteres</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation>Vælg model</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation>Vælg, hvis du ønsker hurtigt at skifte model på Model fane (længe tryk sender dig til model edit menu).</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1384"/>
-        <location filename="../generaledit/generalsetup.ui" line="1583"/>
-        <location filename="../generaledit/generalsetup.cpp" line="278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation>1s</translation>
     </message>
@@ -6309,137 +6236,137 @@ Værdier mellem 5 og 12 volt accepteres</translation>
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="365"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation>Fra</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="365"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation>Knapper</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="365"/>
-        <source>Sticks</source>
-        <translation>Pinde</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="365"/>
-        <source>Keys + Sticks</source>
-        <translation>Knapper + pinde</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="365"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation>TIL</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation>Engelsk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation>Dansk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation>Hollandsk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation>Fransk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation>Italiensk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation>Tysk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation>Tjekkisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation>Slovakisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="397"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation>Spansk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation>Polsk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation>Portugisisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation>Russisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="398"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation>Svensk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation>Ungarnsk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="399"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation>Ukranisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="471"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="471"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation>Inm.hjul A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="471"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation>Inm.hjul B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="471"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation>Inm.hjul C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="471"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation>Inm.hjul D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="471"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation>Inm.hjul E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="583"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6448,42 +6375,42 @@ Det kan ikke deaktiveres af senderen.
 Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="601"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="601"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation>Invers</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="601"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation>Lodret invers, vandret normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="601"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation>Lodret invers, vandret alternativ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="601"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation>Normal, rediger invers</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation>Kinesisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation>Japansk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation>Hebraisk</translation>
     </message>
@@ -6491,17 +6418,17 @@ Er du sikker?</translation>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Ja, kontrolleret af kontakt</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Ja, kontrolleret af drejekontakter</translation>
     </message>
@@ -6509,118 +6436,128 @@ Er du sikker?</translation>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation>Død zone</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation>Drejekontakter</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation>Kontakter</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation>RTC batteri kontrol</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation>Bluetooth</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation>Enheds navn:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation>Registererings tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation>Seriel port</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation>Spænding</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation>USB-VCP</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation>ADC-filter</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>Audio fra, hvis der ikke gives lyd</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation>S.Port spænding</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation>Offset for strømstyrke</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Omvendt (INV)</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation>Advarsel: At ændre det interne modul kan betyde, at den anvendte protokol ødelægges for model!</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation>Internt RF</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation>Akse</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation>Baud hastighed:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation>Antenne:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation>Eksternt RF</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation></translation>
     </message>
@@ -6701,22 +6638,22 @@ Er du sikker?</translation>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>Gas kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>Sideror kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>Højderor kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>Krængeror kanal:</translation>
     </message>
@@ -6724,19 +6661,19 @@ Er du sikker?</translation>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation>Ugyldig EEPROM-fil %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Kan ikke åbne fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Fejl ved skrivning af fil %1:
@@ -6746,159 +6683,159 @@ Er du sikker?</translation>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Nulstil alle indgange</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;Ny</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation>CTRL+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;Rediger</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation>Retur</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>&amp;Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopier</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>Klip &amp;ud</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>Sæt &amp;ind</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>Du&amp;pliker</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation>Der er ikke nok tilgænglige indgange!</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation>Slet valgte indput linjer. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation>Klip ud linjer med valgte indgange. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation>Linjer</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation>Indgang</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation>Nulstil alle indgange. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation>Nulstil alle linjer med valgte indgange. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation>Slet alle linjer med valgte indgange. Er du sikker?</translation>
     </message>
@@ -6939,96 +6876,96 @@ Er du sikker?</translation>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation>Kan ikke udpakke RADIO/radio.bin</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation>Kan ikke udpakke RADIO/models.txt</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation>Kan ikke udpakke %1</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation>Fejl ved indlæsning af modeller</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation>Kan ikke finde %1/RADIO/radio.yml</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation>Fandt %1/RADIO/radio.yml</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation>Kan ikke finde %1/MODELS/models.yml</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation>Fandt %1/MODELS/models.yml</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation>Kan ikke finde %1</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation>Fandt %1</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation>Kan ikke udpakke RADIO/radio.yml</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation>Kan ikke indlæse RADIO/radio.yml</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation>Kan ikke udpakke </translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation>Kan ikke indlæse </translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation>Favoritter</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation>Kan ikke indlæse MODELS/labels.yml</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation>Kan ikke liste filer</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation>Fejl ved sletning af filer</translation>
     </message>
@@ -7036,17 +6973,17 @@ Er du sikker?</translation>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation>INV</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation>NOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation>KA</translation>
     </message>
@@ -7054,7 +6991,7 @@ Er du sikker?</translation>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation>GV</translation>
     </message>
@@ -7062,122 +6999,122 @@ Er du sikker?</translation>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation>----</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation>a&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation>a&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation>|a|&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation>|a|&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation>OG</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation>ELLER</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation>XOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation>a=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation>a!=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation>a&gt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation>a&lt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation>a&gt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation>a&lt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation>d&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation>|d|&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation>a=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation>a~x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation>Tidtagning</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation>Sej</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation>Kant</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation>Ukendt</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation>LF</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation>LSW</translation>
     </message>
@@ -7185,37 +7122,37 @@ Er du sikker?</translation>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation>Værdi 1</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation>Værdi 2</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>Funktion</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>OG kontakt</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>Varighed</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>Forsinkelse</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="114"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation>(omgående)</translation>
     </message>
@@ -7225,12 +7162,12 @@ Er du sikker?</translation>
         <translation> (uendelig)</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="61"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation>Popupmenu mulig</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="50"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
         <source>Persistent</source>
         <translation>Varig</translation>
     </message>
@@ -7343,42 +7280,42 @@ Er du sikker?</translation>
         <translation>Flyvninger</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>Telemetri log</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>Ændre plot title</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>Ny plot title:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>Ændre akse label</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>Nyt akse label:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>Ændre graf navn</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>Nyt grafnavn:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7386,74 +7323,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 Kolumnerna for højde (GAlt) og hastighed (GSpd) er valgfrie</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kan ikke skrive fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>Vælg logfil</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>Tilgængeligt felt</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>Valgt logfil indeholder %1 ugyldige rækker, af totalt %2 rækker</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>tid </translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation> (L1)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation> (R1)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation> (L2)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation> (R2)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>Markør A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation>Tid (hh:mm:ss.ms)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>Markør B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>Tids delta: %1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>Stignings hastighed: %1 m/s</translation>
     </message>
@@ -7463,12 +7400,12 @@ Kolumnerna for højde (GAlt) og hastighed (GSpd) er valgfrie</translation>
         <translation>Gem som CSV</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation>Fejl: ingen GPS-data er fundet</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation>tids interval</translation>
     </message>
@@ -7476,398 +7413,398 @@ Kolumnerna for højde (GAlt) og hastighed (GSpd) er valgfrie</translation>
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Fil indlæst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Filen gemt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Afslut</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>Klassisk</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>Monokrom</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>MonoHvid</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>MonoBlå</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>System sprog</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Indstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Hent/Send</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Ændre indstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Afslut programmet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>Vis information om programmet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>Syntes du at programmet er brugbart, kan du støtte udviklingen ved at &lt;a href=&apos;%1&apos;&gt;donere.&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Opret en ny model og indstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Gem model og indstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>Det klassiske companion9x ikon tema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation>Yerico</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Yellow round honey sweet ikon tema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Vælg menu sprog</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Arkiv</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Modeller</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Hjælp</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Klar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Sammenlign modeller</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Rediger radio startbillede...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>Rediger startbillede på din radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Hent radio firmware</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>Hent radio firmware</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Send firmware til radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Send modeller og indstillinger til radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Hent modeller og indstillinger fra radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>Indstillinger af kommunikations program</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Indlæs sikkerhedskopi til radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Skriv sikkerhedskopi fra fil til radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Sikkerhedskopier radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>Gem en fuldstændig sikkerhedskopi af alle data i radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>Seneste filer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>Skriv</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation>%2</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>De nya ikoner kan bruges efter genstart af Companion.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Åbn model og indstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>Om Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>Et monokromt sort ikon tema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Hent model og indstillinger fra radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>Gem sikkerhedskopi af radio i fil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Gem radio firmware i fil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>Åbn...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Gem</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Gem som...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>Et monokromt hvidt ikon tema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>Et monokromt blåt ikon tema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Små</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>Brug små ikoner i værktøjslinjen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>Brug normal størrelse ikoner i værktøjslinjen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>Brug store ikoner i værktøjslinjen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Store</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>Brug meget store ikoner i værktøjslinjen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Meget store</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>Vis logfil...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Åbn og vis logfil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Indstillinger...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Sammenlig modeller...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Opret radio profil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>Kommunikations indstillinger...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Vælg ikon tema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Vælg ikon størrelse</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>Synkroniser SD-kort</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>Synkronisering af SD-kort</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation>En del tekst er ikke oversat før Companion er genstartet. Bemærk også at der kan være oversættelser som savnes.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation>modeller og indstillinger er indlæst</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation>Denne funktion er endnu ikke udviklet</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation>Standard sprog fra Windows.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation>Brug %1 sprog. Visse oversættelser kan mangle.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
@@ -7876,338 +7813,338 @@ Do you wish to continue?</source>
 Vil du fortsætte?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation>Katalog for lokalt SD katalogstruktur er ikke indstillet!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation>Ingen radio eller SD-kort opdaget!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation>Luk</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation>Luk model- og indstillingsfil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation>Sidste brugte filer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation>Radioprofiler</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation>Opret eller vælg radioprofil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation>Release  information...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation>Vis release information</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation>Opret en ny profil til radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation>Kopier gældende radio profil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation>Dupliker gældende profil med radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation>Slet gældende radio profil...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation>Slet gældende profil med radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation>Arrangeret med faner</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation>Brug tab for at arrangere åbne vinduer.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation>Arrangeret som fliser</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation>Arrangeret med åbne vinduer fordelt over den mulige plads.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation>Arrangeret som kaskade vinduer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation>Arrangeret ved stabling af åbne vinduer.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation>Luk alle vinduer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation>Luk alle åbne filer (du får mulighed for at gemme først).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation>Vinduer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1264"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation>Kan ikke tilføje profil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1264"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation>Der er ikke plads til at tilføje en ny profil. Slet først eksisterende profil.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1294"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation> - Kopier</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1303"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation>Companion :: Advarsel - åbne filer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1303"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation>Gem eller luk ændrede filer inden den aktive profil slettes.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1311"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation>Profilen kan ikke slettes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1311"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation>Standard profil kan ikke slettes.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation>Bekræft slet af profil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1317"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation>Vil du virkelig slette radioprofil %1? Det kan ikke fortrydes!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation>Lokal katalog</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation>Radiokatalog</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation>Eksporter programindstillinger..</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation>Gem alle nuværende %1 og simulatorindstillinger (inkl. radioprofiler) til fil.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation>Importer programindstillinger..</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation>Indlæs %1 og simulatorens indstillinger fra tidligere eksporteret indstillingsfil.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1339"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation>Gem eller luk alle ændrede filer inden indstillinger importeres</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1342"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;p&gt;%1 og simulatorindsillingerne kan importeres (genskabes) fra en tidigere gemt eksportfil (sikkerhedskopi). Dette erstatter nuværende indstillinger med dem som importeres.&lt;/p&gt;&lt;p&gt;Det forsøges at tage en sikkerhedskopiering af aktuelle indstillinger inden import, men det anbafales at du selv først tager en manuel sikkerhedskopi, særligt hvis din model er godt konfigureret/god at gemme.&lt;/p&gt;&lt;p&gt;Skal du importere indstillinger, gives det bedste resultat ved ved import at du &lt;b&gt;lukker alle %1 vinduer - især simulator - inden import.&lt;/p&gt;&lt;p&gt;Vil du fortsætte?&lt;/p&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1350"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation>Bekræft import af indstillingerne</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1355"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation>Vælg %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1360"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation>sikkerhedskopi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1362"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation>Tryk på &apos;Spring over&apos; for at fortsætte alligevel.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1372"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation>Indstillingerne kunne ikke importeres.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1375"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation>&lt;html&gt;&lt;p&gt;Nye indstillinger er læst fra:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 skal indsilles på ny.&lt;/p&gt;&lt;p&gt;Du kan skulle slukke og starte om %2 inden visse indsillinger fx. sprog og ikon tema slår igennem.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1382"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation>&lt;p&gt;Forrige indstillinger er sikkerhedskopieret til:&lt;br&gt; %1&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation>EdgeTX hjemmeside: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation>Companion til EdgeTX har sin oprindelse i &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation>Anmeld &lt;a href=&apos;%1&apos;&gt;problem eller ønske&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation>EdgeTX Companion %1 - Radio: %2 - Profil: %3</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation>Om Companion...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation>Hent komponenter...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation>Hent EdgeTX komponenter og tilhørende ressourcer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation>Søg opdateringer...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation>Søg efter opdateringer af EdgeTX og tilhørende ressourcer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Skriv firmware til radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation>Søger efter opdateringer...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Send modeller og indstillinger til radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation>Sender modeller og indstillinger til radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation>Arbejder...</translation>
     </message>
@@ -8215,114 +8152,114 @@ Vil du fortsætte?</translation>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Rediger model %1: </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Kan ikke finde fil %1 !</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Fejl ved indlæsning af fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Fejl ved åbning af fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Gem som</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 er ændret.
 Vil du gemme ændringer?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Kan ikke skrive i temporær fil!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>Åbn model- og indstillings fil</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>Binær sikkerhedskopi er ugyldig %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation>Vil du overskrive de generelle indstillinger?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8331,7 +8268,7 @@ Vil du gemme ændringer?</translation>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8340,128 +8277,128 @@ Vil du gemme ændringer?</translation>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation>Intet valgt</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation>Rediger model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation>Tag ud</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation>Sæt ind</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation>Rediger radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation>Kopier radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation>Sæt ind radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation>Simulering af radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation>Radio model rækkefølge</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation>Tilføj model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation>Genskab fra sikkerhedskopi</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation>Modelguide</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation>Angiv som standard valg</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation>Udskriv model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation>Simuler model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation>Dupliker model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation>Vis radio værktøjslinje</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation>Vis model værktøjslinje</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation>Kan ikke oprette endnu en model, siste model i listen ville blive slettet.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation>Kan ikke oprette endnu en model, ikke mere plads til modeller.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation>Kan ikke indsætte model, ikke mere plads til modeller.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
             <numerusform>Slet %n valgte model(ler)?</numerusform>
@@ -8469,205 +8406,205 @@ Vil du gemme ændringer?</translation>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation>Ikke muligt at duplikere model, ikke mere plads til modeller.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation>Vil du gennemføre konvertering?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation>Vælg &lt;i&gt;Anvend&lt;/i&gt; for at konvertere;i&gt;Luk&lt;/i&gt; for at afbryde uden at konvertere.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation>&lt;b&gt;Konverteringen har vigtige meddelser, se nedenfor.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation>Companion :: Resultat fra konvertering af %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Gældende radiotype (%1) er ikke kompatibel med fil %3 (fra %2), modeller og indstillinger skal konverteres.&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation>kun læsning</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation>Radioindstillinger kan ikke ændres. mens modeller redigeres.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation>Du er ved at overskrive ALLE radioens modeller.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation>Ønsker du at fortsætte?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation>Vælg en model template</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation>Tilføj en model som anvender</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation>Standard valg</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation>Rediger</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation>Guide</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation>Den temporære model kan ikke slettes!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation>Eksport</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation>Eksporter model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation>Model findes allerede! Ønsker du at overskrive eller vælge ny plads?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation>Overskriv</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation>Favoritter</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation>Radioens SD kort kan ikke findes!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation>Protokol for interne modul er ændret til &lt;b&gt;FRA&lt;/b&gt; for %1 modeller!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation>Skabelon</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation>Eksporter model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation>Label styring</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation>Skift navn</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation>Vis værktøjer for labels</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation>Ugyldig fil efternavn!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation>Vis ikke denne meddelelse igen</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation>Modeller og indstillinger sendt til radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation>Fejl ved send modeller og indstillinger til radio!</translation>
     </message>
@@ -8675,143 +8612,148 @@ Vil du gemme ændringer?</translation>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation>Metode til beregning: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation>antal</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation>størrelse</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation>Komprimer %1 til %2 med ekstra %3</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation>Eksisterende arkiv vil overskrives</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation>Ekisterende arkiv kan ikke åbnes</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation>Ekisterende arkiv åbnet</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation>Kan ikke skrive i ekisterende arkiv</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation>Ekisterende arkiv initialiseret</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation>Fejl ved initialisering af arkiv</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation>Arkiv initialiseret</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation>Beregner antallet af emner som skal arkiveres</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation>Kan ikke klargøre arkiv</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation>Komprimering slut</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation>Fejl ved tilføjning af %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation>Tilføjet fil: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation>Dekomprimering af %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation>Filen ser ikke ud til at være et komprimeret arkiv</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation>Komprimeret arkiv indeholder ingen filer</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation>Fejl ved fil status</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation>Kan ikke hente status for fil ved indeks: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation>Kan ikke dekomprimere %1 til %2</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation>Størrelsen %2 for filen %1 svarer ikke til orignalen %3</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation>Dekomprimeret fil: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation>Dekomprimering slut</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation>Kand ikke oprette katalog: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation>Oprettet katalog: %1</translation>
     </message>
@@ -8819,12 +8761,12 @@ Vil du gemme ændringer?</translation>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation>MIX</translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation> (@%1)</translation>
     </message>
@@ -8837,197 +8779,162 @@ Vil du gemme ændringer?</translation>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>Mixer kilde</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Vægt</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Offset</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">Præcision</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Inkluder trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Mix kurve</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Kontakt</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Kontakter der bruges i mix.
-Er feltet blankt, så er mix altid aktivt.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translatorcomment>Not clear what that means...</translatorcomment>
-        <translation>Mix advarsel.
-Angives en værdi, så lyder alarmen når værdien nåes.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>Fra</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 bip</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2 bip</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 bip</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Multiplex</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Multiplexer
-
-Angiver hvordan mix værdier påvirker kanalen.
-
-&quot;+&quot; betyder at værdi af mix lægges til mix som på samme kanal, som kommer før.
-&quot;*&quot; betyder at værdi af mix ganges med mix som på samme kanal, som kommer før.
-&quot;R&quot; betyder at værdi overskriver værdier på samme kanal som kommer før. Er en kontakt sat til FRA, gøres ingenting.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>Læg til</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>gange</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>Erstat</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation>Træg op/ned præcision</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation>0.00</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Forsinkelse</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Langsom</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Op</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>Inkluder DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Flyve tilstand</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -9052,32 +8959,32 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Er sejhed ikke nul, begrænses hastigheden af ændringer med den angivne værdi -&amp;gt; værdien angiver det antal sekunder det tager at gå fra fuld negativ udslag(-100) til fuld positiv udslag(100).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="116"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation>Klik for at åbne popup menu</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="265"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation>Sæt alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="266"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation>Inverter alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation>RETN -&gt; %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation>billede</translation>
     </message>
@@ -9085,22 +8992,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation>Øge font størrelse</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation>Forminske font størrelse</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation>Standard font størrelse</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation></translation>
     </message>
@@ -9108,136 +9015,136 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Nulstil mix</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>Der er for få mix tilgængelige!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;Ny</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation>CTRL+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;Rediger</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>Retur</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>Skift &amp;markering til/fra</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopier</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>Klip &amp;ud</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>Sæt &amp;ind</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>Du&amp;pliker</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>Slet mix?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>Vil du virkelig slette alle mix?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation>Slet valgte Mix linjer. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation>Klip ud valgte Mix linjer. Er du sikker?</translation>
     </message>
@@ -9245,109 +9152,114 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation>Model: </translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation>Gas kanal</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1503"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation>GAS</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1616"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1620"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1618"/>
+        <location filename="../firmwares/modeldata.cpp" line="1622"/>
         <source>Master/Jack</source>
         <translation>Træner/stik</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1620"/>
+        <location filename="../firmwares/modeldata.cpp" line="1624"/>
         <source>Slave/Jack</source>
         <translation>Elev/stik</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1622"/>
+        <location filename="../firmwares/modeldata.cpp" line="1626"/>
         <source>Master/SBUS Module</source>
         <translation>Træner/SBUS-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1624"/>
+        <location filename="../firmwares/modeldata.cpp" line="1628"/>
         <source>Master/CPPM Module</source>
         <translation>Træner/CPPM-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1626"/>
+        <location filename="../firmwares/modeldata.cpp" line="1630"/>
         <source>Master/Serial</source>
         <translation>Træner/Seriel</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1628"/>
+        <location filename="../firmwares/modeldata.cpp" line="1632"/>
         <source>Master/Bluetooth</source>
         <translation>Træner/bluetooth</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1630"/>
+        <location filename="../firmwares/modeldata.cpp" line="1634"/>
         <source>Slave/Bluetooth</source>
         <translation>Elev/bluetooth</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1632"/>
+        <location filename="../firmwares/modeldata.cpp" line="1636"/>
         <source>Master/Multi</source>
         <translation>Træner/Multi</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1719"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation>INGEN</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1721"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation>Skifter</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1723"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation>2 positioner</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1748"/>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
         <source>SW</source>
         <translation>SW</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1750"/>
-        <location filename="../firmwares/modeldata.cpp" line="1886"/>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
         <source>Off</source>
         <translation>Fra</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1761"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1763"/>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
         <source>Group </source>
         <translation>Gruppe </translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1888"/>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
         <source>On</source>
         <translation>Til</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1746"/>
-        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation>Genskab</translation>
     </message>
@@ -9360,58 +9272,53 @@ p, li { white-space: pre-wrap; }
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>Heli</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Indgange</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Specialfunktioner</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Grund indstillinger</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Mix</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Logiske funktioner</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Kurver</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Flyve tilstand</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>Udgange</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation>Bruger dialog</translation>
     </message>
@@ -9421,7 +9328,7 @@ p, li { white-space: pre-wrap; }
         <translation>Simulering</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation>Aktiverede funktioner</translation>
     </message>
@@ -9475,8 +9382,8 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation>Flyve tilstand</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9512,595 +9419,595 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation>Exponentiel</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>Ekstra fin</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>Fin</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>Medium</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>Grov</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation>Ukendt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation>Fra</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation>FT%1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation>FT%1%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation>FT%1+%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation>Ingen trim</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation>Ingen trim</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation>Ingen DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>Deaktiveret i alla fly tilstande</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>Tilpasset</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation>Offset(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation>120X</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation>140</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation>Vægt(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation>Kontakt(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation>Forsinkelse(u%1:d%2)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation>Langsom(u%1:d%2)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation>Advarsel(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation>øjeblikkelig</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation>Aktiver</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation>Deaktiver</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation>Sandt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation>Falskt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation>J</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation>TIL</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation>byte</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="784"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation>Mode</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation>Kanaler</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation>Frame længde</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation>PPM forsinkelse</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation>Polaritet</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation>Protokol</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="640"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation>Forsinkelse</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="851"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation>Modtager</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation>Radio protokol</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation>Sub type</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation>Tilvalg</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation>Sub type</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation>RF udgangs effekt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation>Tilvalg</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="778"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation>2 positioner {3P?}</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation>Træg præcision(0.00)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation>Flyve tilstande</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation>Flyve tilstand</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation>Alle hændelser</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation>Kant</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation>uendelig</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation>Sej</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="535"/>
+        <location filename="../modelprinter.cpp" line="539"/>
         <source> Persistent</source>
         <translation> Varig</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="538"/>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation>Tidtagning</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="565"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation> savnes</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation>Varighed</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation>Udvidede grænser</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation>Vis checkliste</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="751"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation>Globale funktioner</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation>Manuel</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="808"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation>Automatisk</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="818"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation>Fejlsikrings tilstand</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation>Håll senaste</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="833"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation>Ingen puls</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation>Ikke defineret</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation>Ingen puls</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation>Trin</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="861"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation>Skærm</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="862"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation>Udvidet</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="865"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation>Joystik indstilling</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation>Aldrig</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation>Ved ændring</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="893"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation>Alltid</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation>Kun trim</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation>Kun knap</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation>Trim / Knap</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="909"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation>Global</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
-        <location filename="../modelprinter.cpp" line="1066"/>
-        <location filename="../modelprinter.cpp" line="1076"/>
+        <location filename="../modelprinter.cpp" line="935"/>
+        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation>Gastrim kun for tomgang</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="933"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="934"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation>Omvendt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="938"/>
+        <location filename="../modelprinter.cpp" line="942"/>
         <source>Trim source</source>
         <translation>Trim kilde</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="952"/>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation>FrSky S.PORT</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="954"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation>FrSky D</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="956"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation>FrSky D (kabel)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation>Højde</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation>Højde+</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="975"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation>VFart</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="977"/>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="979"/>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
-        <location filename="../modelprinter.cpp" line="1020"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1000"/>
-        <location filename="../modelprinter.cpp" line="1022"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1002"/>
-        <location filename="../modelprinter.cpp" line="1024"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation>FAS</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation>Celler</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1076"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1076"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1046"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation>Cifre</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1048"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation>Bjælke</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1050"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation>Skript</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1097"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation>Filnavn</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1107"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation>Fejl: Kan ikke åbne eller læse fil!</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation>Rå 12 bit</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation>Skala(%1)</translation>
     </message>
@@ -10108,27 +10015,27 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Fly</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>Multirotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Helikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Modelnavn:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Modeltype:</translation>
     </message>
@@ -10136,27 +10043,27 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation>Indeks</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation>Modtager #</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation>Model %1</translation>
@@ -10412,290 +10319,290 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation>Positiv</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation>Negativ</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation>Træner indgang</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation>Intern sender</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation>Ekstern sender</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="294"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation>Ekstra sende system</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="296"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation>Radio system</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="321"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="321"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="333"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation>10mW - 16KA</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="333"/>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation>100mW - 16KA</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="333"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation>500mW - 16KA</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="333"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation>Auto &lt;= 1W - 16KA</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="334"/>
-        <location filename="../firmwares/moduledata.cpp" line="336"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation>25mW - 8KA</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="334"/>
-        <location filename="../firmwares/moduledata.cpp" line="336"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation>25mW - 16KA</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation>200mW - 16KA (ingen telemetri)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation>500mW - 16KA (ingen telemetri)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="336"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation>100mW - 16KA (ingen telemetri)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="339"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation>25 mW</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="339"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation>100 mW</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="339"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation>500 mW</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="339"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation>1 W</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="339"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation>2 W</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="58"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
         <source>Current firmware board does not match conversion to board</source>
         <translation>Aktuel firmware er ikke kompatibel med hardware</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation>PPM</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation>SBUS via VBat</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="320"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="320"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="320"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="322"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="323"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="259"/>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation>Ingen telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="260"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation>MLink</translation>
     </message>
@@ -10703,57 +10610,57 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation>intern</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation>ekstern</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation>hardware</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation>profil</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation>Advarsel: Modul protokol %1 - &lt;b&gt;%2&lt;/b&gt; er ikke kompatibel med &lt;b&gt;%3 %1 modul %4&lt;/b&gt; og er ændret til &lt;b&gt;FRA&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation>Værdi</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>Behold seneste</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>Ingen pulsering</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation>Tilslut kanal</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation>Tilvalg</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
@@ -10761,456 +10668,456 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>Flyve tilstande</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>Flyve tilstand</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>Kontakt</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation>GV%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>Globale variabler</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>Indgange</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>Mix</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>Kurver</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation>LF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>Logiske funktioner</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>Specialfunktioner</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>Enhed</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>RSSI-alarm</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>Indgang</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>Vægt</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation>Long. cyk</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation>Lateral cyk</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>Samling</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation>Generelt</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation>Model billede</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation>Gas</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation>Trim</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation>Bip i center</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation>Kontakt advarsel</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation>Drejekontakt advarsel</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation>Andet</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation>Tidtagning</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation>Nedtælling</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation>Moduler</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation>Elev port</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation>Helikopter</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation>Styreplade</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation>Præcision</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation>Popup</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation>Udgange</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation>Subtrim</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation>Direkte</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation>PPM</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation>Linær</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation>Protokol</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation>Lav</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation>Kritisk</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation>Telemetri lyd</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation>Høje måler</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation>Variometer kilde</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation>Variometer grænser &gt;</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation>Max synke/ned</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation>Min synke/ned</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation>Min stige/op</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation>Max stige/op</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation>Centrum stille</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation>Øvre bjælke</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation>Volt kilde</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation>Højde kilde</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation>Parametre</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation>Telemetri sensorer</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation>Telemetri visning</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation>Min kald</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation>Bestående</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation>F.Ind</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation>F.Ud</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation>Global variabel</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation>Globale funktioner</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation>Checkliste</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation>Tilstand</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>Kontakter der kan tilpasses</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation>Kontakt %1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation>Gruppe</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation>Altid til</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation>Multi sensorer</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation>Funktion</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation>Gentag</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation>Aktiveret</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation>Vis ID</translation>
     </message>
@@ -11218,7 +11125,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation>Servo opdaterings frekvens</translation>
     </message>
@@ -11226,22 +11133,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Gas kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Sideror kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Højderor kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Krængeror kanal:</translation>
     </message>
@@ -11249,22 +11156,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="349"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation>Ukendt Fejl</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="357"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation> ... plus %1 Fejl</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="426"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation>Kan ikke gemme radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation>Kan ikke gemme model %1</translation>
     </message>
@@ -11272,17 +11179,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Gas afskæring</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Tidtagning ved gas</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Tidtagning ved flyvetid</translation>
     </message>
@@ -11290,43 +11197,43 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Fejl ved åbning af fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Fejl ved skrivning af filen %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation>Fejl ved åbning af OpenTx arkiv %1</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation>Fejl ved initialisering til skrivning af arkiv</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation>Fejl ved oprettelse af OpenTX fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation>Fejl ved oprettelse af OpenTX arkiv</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation>Fejl ved tilføjelse af %1 til OpenTX arkiv</translation>
     </message>
@@ -11349,7 +11256,7 @@ p, li { white-space: pre-wrap; }
         <translation>Skriv til fil</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Udskriv dokument</translation>
     </message>
@@ -11359,12 +11266,12 @@ p, li { white-space: pre-wrap; }
         <translation>Stil</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation>Vælg fil</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation>PDF filer (*.pdf);;HTML filer (*.htm *.html);;Alle filer (*)</translation>
     </message>
@@ -11412,22 +11319,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation>ADVARSEL</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation>&lt;p&gt;Import af JumperTX data til EdgeTX &lt;b&gt;understøttes ikke og kan være meget risikofyldt.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Det er desværre ikke muligt at adskille JumperTX data fra rigtige FrSky X10 data, og &lt;b&gt;du bør kun fortsætte hvis du er sikker på at filen kommer fra en ægte FrSky X10&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Vil du virkelig fortsætte?&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation>Komprimeret firmware overskrider reserveret plads.</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation>Vis denne meddelelse ved næste programstart?</translation>
     </message>
@@ -11435,24 +11342,24 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation>Favoritter</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation>Navn %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation>Sidst åbnet %1</translation>
     </message>
@@ -11460,107 +11367,107 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation>er ugyldig</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation>konverter til</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation>verificer er</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="132"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
         <source>unsupported</source>
         <translation>ikke understøttet</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="171"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="171"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="171"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="171"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="171"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="171"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation>[INV]</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="171"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[XSP]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation>Hændelse</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation>Oprindelse</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation>Komponent</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation>Underkomponent</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation>Felt</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation>Gammel</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation>Funktion</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="184"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="198"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation>Sekv</translation>
     </message>
@@ -11568,30 +11475,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kan ikke skrive fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation>Det lykkes ikke at slette temporær fil: %1</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation>Kan ikke finde radio SD kort!</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation>Fejlet at indlæse modeller og indstillinger fra</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation>Fejlet at skrive model og indstillings fil</translation>
     </message>
@@ -11599,12 +11506,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation>Dobbel-Højreklik for at genstille til center.</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Værdi (indgang): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
@@ -11720,12 +11627,17 @@ i
 x</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation>FT%1</translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished">FT</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation></translation>
     </message>
@@ -11741,360 +11653,432 @@ x</translation>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="93"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="98"/>
-        <location filename="../firmwares/rawsource.cpp" line="110"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
-        <source>TrmR</source>
-        <translation>TrmS</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
-        <source>TrmE</source>
-        <translation>TrmH</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
-        <source>TrmT</source>
-        <translation>TrmG</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
-        <source>TrmA</source>
-        <translation>TrmK</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
-        <source>Trm5</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
-        <source>Trm6</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
-        <source>Trm7</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
-        <source>Trm8</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation>TrmH</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation>TrmV</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="148"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation>Batt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="148"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="151"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="151"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation>IND</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="172"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="191"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation>CYK%1</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="216"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation>Træner</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="260"/>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
         <source>GR%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="380"/>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="392"/>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="148"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="148"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation>Reserveret 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="148"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation>Reserveret 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="148"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation>Reserveret 3</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="148"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation>Reserveret 4</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="257"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation>sm%1</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="96"/>
-        <source>!</source>
-        <translation>!</translation>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
+        <translation type="unfinished">-</translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation>↑</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="92"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation>↓</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="93"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="94"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation>!</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation>TrmH Venstre</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation>TrmH Højre</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation>TrmV ned</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation>TrmV op</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation>REa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation>REb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation>Sid-</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
-        <translation>Sid+</translation>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation>Høj-</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
-        <translation>Høj+</translation>
+        <source>Trim Rud+</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
-        <translation>Gas-</translation>
+        <source>Trim Ele-</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
-        <translation>Gas+</translation>
+        <source>Trim Ele+</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
-        <translation>Kræ-</translation>
+        <source>Trim Thr-</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
-        <translation>Kræ+</translation>
+        <source>Trim Thr+</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
-        <translation></translation>
+        <source>Trim Ail-</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
-        <translation></translation>
+        <source>Trim Ail+</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation>TIL</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation>THs</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation>TH%</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation>THt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation>En</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation>----</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
         <source>Switch</source>
         <translation>Kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="226"/>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation>Act</translation>
     </message>
@@ -12102,7 +12086,7 @@ x</translation>
 <context>
     <name>RepoAssets</name>
     <message>
-        <location filename="../updates/repoassets.cpp" line="172"/>
+        <location filename="../updates/repoassets.cpp" line="181"/>
         <source>Generic asset build not implemented</source>
         <translation>Generisk byg er ikke implementeret</translation>
     </message>
@@ -12110,17 +12094,17 @@ x</translation>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;Siderorkanal:</translation>
     </message>
@@ -12128,21 +12112,21 @@ x</translation>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Fejl ved åbning af fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation>Fejl ved åbning af fil %1 i skrive tilstand:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation>Fejl ved sletning af fil %1</translation>
     </message>
@@ -12150,334 +12134,334 @@ x</translation>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="411"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation>knob</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation>g</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation>timer</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="407"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation>minutter</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="409"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation>sekunder</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation>TM</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation>Tilpasset</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation>Beregnet</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation>Formel</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation>Forekomst</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation>Sensor</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation>Kilder</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation>Højde</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation>Enhed</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation>Præcision</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation>Forhold</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation>Offset</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation>Auto offset</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation>Blad</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation>Multiplikator</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation>Filter</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation>Positiv</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation>Log</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation>Ny</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation>Gennemsnit</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation>Minimum</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation>Maximum</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation>Multiplicere</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation>Summering</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation>Celle</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation>Forbrug</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation>Afstand</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation>Laveste</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation>Celle %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation>Højeste</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation>Delta</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation>Rå (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
         <source>f/s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
         <source>ml</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
         <source>fl.oz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation>ml/minut</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="468"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation>(standard)</translation>
     </message>
@@ -12699,87 +12683,87 @@ Gas er omvendt (INV) - betyder at tomgang er opad. Gas og trim advarsel vendes o
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1674"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>Tidtagning %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2165"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation>Profil indstillinger</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2165"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation>Katalogstruktur til SD kort er ikke specificeret eller gyldig</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1658"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation>Popup menu mulig</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2180"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation>Kopi</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2181"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation>Klip ud</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2182"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation>Sæt ind</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2183"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2185"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2186"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2187"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2188"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2190"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2225"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation>Nulstil ur, er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2237"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation>Nulstil alle ure, er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2259"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation>Klip ud uret, er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2267"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation>Slet ur, er du sikker?</translation>
     </message>
@@ -12787,7 +12771,7 @@ Gas er omvendt (INV) - betyder at tomgang er opad. Gas og trim advarsel vendes o
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Højderorkanal:</translation>
     </message>
@@ -12795,204 +12779,204 @@ Gas er omvendt (INV) - betyder at tomgang er opad. Gas og trim advarsel vendes o
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation>Simulator LCD skærmklip fil prefix</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
@@ -13000,94 +12984,94 @@ Gas er omvendt (INV) - betyder at tomgang er opad. Gas og trim advarsel vendes o
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation>Tilgængelige profiler:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation>Navn: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation>Tilgængelige radioer:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation>Radioprofil ID eller navn for simulator.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation>profil</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation>Radiotype som skal simuleres (typisk defineret i profilen).</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation>radio</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation>Katalog som indeholder SD katalogstruktur. Standard findes i indstillinger i den valgte radioprofil.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation>sti</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation>type</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation>datakilde</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation>[data kilde]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation>Fejl: Profil-ID %1 ikke fundet.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation>Ukendt datakilde: %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation>Advarsel: Kan ikke initialisere SDL:
 %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation>Fejl: Biblioteksfiler til simulator mangler.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
@@ -13096,31 +13080,31 @@ Data File: [%3]</source>
 Datafil: [%3]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation>Fejl: Radioprofil eller firmware til simulator mangler.
 Profil-ID: [%1]; Radio-ID [%2]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation>Radio data (.bin/.eeprom/.etx) som anvendes ELLER sti til katalog (for Horus og lignende radioer).
         BEMÆRK: alle eksisterende EEPROM data som er inkompatible med den valgte radio type bliver overskrevet!</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation>Data kilde: En af:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation>Ukendt fejl ved Simulator start.</translation>
     </message>
@@ -13129,8 +13113,8 @@ NOTE: any existing EEPROM data incompatible with the selected radio type may be 
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
-        <translation>EdgeTX simulator</translation>
+        <source>EdgeTX Simulator</source>
+        <translation type="unfinished">EdgeTX simulator</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
@@ -13278,73 +13262,73 @@ NOTE: any existing EEPROM data incompatible with the selected radio type may be 
         <translation>Angiv fast højde for radioens widget.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation>Fejl: Kunde ikke opbygge simulator, mulig problem er manglende eller forkert bibilotek.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation>Uddata fra radio</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation>Telemetri simulator</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation>Instruktør simulator</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation>Debug data</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation>Simulator hjælp</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Simulator kontroller:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation>&lt;tr&gt;&lt;th&gt;Knap/Mus&lt;/th&gt;&lt;th&gt;Værktøj&lt;/th&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation></translation>
@@ -13453,32 +13437,32 @@ Standard valg findes i den valgte radioprofil.</translation>
         <translation>SD sti</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation>Start indstillinger</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation>Der er ikke fundet radio profiler. Brug %1 for oprettelse.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation>Alle filer (*.*)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation>Vælg en fil</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation>Vælg et katalog</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation>Vælg katalog med SD katalogstruktur</translation>
     </message>
@@ -13512,69 +13496,74 @@ Standard valg findes i den valgte radioprofil.</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation>Radiosimulator (%1)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="306"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation>Ukendt datakilde.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="311"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation>Kan ikke indlæse data, muligvis forkert fil format.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="312"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation>Fejl ved data indlæsning</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="370"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation>Ugyldig startup data. Angiv korrekt fil/sti.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="371"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation>Fejl ved start af simulator</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="431"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation>Data kunne ikke gemmes: kan ikke åbne fil for skrivning: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="437"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation>Data kunne ikke gemmes: kan ikke hente data fra simulator.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="462"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation>En uventet fejl er opstået da data for radio skulle gemmes i fil &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="463"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation>Fejl ved skrivning af data</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="723"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation>Joystik kan ikke findes, er afkoblet</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="821"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation>Firmware fejl: %1</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="826"/>
-        <source> - Flight Mode %1 (#%2)</source>
-        <translation> - Flyve tilstand %1 (#%2)</translation>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13599,17 +13588,17 @@ Standard valg findes i den valgte radioprofil.</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>Billede bibliotek - Side %1 af %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>Forkert billede i bibliotek %1</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>Ingen anvendelige billeder i biblioteket, kontroller indstillinger</translation>
     </message>
@@ -13617,7 +13606,7 @@ Standard valg findes i den valgte radioprofil.</translation>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>Kanal %1</translation>
     </message>
@@ -13625,7 +13614,7 @@ Standard valg findes i den valgte radioprofil.</translation>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation>Kan ikke finde fil %1!</translation>
     </message>
@@ -13634,9 +13623,9 @@ Standard valg findes i den valgte radioprofil.</translation>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation>Rediger stilguide</translation>
     </message>
@@ -13661,21 +13650,21 @@ Standard valg findes i den valgte radioprofil.</translation>
         <translation>Denne funktion validerer ikke ændringer og forudsætter at du kender til CSS syntax for QT.</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation>Kan ikke hente stil %1
 Fejl: %2</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation>Kan ikke hente standard stil %1
 Fejl: %2</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation>Kan ikke opdatere tilpasset stil %1
@@ -13685,47 +13674,47 @@ Fejl: %2</translation>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation>Stil guide indlæst fra &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation>Stil guide kan ikke indlæses fra &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation>Katalog kan ikke oprettes &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation>Kan ikke for skrivning, åbne fil &apos;%1&apos;: Fejl: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation>Kan ikke skrive til fil &apos;%1&apos;: Fejl: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation>Kan ikke tømme buffer for fil &apos;%1: Fejl: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation>Stil guide skrevet til &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation>Tilpasset stil guide slettet: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation>Kan ikke slette tilpasset stil guide: &apos;%1&apos;</translation>
     </message>
@@ -13733,89 +13722,89 @@ Fejl: %2</translation>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation>[TESTKØRSEL] </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation>Synkronisering fejlet, der er ikke fundet noget at kopiere.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation>Springer over stor fil: %1 (%2kB)</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation>Opretter katalog: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation>Kan ikke oprette katalog: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation>Springer over ældre fil: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation>Kan ikke åbne kilde &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation>Kan ikke åbne mål &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation>Springer over identisk fil: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation>Kan ikke slette mål fil &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation>Kopiering fejlet: &apos;%1&apos; til &apos;%2&apos;: %3</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation>Samler filinformation for %1...</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation>Ingen filer i %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation>Synkronisering afbrudt ved %1 af %2 filer.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation>Synkronisering afsluttet med %1 filer på %2m %3s.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation>Synkroniserer: %1
     Til: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
@@ -13824,54 +13813,54 @@ Fejl: %2</translation>
 </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation>
 For mange fejl - afbryder.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation>Dropper filteret fil: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation>Dropper linket fil: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation>Afbrød synkronisering af:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation>Synkronisering klar:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation>Oprettet: %1; Opdateret: %2; Droppet: %3; Fejl: %4;</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation>Katalog findes: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation>Mindst en af dato egenskaber ved fil er i fremtiden, Fejl på: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation>Erstatter fil: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation>Opretter fil: %1</translation>
     </message>
@@ -13879,17 +13868,17 @@ For mange fejl - afbryder.</translation>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>Sideror kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Højderor kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>Kun en fri kanal tilbage!&lt;br&gt;Du bør nok konfigurere din model uden brug af modelguiden.</translation>
     </message>
@@ -13897,22 +13886,22 @@ For mange fejl - afbryder.</translation>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Højderor og Sideror</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Kun højderor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>V form</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Hale type:</translation>
     </message>
@@ -14244,7 +14233,7 @@ For mange fejl - afbryder.</translation>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation>Telemetri skærm %1</translation>
     </message>
@@ -14252,29 +14241,966 @@ For mange fejl - afbryder.</translation>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="514"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Lavt alarmniveau</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="515"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Kritisk alarmniveau</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="547"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation>Winged Shadow How High</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="550"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (understøttes ikke)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="678"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
         <translation>Slet sensor. Er du sikker?</translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vertikal hastighed</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Retning</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished">grader</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished">2 W {0m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished">2 W {10m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished">2 W {25m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished">2 W {50m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished">2 W {100m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished">2 W {250m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished">2 W {500m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished">2 W {1000m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished">2 W {2000m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished">Gem telemetri værdier</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished">Lat,Lon
+(dec.grad)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GHast</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished">FT</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">Strøm</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished">Indlæs telemetri værdier</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Højde</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished">Start</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished">Stop</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished">Gem telemetri</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished">Ikke muligt at åbne fil for skrivning. %1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished">Åbn telemetri fil</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished">Ikke muligt at åbne fil for læsning. %1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished">Celler</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished">Brændstof mængde</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished">GHøj</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished">Gem telemetri værdier</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished">A4</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished">volt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished">Start/Stop</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished">grader</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished">GPS simulator</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished">V / forhold</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished">*</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished">dd-MM-åååå
+tt:mm:ss</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished">meter</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vertikal hastighed</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished">Indlæs telemetri værdier</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished">Lat,Lon
+(dec.grad)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished">A3</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Brændstof</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Retning</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">Strøm</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished">ampere</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished">Start</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Højde</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished">Dato</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GHast</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished">Gem telemetri</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished">Ikke muligt at åbne fil for skrivning. %1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished">Åbn telemetri fil</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished">Ikke muligt at åbne fil for læsning. %1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished">Stop</translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Brændstof</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished">Start</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vertikal hastighed</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Retning</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished">Dato</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished">Batt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished">GHøj</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Højde</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished">grader</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">Strøm</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished">Indlæs telemetri værdier</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished">Gem telemetri værdier</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GHast</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished">Lat,Lon
+(dec.grad)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished">Stop</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished">Gem telemetri</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished">Ikke muligt at åbne fil for skrivning. %1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished">Åbn telemetri fil</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished">Ikke muligt at åbne fil for læsning. %1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14390,72 +15316,72 @@ For mange fejl - afbryder.</translation>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="57"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation>TM%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="66"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation>Popup menu mulig</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation>Kopier</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation>Klip ud</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="256"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation>Sæt ind</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation>Indsæt</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="261"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation>Flyt op</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation>Flyt ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="264"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation>Slet alt</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="307"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation>Klip ud telemetri sensor. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="326"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation>Nulstil telemetri sensor. Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="337"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation>Nulstil alle telemetri sensorer. Er du sikker?</translation>
     </message>
@@ -14468,42 +15394,6 @@ For mange fejl - afbryder.</translation>
         <translation>Telemetri simulator</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
         <source>When enabled, sends any non-blank values as simulated telemetry data.</source>
         <translation>Når aktiveret, send alle ikke blanke værdier som simulerede telemetri data.</translation>
@@ -14514,391 +15404,151 @@ For mange fejl - afbryder.</translation>
         <translation>Simulering</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation>Afspil SD logfil</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation>Afspilnings hastighed</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation>Indlæs</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation>Række # 
 Tidstempel</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation>Ingen logfil indlæst</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation>V / forhold</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished">Internt modul</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Ingen</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>Brændstof</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished">Eksternt modul</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation>meter</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation>Højde</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation>Vertikal hastighed</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation>Brændstof mængde</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation>Retning</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation>Lat,Lon
-(dec.grad)</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation>dd-MM-åååå
-tt:mm:ss</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation>Dato</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation>ampere</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation>GHøj</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation>volt</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation>Celler</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation>Strøm</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation>GHast</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation>grader</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation>Log fil</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation>Logfiler (*.csv)</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
         <translation>Fejl - ugyldig fil</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation>Hvis RSSI nulstilles afbrydes, simuleres afbrudt telemetri- og radiolink.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation>Nulstil RSSI når afspilning sættes på pause.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation>Send ikke telemetri data, når telemetri simulator vindue ikke er aktivt.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation>Pauser simuleringen når simulator vindue ikke er aktivt.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation>dB</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation>Start</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation>GPS simulator</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation>Start/Stop</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation>Indlæs telemetri værdier</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation>Gem telemetri værdier</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation>25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation>*</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation>Forkert GPS format</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation>Skal være decimal bredegrad, længdegrad</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation>Gem telemetri</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation>Ikke muligt at åbne fil for skrivning. %1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation>Åbn telemetri fil</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation>Ikke muligt at åbne fil for læsning. %1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
-        <translation>Stop</translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;Gas kanal:</translation>
     </message>
@@ -14924,138 +15574,138 @@ tt:mm:ss</translation>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation>TID</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation>Tidtagning %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation>Stille</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation>Bip</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation>Stemme</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation>Ikke</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation>Flyvning</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation>Manuel nulstil</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation>Ikke varig</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation>Varig (under flyvning)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation>Varig (manuel nulstilling)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation>Vibration</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation>TIL</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation>THs</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation>TH%</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation>THt</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation>Vis tid gået</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation>Vis tid tilbage</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation>TID</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation>Bip og vibration</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation>Stemme og vibration</translation>
     </message>
@@ -15063,22 +15713,22 @@ tt:mm:ss</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="918"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="920"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation>+= (Sum)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="922"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation>:= (Erstat)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation>KA%1</translation>
     </message>
@@ -15086,27 +15736,27 @@ tt:mm:ss</translation>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation>Tilstand</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation>Vægt</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation>Kalibrering</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation>Multiplikator</translation>
     </message>
@@ -15122,170 +15772,205 @@ tt:mm:ss</translation>
 <context>
     <name>UpdateCloudBuild</name>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="35"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
         <source>CloudBuild</source>
         <translation>Byg i skyen</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="82"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">ukendt</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
         <source>Radio profile language &apos;%1&apos; not supported</source>
         <translation>Radio profilens sprog &apos;%1&apos; understøttes ikke</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="97"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
         <source>fai_mode values do not contain CHOICE and YES</source>
         <translation>fai_mode værdier indeholder ikke CHOICE og YES</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="129"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
         <source>Write firmware to radio: %1</source>
         <translation>Skriver firmware til radio: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="129"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
         <source>true</source>
         <translation>sand</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="129"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
         <source>false</source>
         <translation>falsk</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="134"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
         <source>Install</source>
         <translation>Installer</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="137"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
         <source>Asset filter applied: %1 Assets found: %2</source>
         <translation>Mål filter: %1 Mål fundet: %2</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="143"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation>Forventet mål %1 til installation, men fandt %2</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation>Firmware findes ikke i %1 med anvendelse af filter %2</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="180"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation>Skal opdateret firmware sendes til radioen nu?</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="197"/>
-        <location filename="../updates/updatecloudbuild.cpp" line="198"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
         <source>Building firmware for: %1</source>
         <translation>Byg af firmware til: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="204"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
         <source>Failed to create directory %1!</source>
         <translation>Kan ikke oprette katalog %1!</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="221"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
         <source>Unexpected format for build targets meta data</source>
         <translation>Uventet format ved byg af målets meta data</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
         <source>No build support for target %1</source>
         <translation>Ingen byg til mål %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="239"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
         <source>Build target %1 has no valid tags</source>
         <translation>Byg af %1 har ingen gyldige indgange</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="245"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
         <source>No flag entries found</source>
         <translation>Ingen indgange fundet</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="292"/>
-        <source>Submit firmware build</source>
-        <translation>Firmware byg</translation>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="298"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
         <source>Failed to initiate build job</source>
         <translation>Intialisering af byg fejlet</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="303"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
         <source>Unexpected response format when submitting build job</source>
         <translation>Uventet svar format ved start af byg job</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="313"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
         <source>Build error: %1</source>
         <translation>Byg fejl: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="317"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
         <source>Process status not returned when submitting build job</source>
         <translation>Status for proces er ikke modtaget ved start af byg job</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="327"/>
-        <source>Firmware build finished status: %1</source>
-        <translation>Firmware byg med status: %1</translation>
-    </message>
-    <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="337"/>
-        <source>Build firmware cancelled</source>
-        <translation>Byg af firmware annulleret</translation>
-    </message>
-    <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
-        <source>Build firmware timeout</source>
-        <translation>Byg af firmware har timeout</translation>
-    </message>
-    <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="373"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
         <source>Submit get build status</source>
         <translation>Hent byg status</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="382"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
         <source>Build status unknown</source>
         <translation>Byg status ukendt</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="414"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
         <source>Build status contains %1 artifacts when only 1 expected</source>
         <translation>Byg status indeholde %1 modeller, men kun 1 er forventet</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="424"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
         <source>Build status does not contain download url</source>
         <translation>Byg status indeholder ikke en url for hentning</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="429"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
         <source>Build status does not contain firmware artifact</source>
         <translation>Byg status indeholder ikke en firmware model</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="434"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
         <source>Build status firmware artifact not in expected format</source>
         <translation>Byg af firmware har elementer med uventet format</translation>
     </message>
     <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="440"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
         <source>Build status does not contain artifacts</source>
         <translation>Byg status har ingen elementer</translation>
-    </message>
-    <message>
-        <location filename="../updates/updatecloudbuild.cpp" line="454"/>
-        <source>Waiting for firmware build to finish...</source>
-        <translation>Venter på firmware byg bliver færdigt...</translation>
     </message>
 </context>
 <context>
@@ -15408,198 +16093,223 @@ tt:mm:ss</translation>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="1015"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation>Indlæser opdatering til: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="820"/>
-        <location filename="../updates/updateinterface.cpp" line="855"/>
-        <source>%1 preparation failed</source>
-        <translation>Klargøring af %1 fejlet</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="841"/>
-        <source>%1 download failed</source>
-        <translation>Hent af %1 fejlet</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="834"/>
-        <source>%1 decompress failed</source>
-        <translation>Dekomprimering af %1 fejlet</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="827"/>
-        <source>%1 copy to destination failed</source>
-        <translation>Kopiering af %1 til målet fejlet</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="813"/>
-        <source>%1 start async failed</source>
-        <translation>Start af async for %1 fejlet</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="848"/>
-        <source>%1 housekeeping failed</source>
-        <translation>Oprydning af %1 fejlet</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="1084"/>
-        <location filename="../updates/updateinterface.cpp" line="1087"/>
-        <source>%1 update successful</source>
-        <translation>Opdatering af %1 med succes</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="153"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation>Katalog for %1 er ikke konfigureret i program indstillinger!</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="157"/>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation>Kan ikke oprette %1 katalog %2!</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="862"/>
-        <source>%1 save release settings failed</source>
-        <translation>%1 fejl ved gem af release indstllinger</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="874"/>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation>Kan ikke tildele parametere ved behandling af mål %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="879"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation>Kan ikke give underkatalog til mål %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation>Kan ikke give kopi filter til mål %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="449"/>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation>Dekomprimerer %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="450"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation>Dekomprimerer: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="467"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation>Kan ikke dekomprimere %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="293"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation>Dekomprimeret fil struktur er ikke fundet ved %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="297"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation>Kopi af fil struktur fra: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="200"/>
-        <location filename="../updates/updateinterface.cpp" line="320"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation>Kan ikke oprette katalog %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="204"/>
-        <location filename="../updates/updateinterface.cpp" line="324"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation>Kontroller/opret katalog: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="205"/>
-        <location filename="../updates/updateinterface.cpp" line="328"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation>Kataloger som er kontrolleret/oprettet: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="243"/>
-        <location filename="../updates/updateinterface.cpp" line="369"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation>Kan ikke slette ekisterende fil: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="250"/>
-        <location filename="../updates/updateinterface.cpp" line="375"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation>Kan ikke kopiere fil %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="265"/>
-        <location filename="../updates/updateinterface.cpp" line="385"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation>Kopierede filer: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="188"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation>Kan ikke bestemme kilde katalog for mål %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="192"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation>Kopierer filer fra %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="246"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation>Slettet fil: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="254"/>
-        <location filename="../updates/updateinterface.cpp" line="379"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation>Kopieret %1 til %2</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="260"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation>Der er ikke hentet eller dekomprimeret filer som matcher filteret &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="683"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation>Klargør</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="690"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation>Kan ikke afgøre eksekverings katalog</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation>Klargør mål</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="502"/>
-        <source>Unable to download flagged assets</source>
-        <translation>Kan ikke hente klargjorte mål</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="404"/>
-        <source>Decompressing assets</source>
-        <translation>Dekomprominer mål</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="407"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation>Kan ikke dekomprominere mål</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="392"/>
-        <source>Copying to destination</source>
-        <translation>Kopierer til mål</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="121"/>
@@ -15612,68 +16322,58 @@ tt:mm:ss</translation>
         <translation>Kan ikke bygge markerede mål</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="395"/>
-        <source>Unable to copy assets</source>
-        <translation>Kan ikke kopiere mål</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="499"/>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
         <source>Downloading...</source>
         <translation>Henter...</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="543"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation>Oprydning</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="554"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation>Slet katalog for hentning: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="557"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation>Kan ikke slette katalog for hentning: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="564"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation>Slet dekomprimerings katalog: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="567"/>
-        <location filename="../updates/updateinterface.cpp" line="576"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation>Kan ikke slette dekomprimerings katalog: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="673"/>
-        <source>Update cancelled</source>
-        <translation>Opdatering afbrudt</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="750"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation>Gem release indstillinger</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="516"/>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation>Ingen mål er fundet i release &apos;%1&apos; med filteret &apos;%2&apos;</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation>%1 mål er fundet, når %2 er forventet i release &apos;%3&apos; med filteret &apos;%4&apos;</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation>Kan ikke release id fra opdatering &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="574"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation>Slet dekomprimerings katalog: %1</translation>
     </message>
@@ -15683,26 +16383,27 @@ tt:mm:ss</translation>
         <translation>Komponent id: %1 overskrider maksimalt antal opsætninger af komponent: %2!</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="653"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation>ukendt</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="208"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation>Kopier filter mønster: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="134"/>
-        <location filename="../updates/updateinterface.cpp" line="273"/>
-        <location filename="../updates/updateinterface.cpp" line="422"/>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
-        <location filename="../updates/updateinterface.cpp" line="513"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation>Filter tilføjet: %1 - %2 fundet</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="286"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation>Kopier katalog struktur</translation>
     </message>
@@ -15718,82 +16419,90 @@ tt:mm:ss</translation>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="134"/>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation>Henter: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="135"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation>Henter: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="138"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation>Fil findes allerede: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="140"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation>Fil %1 findes allerede. Hente igen?</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="155"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation>Kan ikke oprette katalog %1!</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="176"/>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
         <source>Unable to open the download file %1 for writing. Error: %2</source>
         <translation>Ved hentning, kan filen %1 ikke åbnes for skrivning. Fejl: %2</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="195"/>
-        <source>Downloading...</source>
-        <translation>Henter...</translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="255"/>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
         <source>Invalid URL: %1</source>
         <translation>Ugyldig URL: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="259"/>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
         <source>URL: %1</source>
         <translation>URL: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="283"/>
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
         <source>Unable to download %1. GET error:%2
 %3</source>
         <translation>Kan ikke hente: %1. GET fejl: %2 %3</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="345"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
         <source>POST error: %2
 %3</source>
         <translation>POST fejl: %2 %3</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="360"/>
-        <location filename="../updates/updatenetwork.cpp" line="376"/>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
         <source>Failed to open %1 for writing</source>
         <translation>Fejler ved at åbne %1 for skrivning</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="202"/>
-        <location filename="../updates/updatenetwork.cpp" line="321"/>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
         <source>Network error has occurred. Error code: %1</source>
         <translation>Der sket en netværksfejl: Fejlkode: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="207"/>
-        <location filename="../updates/updatenetwork.cpp" line="326"/>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
         <source>Ssl library version: %1</source>
         <translation>SSL bibilotek version: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="60"/>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation>Kan ikke konvertere hentede metadata til json format. Fejl:%1 %2</translation>
@@ -15991,52 +16700,52 @@ tt:mm:ss</translation>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation>Ingen opdateringer tilgængelige denne gang</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation>Søg efter opdateringer</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation>Ingen komponenter er markeret som aktuelle for søgning i opdaterings indstillinger!</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation>Opdater komponenter</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation>Startar...</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation>Afsluttet %1</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation>med sucess</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation>med fejl</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation>Synkroniser SD struktur?</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -16191,32 +16900,32 @@ Indlæs dem nu?</translation>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation>Information utilgængelig</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation>Tema</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation>Forfatter</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation>Kan inte indlæse %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation>Øverste bjælke</translation>
     </message>
@@ -16224,12 +16933,12 @@ Indlæs dem nu?</translation>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>Første hale kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>Anden hale kanal:</translation>
     </message>
@@ -16237,55 +16946,55 @@ Indlæs dem nu?</translation>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation>Hold Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
-        <translation>Hold vertikal pind position.</translation>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation>Fix Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation>Forhindre vertikal ændring af pind.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation>Fix X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation>Forhindre horisontal ændring af pind.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
         <translation>Hold X</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
-        <translation>Hold horisontal pind position.</translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Almindeligt fly</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Flyvende vinge / Deltavinge</translation>
     </message>
@@ -16293,22 +17002,22 @@ Indlæs dem nu?</translation>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation>Flap op</translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation>Flap ned</translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation>Luftbremse fra</translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation>Luftbremse til</translation>
     </message>
@@ -16316,273 +17025,273 @@ Indlæs dem nu?</translation>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Model guide</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Model type</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Angiv model navn og model type.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Gas</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>Har din model en motor?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Vinge type</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>Er din model en deltavinge eller et almindeligt fly?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>Krængeror</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>Har din model krængeror?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Flaps</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>Har din model flaps?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Luftbremser</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>Har din model luftbremser?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Flyvende vinge/Deltavinge</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Vælg kanal for højderor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Sideror</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>Har din model et sideror?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Hale type</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Vælg hale type for din model.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Hale</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Vælg kanaler for styring af hale.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>V hale</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Vælg Højderor kanal.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>Rotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Helikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>Multirotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Vælg kanal opsætning for Multirotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Model tilvalg</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Vælg flere tilvalg</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>Gem ændringer</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Guiden har sammenkædet radiokanaler til kontroller i din model. Nu skal du selv indstille retningen for kontrollerne. Test og vend de kanaler (INV) som bevæger sig i den forkerte retning.&lt;br&gt;Forsøg at tænde og teste din model, UDEN propeller er monteret.&lt;br&gt;OBS! Gennemføerer du guiden, sletter du alle tidligere indstillinger af modellen(modellen overskrives)!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Angiv et navn for din model og vælg modeltype.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Vælg den modtager kanal som er forbundet til fartregulator (ESC) eller til gas servo.&lt;br&gt;&lt;br&gt;Gas - Spektrum: KA1, Futaba: KA3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>De fleste fly har en hovedvinge og en hale med kontrol flader. Flyvende vinger og deltavinger har ingen hale. Hovedkontrol af standardvinge er krængror.&lt;br&gt; Roret på en deltavinge fungerer som en kombination af krængeror og højderor. </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>Modeller bruger 1 eller 2 kanaler til at kontrollere krængror.&lt;br&gt;Et Y-kabel kan bruges til at sammenkoble 2 servo til en kanal. Anvender du Y-kabel skal du selv ændre til 2 servo, ved at redigere din model.&lt;br&gt;&lt;br&gt;Krængeror - Spektrum: KA2, Futaba: KA1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>Modeller bruger 2 kanaler til at kontrollere højden på en deltavinge/Flyvende vinge. Vælg hvilke kanaler det skal være</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>Denne modelguide antager at dine flaps styres af en kontakt. Vil du istedet anvende en drejekontakt, skal du ændre det ved at selv redigere din model.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>Luftbremser bruges til at sænke hastigheden for advancerede sejl flyvere. &lt;br&gt;De er meget anderledes end andre fly.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Angiv kanal til Sideror.&lt;br&gt;&lt;br&gt;Sideror - Spektrum: KA4, Futaba: KA4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Angiv haletype for din model.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Angiv kanaler til sideror og højderor.&lt;br&gt;&lt;br&gt;Sideror - Spektrum: KA4, Futaba: KA4&lt;br&gt;Højderor - Spektrum: KA3, Futaba: KA2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Angiv kanal til højderor.&lt;br&gt;&lt;br&gt; Højderor - Spektrum: KA3, Futaba: KA2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation>Information er endnu ikke skrevet for denne dialog.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Vælg hvilke kanaler som skal bruges til at kontrollere din Multirotor.&lt;br&gt;&lt;br&gt;Gas - Spektrum: KA1, Futaba: KA3&lt;br&gt;Sideror - Spektrum: KA4, Futaba: KA4&lt;br&gt;Højderor - Spektrum: KA3, Futaba: KA2&lt;br&gt;Krængeror - Spektrum: KA2, Futaba: KA1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>Der finnes ingen hjælp for denne side.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Hjælp til modelguiden</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>Hvilken type styreplade anvender din helikopter?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>Hale gyro</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>Har din helikopter en justerbar gyro i halen?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>Rotor type</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>Har din helikopter en Flybar?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>Vælg kontroller til din helikopter</translation>
     </message>
@@ -16590,37 +17299,37 @@ Indlæs dem nu?</translation>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>Fly</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>Multikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>Helikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>Modelnavn: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>Modeltype: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>Tilvalg: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>Kanal %1: </translation>
     </message>
@@ -16628,47 +17337,47 @@ Indlæs dem nu?</translation>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Fejl ved åbning af fil %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation>Fejl ved åbning af fil %1 for skrivning:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation>Kan ikke læse fil %1</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation>Fil %1 har ikke et gyldigt format</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation>Kan ikke indlæse </translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation>Konvertiering kan ikke gennemføres, venligst kontroller alle radio- og model indstillinger.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation>Fil %1 ser ud til at indeholde radio indstillinger som ikke understøttes.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation>Indholdstype kan ikke bestemmes for fil %1</translation>
     </message>
@@ -16676,19 +17385,19 @@ Indlæs dem nu?</translation>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="371"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
         <source>Warning: File version %1 is not supported by this version of Companion!
 
 Model and radio settings may be corrupted if you continue.</source>
         <translation>Advarsel: Version %1 understøttes ikke af denne version af Companion. Model og radio indstillinger kan blive ødelagt hvis du fortsætter.</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="374"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
         <source>Read Radio Settings</source>
         <translation>Indlæser radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="411"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16701,7 +17410,7 @@ Aktuelt firmware profil Board anvendes.
 Vil du fortsætte?</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="422"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
@@ -16712,14 +17421,14 @@ Vil du fortsætte?</translation>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1263"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation>Advarsel: &apos;%1&apos; har version %2 indstillinger som ikke understøttes af denne version af Companion. Model og radio indstillinger kan blive ødelagt hvis du fortsætter.</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1266"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
         <source>Read Model Settings</source>
         <translation>Indlæser radio indstillinger</translation>
     </message>
@@ -16762,8 +17471,8 @@ OBS! Skriv kun her, hvis du er sikker på hvad du gør! Der er ingen kontrol ell
         <translation></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Vælg placering</translation>
     </message>
@@ -16834,12 +17543,12 @@ m2560 for v4.1-kort</translation>
         <translation>Konfiguration af programmer</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>Konfiguration af DFU-UTIL</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>Konfiguration af SAM-BA</translation>
     </message>
@@ -16862,7 +17571,7 @@ m2560 for v4.1-kort</translation>
         <translation>Afbryd</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>Næste</translation>
     </message>
@@ -16872,7 +17581,7 @@ m2560 for v4.1-kort</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>Kan ikke åbne joystik.</translation>
     </message>
@@ -16892,60 +17601,60 @@ m2560 for v4.1-kort</translation>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation>Ikke anvendt</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation>Kan ikke finde joystik</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation>Tryk på startknap for at begynde kalibrering af håndtag.
 Du kan altid ændre tildelte kanaler eller sætte dem omvendt (INV).</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation>Bevæg pinde og drejekontakter, skub og flyt i alle retninger - helt ud til maksimal bevægelse
 Tryk på næste når du er klar</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation>Placer pinde og drejekontakter i center.
 Tryk på næste når du er klar</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation>Tildel joystik kanaler til kontroller med komboboxene.
 Tryk på næste når du er klar.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation>Afkryds omvendt (INV) retning, hvis den skal være modsat.
 Tryk på næste når du er klar.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation>Tryk OK for at gemme indstillinger.
 Tryk Afbryd for at afslutte kalibrering uden at gemme.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation>Kalibrering ikke gennemført, gem alligevel?</translation>
     </message>

--- a/companion/src/translations/companion_de.ts
+++ b/companion/src/translations/companion_de.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ja, über einen Kanal gesteuert</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ja, über zwei Kanäle gesteuert</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt; Erster Querruderkanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>Zweiter Querruderkanal:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ja, über einen Kanal gesteuert</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ja, über zwei Kanäle gesteuert</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt; Erster Störklappenkanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>Zweiter Störklappenkanal:</translation>
     </message>
@@ -60,7 +60,7 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation>Die Anwendungseinstellungen wurden unter
@@ -68,19 +68,19 @@
 gespeichert</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation>Die Anwendungseinstellungen konnten nicht unter
 %1
 gespeichert werden</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation>, da auf die Datei nicht zugegriffen werden konnte (Überprüfen Sie die Zugriffsrechte).</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation>. Der Grund hierfür ist unbekannt.</translation>
     </message>
@@ -173,22 +173,22 @@ gespeichert werden</translation>
         <translation>Sender Profil</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>Voreingest. Kanalordnung</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>Standard Knüppelmodus</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>Wähle Bild</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -229,662 +229,657 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Mode 1 (Seite Höhe Gas Quer)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Mode 2 (Seite Gas Höhe Quer)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Mode 3 (Quer Höhe Gas Seite)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Mode 4 (Quer, Gas, Höhe, Seite)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>Splash Screen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>Backup Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kanalreihenfolge&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Definiert die Reihenfolge der Mischer wenn ein neues Modell erzeugt wird.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>S H G Q</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>S H Q G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>S G H Q</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>S G Q H</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>S Q H G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation>S Q G H</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>H S G Q</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>H S Q G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>H G S Q</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>H G Q S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>H Q S G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>H Q G S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>G S H Q</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>G S Q H</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>G H S Q</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>G H Q S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>G Q S H</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>G Q H S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>Q S H G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>Q S G H</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>Q H S G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>Q H G S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>Q G S H</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>Q G H S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>Wähle Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>Wähle ausführbare Datei (Programm)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>Simulator Lautstärke</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>Profil Name</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>Lösche Bild</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>Sender Typ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>Andere Einstellungen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>Sender Grundeinstellungen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>SD Verzeichnis Pfad</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>Anwendungs-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>Erstelle automatische Backups, bevor neue Firmware in den Sender geschrieben wird</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>Splash Screen Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Ausführbare Datei Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>Nur das Benutzter-Bild zeigen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>Zeige Benutzer-und CompanionBild</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>Verwende Startbild</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>Autom. Backup Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>Simulator Einstellungen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>Simulator LCD-Beleuchtung</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>Freigabe</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation>Zuletzt verwendete Dateien</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation>Starteinstellungen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation>Merke</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation>Anwendung (Companion/Simulator)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation>Senderfirmware (im Simulator)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation>Aktion die beim Anlegen eines neuen Modells ausgeführt werden soll</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>Blau</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>Grün</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>Rot</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>Gelb</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation>Screenshot Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>Joystick</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>Kalibrieren</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>Hardcopy nur in die Zwischenablage speichern</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Mein Sender</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Auswahl des Snapshot Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Kein Joystick gefunden</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>LEER: Keine Sender-Einstellungen im Profil gespeichert</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>Verüfgbar: Sender-Einstellungen mit unklarem Alter</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>Verfügbar: Sender-Einstellungen gespeichert %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Auswahl des Bibliotheks-Verzeichnis</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Auswahl der Modell-und Einstellungs-Verzeichnisse</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished">Verzeichnis für Anwendungs-Logs</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Wähle Google Earth exe</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Öffne Bild zum laden</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Bilder (%1)</translation>
     </message>
@@ -892,31 +887,31 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation>Lesefehler %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation>Schreibfehler EEPROM</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Kann Datei nicht öffnen %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Fehler beim Schreiben der Datei %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation>Ungültige binäre EEPROM-Datei %1</translation>
     </message>
@@ -954,33 +949,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -991,255 +986,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation>Links Horizontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation>Links Vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation>Rechts Vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation>Rechts Horizontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation>Aux1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation>Aux2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished">Schalter</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">Flug</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Poti mit Raste</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2 Position Taster</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 Positionen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 Positionen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Funktion</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">Klein</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">Beide</translation>
     </message>
@@ -1247,17 +1252,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation>Negativer Bereich</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation>Mitte Wert</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation>Pos Bereich</translation>
     </message>
@@ -1265,132 +1270,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished">Mitte</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished">Richtung</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">Kurve</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished">PPM Mitte</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished">Lineare Mitte</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished">INV</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished">Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished">Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished">Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1433,59 +1438,59 @@ Error description: %4</source>
         <translation>Datei: unbekannt</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation>Öffne Checkliste</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation>Checkliste Datei (*.txt)</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation>Modell Checkliste</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei nicht schreiben%1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Kann Datei nicht öffnen %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Kann Datei nich tlesen %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1501,12 +1506,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1514,173 +1519,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished">Anwendungs-Einstellungen</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation>Dateien</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation>Sender- und Modelleinstellungen</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation>Simulation für diese Firmware ist noch nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation>Unbekannter Fehler während Simulator startup.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation>Simulator Fehler</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation>Daten Ladefehler</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation>Beim Starten des Simulators ist ein Fehler aufgetreten.</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1718,22 +1733,22 @@ Do you want to import settings from a file?</source>
         <translation>Druck in Datei</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation>Namenloses Modell %1</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation>Klick um dieses Modell zu entfernen.</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Drucke Dokument</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>PDF Output Datei wählen</translation>
     </message>
@@ -1759,7 +1774,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>OK, verstanden.</translation>
     </message>
@@ -1767,17 +1782,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>Schreibfehler</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>Kann nicht speichern %1 (Grund: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation>Kann nicht öffnen %1 (Grund: %2)</translation>
     </message>
@@ -1785,22 +1800,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation>CV</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished">%1 Punkte</translation>
     </message>
@@ -1883,32 +1898,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished">Punktgröße</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">Linear</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">Enfache Expo</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">Punktsym. Expo</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">Achsensym. Expo</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1916,7 +1931,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1924,22 +1939,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished">Diff</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished">Expo</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished">Funktion</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1947,113 +1962,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished">Add</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished">Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished">Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished">Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2061,343 +2076,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation>GF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation>SF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation>Überschreibe %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation>Trainer Sei</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation>Trainer Höh</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation>Trainer Gas</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation>Trainer Que</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation>Instant Trim</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation>Audio abspielen</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation>Haptik</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation>Reset</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>Audio Amp AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished">Kommt einmal, aber nicht beim Start</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished">Keine Wiederholung</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished">1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished">%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished">Trimmung</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished">Ring</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished">Wert</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation type="unfinished">Quelle</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation>Varioton Ein/Aus</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation>Spiel Sound</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation>Sag Beides</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation>Sag Wert</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation>SD Logs</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation>Lautstärke Gesamt</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation>LCD-Beleuchtung</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation>LCD Screenshot</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation>Hintergrundmusik</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation>Hintergrundmusik Pause</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation>Verstelle %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation>Binden Int. Modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation>Binden Ext. Modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation>Flug</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation>Telemetrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation>Gesperrt</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation>CFN</translation>
     </message>
@@ -2405,123 +2440,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Schalter</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Aktion</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Parameter</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished">Freigabe</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation>Popup-Menü verfügbar</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation>Beim Abspielen der Audio-Datei kam es zu einem Fehler, möglicherweise ist sie bereits geöffnet. (Err: %1 [%2])</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation>Diese Audio-Datei %1 konnte nicht gefunden bzw. geöffnet werden:</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished">Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished">Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished">Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2529,22 +2564,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished">Nummern</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">Balken</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished">Script</translation>
     </message>
@@ -2552,47 +2587,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">Flugphase</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished">Trimmung</translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished">Trimmung</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2649,82 +2684,82 @@ Do you want to import settings from a file?</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation>FW %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation>Bild: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation>Profilbild</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>Öffne Firmware Datei</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>Die Bilddatei konnte nicht aus dem Firmware-File %1 geladen werden.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>Bilddatei öffnen</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>Bilder (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>Die Bilddatei %1 konnte nicht geladen werden.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>Die Bilddatei %1 konnte nicht aus dem Profil geladen werden.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>Die Bilddatei %1 konnte nicht aus der Bibliothek geladen werden.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>Datei gespeichert</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>Das Bild wurde als %1 gespeichert</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>Fehler beim Aktualisieren des Bildes</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>Das Aktualisieren des Bildes durch die Datei %1 ist fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>Fehler beim Speichern der Datei</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>Das Speichern des Bildes in die Datei %1 ist fehlgeschlagen</translation>
     </message>
@@ -2732,22 +2767,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2755,53 +2790,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation>Übersetzungsfehler im Feld %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation>Schalter</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation>Schalter </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation>Kann nicht in dieses Board übertagen werden!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation>Quelle</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation>OpenTX unterstützt nur maximal %1 Stützstellen für alle Kurven</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation>OpenTX unterstützt diese Funktion für dieses Board nicht</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation>OpenTx kennt dieses Sendeprotokoll nicht</translation>
     </message>
@@ -2809,52 +2844,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished">AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished">EIN</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished">Falsch</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished">Wahr</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished">Nein</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished">Ja</translation>
     </message>
@@ -2933,101 +2968,82 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation>Filter Ein/Aus.</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation>Herunterladen: </translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation>Herunterladen fehlgeschlagen: %1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation>Mögliche Ursachen:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation>Warnung:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3036,12 +3052,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3049,12 +3065,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation>Fehler beim Öffnen %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation>Ungültige EEPROM Datei %1</translation>
     </message>
@@ -3062,12 +3078,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;Erster Elevon-Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>Zweiter Elevon-Kanal:</translation>
     </message>
@@ -3075,41 +3091,41 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Fehler beim Öffnen der Datei %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3117,23 +3133,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation>INP</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation> (@%1)</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished">AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">EIN</translation>
     </message>
@@ -3141,110 +3157,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Gewichtung</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Offset</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>Die Mischerquelle</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Input Name</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Flugphasen</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Schalter</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>Quelle</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Info Name</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Knüppel Seite</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>Skalierung</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Trimmung einschließen</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>Kurve die auf die Quelle angewendet wird.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation>NEG</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>Quelle für den Mischer.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Schalter mit dem der Input freigegeben wird  Steht nichts drinnen ist er immer &quot;EIN&quot;.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation>POS</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>BEIDE</translation>
     </message>
@@ -3254,22 +3255,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation>Edit %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation>Popup-Menü verfügbar</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation>Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation>Alles setzen</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation>Alles invertieren</translation>
     </message>
@@ -3277,22 +3278,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>Gas Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>Yaw Heck Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>Pitch Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>Roll Kanal:</translation>
     </message>
@@ -3300,262 +3301,262 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished">Schliessen</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished">Start</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3563,367 +3564,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation>Keine Überschreibefunktion verfügbar</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation>Sperrt das D8 Protokoll wenn ausgewählt, denn D8 ist seit Jan 2015 in der EU nicht mehr zulässig</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Kein Helimenü und zykl. Mischer </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation>Keine Globale Variablen</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation>Alternative SQT5 Schrift verw</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation>Potis als Menü Navigation benutzen</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation>Haptikmodul installiert</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Ausschalten bestätigung vor Sender runterfährt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Horus Knüppel installiert(Hallgeber)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation>Freigabe von Heli-Menüs und zyklischer Mischer Unterstützung</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation>Globale Variablen</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation>Akku Ladezustand</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3931,27 +3976,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Ja, über einen Kanal gesteuert</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Ja, über zwei Kanäle gesteuert</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt; Erster Wölbklappenkanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>Zweiter Wölbklappenkanal:</translation>
     </message>
@@ -3960,7 +4005,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Schreibe Modelle und Einstellungen in den Sender</translation>
     </message>
@@ -4025,51 +4070,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Schreibe in Sender</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei nicht schreiben%1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Fehler beim Schreiben der Datei %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>Die Sender Firmware ist überholt, bitte updaten!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4147,103 +4192,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Schreibe in Sender</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>Öffne Firmwaredatei</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 ist keine gültige Firmwaredatei </translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>Diese Firmwaredatei ist nicht zulässig.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>Es ist kein Start-Screnn in der Firmwaredatei.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>Das Profilbild %1 ist ungültig.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>Bilder (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>Splashbild nicht gefunden</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>Kann benutzerspezifische Firmware nicht speichern</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>Schreibe Firmware in den Sender</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>Firmwarecheck fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>Kann die Firmware im Sender nicht überprüfen</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation type="unfinished">Neue Firmware ist nicht mit der schon installierten kompatibel!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>Umwandlung gescheitert</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>Wiederherstellung gescheitert</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>Flashen fertig</translation>
     </message>
@@ -4251,47 +4296,47 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation>Die ausführbare Datei %1 wurde nicht gefunden</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation>Schreiben...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation>Lesen...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation>Vergleichen...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation>unbekannt</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>ie: OpenTX für das 9X Board oder OpenTX für das 9XR Board</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>ie: OpenTX für das M128 / 9X Board oder OpenTX für das 9XR Board mit dem M128 chip</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>ie: OpenTX für das Gruvin9X Board</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4300,7 +4345,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 Bitte die weiteren Brenn-Optionen prüfen und den CPU Typ korrekt setzen.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4309,7 +4354,7 @@ Please select an appropriate firmware type to program it.</source>
 Bitte dazu eine passende Firmware zum Programmieren auswählen.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4318,22 +4363,22 @@ Sie verwenden gerade:
  %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>Der Sender scheint entweder nicht per USB angeschlossen zu sein, oder der entsprechende Treiber wurde nicht installiert.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>Flashen fertig (exit code = %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>Flashen fertig mit Fehlern</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>FUSES: Low=%1 High=%2 Ext=%3</translation>
     </message>
@@ -4341,7 +4386,7 @@ Sie verwenden gerade:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
@@ -4392,225 +4437,240 @@ Sie verwenden gerade:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
         <translation>FM</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>Drehgeber %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>WertQuelle</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>GVAR%1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Anzeige im Popup-Fenster freigeben</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation>Popup-Menü verfügbar</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation>Trimmung deaktivieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation>Eigene Trimmung</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation>Trimmung von Flugphase %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation>Trimmung von Flugphase %1 + Eigene Trimmung als Offset</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation>Einheit</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation>Prec</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation>0._</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">GV%1</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Eigener Wert</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished">Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished">Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished">Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>Löschen</translation>
     </message>
@@ -4618,17 +4678,17 @@ Sie verwenden gerade:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>Flugphase %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation> (%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (normal)</translation>
     </message>
@@ -4636,17 +4696,17 @@ Sie verwenden gerade:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>Mit Flybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>Flybarless</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>Flybar:</translation>
     </message>
@@ -4654,17 +4714,17 @@ Sie verwenden gerade:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation>Gelb</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation>Rot</translation>
     </message>
@@ -4672,13 +4732,13 @@ Sie verwenden gerade:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation>---</translation>
     </message>
@@ -4696,17 +4756,18 @@ Sie verwenden gerade:
         <translation>Anpassbare Schalter</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished">Start</translation>
     </message>
@@ -4716,7 +4777,12 @@ Sie verwenden gerade:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4724,8 +4790,13 @@ Sie verwenden gerade:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4821,13 +4892,13 @@ p, li { white-space: pre-wrap; }
         <translation>Das Ändern der Fuses kann Deine Fernsteuerung unbrauchbar machen. Mache nur weiter, wenn Du weißt was Du machst</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>Reset Sender Fuses</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>Lese Fuses des Senders</translation>
     </message>
@@ -4835,44 +4906,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation>?</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation>0._</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation>?.?</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation>Eigener Wert</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation>Flugphase %1 Wert</translation>
     </message>
 </context>
 <context>
@@ -4890,12 +4951,12 @@ These will be relevant for all models in the same EEPROM.</source>
 Dieses sind für alle Modelle im gleichen EEPROM gültig.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Schüler Signaleingang</translation>
     </message>
@@ -4910,47 +4971,47 @@ Dieses sind für alle Modelle im gleichen EEPROM gültig.</translation>
         <translation>Verwende Kal-und HW Einstellungen aus dem Profil</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>Globale Funktionen</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation>Kalibrierung</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>Falsche Werte im Profil, Sender-Kalibireierung wurde nicht ausgeführt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>Falsche Daten im Profil, konfigurierte Schalter/Potis sind nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>Falsche Werte im Profil, HW Parameter wurden nicht verwendet</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>Wollen Sie die Kalibrierwete im %1 Profil speichern&lt;br&gt;und die vorhandenen Kalibrierwerte überschreiben?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>Kalibrierung und HW Parameter gesichert.</translation>
     </message>
@@ -4989,8 +5050,8 @@ Dieses sind für alle Modelle im gleichen EEPROM gültig.</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Flugphasen</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5026,185 +5087,208 @@ Dieses sind für alle Modelle im gleichen EEPROM gültig.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation>Sender Grunfeinstellungen</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished">Hardware</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished">Schalter</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished">Interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished">Externe</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished">AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">Schüler Signaleingang</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">SBus Schüler</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">Debugmode</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished">mA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished">Normal</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished">Nur Trimmung</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished">Nur Tasten</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished">Umschaltbar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished">Global</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5220,202 +5304,200 @@ Dieses sind für alle Modelle im gleichen EEPROM gültig.</translation>
         <translation>Schreibschutz freigeben</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation>SC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation>SE</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation>SA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation>SF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation>SH</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation>SD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation>SB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation>SG</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Zeitverschiebung von UTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Ansagesprache</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Ländercode</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Knüppel umkehren</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>FAI Modus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Uhr einstellen</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Vario Tonhöhe bei Max-Steig</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Gesamtlautstärke</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>LCD-Beleuchtung EIN mit</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Sound Modus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>Farbe 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>Farbe2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>Lautstärke (Spkr Mod)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Wenn dieser Wert ungleich 0 ist, wird die Hintergrundbeleuchtung nach irgendeinem Tastendruck eingeschaltet
 und nach einer eingestellten Zeit in Sekunden ausgeschaltet.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation>sek</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>LCD-Beleuchtung Farbe</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>Piepser</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Lautsprecher</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>Beeper Sound</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>Sprecher Stimme</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Piepser Lautstärke</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Wav Lautstärke</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Vario Lautstärke</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Hintergrundlautstärke</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation> ms</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>LCD-Beleuchtung AUS nach</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>LCD-Beleuchtung an bei Alarm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Vario Tonhöhe bei Min-Sink</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Vario Ton Wiederholrate</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5425,7 +5507,7 @@ und nach einer eingestellten Zeit in Sekunden ausgeschaltet.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5436,42 +5518,42 @@ p, li { white-space: pre-wrap; }
 Die Werte können sein</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>LCD-Beleuchtung Helligkeit</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Drehgeber Navigation</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>Automatisches Einstellen der Uhr im Sender wenn GPS mit der Telemetrie verbunden.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>Amerika</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Japan</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>Europa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>Resthelligkeit wenn Beleuchtung AUS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5512,252 +5594,112 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>Mode 1 (Sei Höh Gas Qur)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>Mode 2 (Sei Gas Höh Qur)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>Mode 3 (Qur Höh Gas Sei)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>Mode 4 (Qur Gas Höh Sei)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kanalreihenfolge&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Definiert die Reihenfolge der Mischer wenn ein neues Modell erzeugt wird.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation>Wenn man FAI auswählt gibt es nur noch RSSI und RxBat Werte. Diese Funktion kann dann im Sendern nicht mehr deaktiviert werden.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation>RSSI Poweroff Warnung</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation>Low EEPROM Warnung</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation>S H G Q</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation>S H Q G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation>S G H Q</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation>S G Q H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation>S Q H G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation>S Q G H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation>H S G Q</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation>H S Q G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation>H G S Q</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation>H G Q S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation>H Q S G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation>H Q G S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation>G S H Q</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation>G S Q H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation>G H S Q</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation>G H Q S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation>G Q S H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation>G Q H S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation>Q S H G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation>Q S G H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation>Q H S G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation>Q H G S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation>Q G S H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation>Q G H S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5768,320 +5710,353 @@ Legt die Schaltschwelle fest wann die Warnung für die Akku-Unterspannungmeldung
 Werte liegen zwischen 3-12V</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished">Schüler Signaleingang</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation>Nachfragen beim Verbinden</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation>USB Serial (CDC)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>Joystick Modus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Knüppelmodus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Metrisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Zöllig</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Voreingest. Kanalordnung</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>GPS Koordinaten</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Inaktivitätstimer</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Zeige Startbild an</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>LCD Kontrast</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Akku Ladestand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Haptik Stärke</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>LCD Display Typ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Keine Sound Warnung</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Sender Akkuwarnung</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Haptik Länge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>Mav Link Baudrate</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Stumm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Nur Alarme</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>Kein Tastenpieps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation>Optrex LCD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Falls ungleich 0 ertönt ein Piepston wenn der Sender für eine bestimmte Anzahl Minuten nicht bedient wurde.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation>---</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">5x {0s?}</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">5x {0.5s?}</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation>2s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation>3s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation>4s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation>6s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation>8s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation>10s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation>15s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation>4800 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation>9600 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation>14400 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation>19200 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation>38400 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation>57600 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation>76800 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation>115200 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6102,67 +6077,67 @@ Warnung stummer Betrieb - Wird angezeigt, wenn der Piepser komplett ausgeschalte
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>X-kurz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Kurz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>X-lang</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation>NMEA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Schalter Mittenpos. verzögern</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Maßeinheiten</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Haptik Modus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Piepser Länge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Modus Piepser</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6179,12 +6154,14 @@ Warnung stummer Betrieb - Wird angezeigt, wenn der Piepser komplett ausgeschalte
 4 - Sehr laut.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Nur Alarme</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished">1s</translation>
     </message>
@@ -6192,157 +6169,157 @@ Warnung stummer Betrieb - Wird angezeigt, wenn der Piepser komplett ausgeschalte
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation>AUS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation>Tasten</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation>Knüppel</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation>Tasten+ Knüppel</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation>EIN</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation>Englisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation>Niederländisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation>Französisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation>Italienisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation>Deutsch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation>Tschechisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation>Spanisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation>Polnisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation>Portugiesisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation>Russisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation>Schwedisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation>Ungarisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation>Drehgeber A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation>Drehgeber B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation>Drehgeber C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation>Drehgeber D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation>Drehgeber E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6351,22 +6328,22 @@ Diese Funktion kann im Sender nicht mehr abgewählt werden.
 Sind Sie sicher?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished">Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6374,17 +6351,17 @@ Sind Sie sicher?</translation>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Ja, mit Schalter gesteuert</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Ja, mit Poti gesteuert</translation>
     </message>
@@ -6392,118 +6369,128 @@ Sind Sie sicher?</translation>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished">Gerätename:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished">ADC-Filter</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>Geräuschunterdrückung</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished">Strom Offset</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Invertieren</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6584,22 +6571,22 @@ Sind Sie sicher?</translation>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>Gas-Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>Yaw-Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>Pitch-Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>Roll-Kanal:</translation>
     </message>
@@ -6607,19 +6594,19 @@ Sind Sie sicher?</translation>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation>Ungültige EEPROM Datei %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Kann Datei nicht öffnen %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Schreibfehler Datei %1:
@@ -6629,159 +6616,159 @@ Sind Sie sicher?</translation>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Alle Inputs löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished">Linien</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;Addieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+a</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation>Eingabe</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>&amp;Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>&amp;Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>Ein&amp;fügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>D&amp;uplizieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished">Eingang</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished">Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6822,96 +6809,96 @@ Sind Sie sicher?</translation>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6919,17 +6906,17 @@ Sind Sie sicher?</translation>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation>INV</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation>NOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation>CH</translation>
     </message>
@@ -6937,7 +6924,7 @@ Sind Sie sicher?</translation>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation>GV</translation>
     </message>
@@ -6945,122 +6932,122 @@ Sind Sie sicher?</translation>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation>---</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation>a&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation>a&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation>|a|&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation>|a|&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation>AND</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation>OR</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation>XOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation>a=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation>a!=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation>a&gt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation>a&lt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation>a&gt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation>a&lt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation>d&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation>|d|&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation>a=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation>a~x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation>Takt</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation>SRFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation>Puls</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation>L</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation>LSW</translation>
     </message>
@@ -7068,112 +7055,117 @@ Sind Sie sicher?</translation>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation>V1</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation>V2</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>Dauer</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>Verzögerung</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>Funktion</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>UND Schalter</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">Dauerhaft</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished">Menü verfügbar</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation>(sofort)</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation> (endlos)</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished">Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished">Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished">Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7226,52 +7218,52 @@ Sind Sie sicher?</translation>
         <translation>Flugdaten</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>Telemetrie Logs</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>Diagrammtitel ändern</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>Neuer Diagrammtitel:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>Achsbezeichnungen ändern</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>Neue Achsenbezeichnung:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>Grafikname ändern</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>Neuer Grafikname:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7280,74 +7272,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 Die Spalten für Höhe &quot;GAlt&quot; und für Geschwindigkeit &quot;GSpd&quot; sind optional</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei nicht schreiben%1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>Cursor A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>Cursor B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>Zeitdifferenz: %1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>Steigrate: %1 m/s</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>Wähle die Logdatei aus</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>Verfügbare Felder</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>Die ausgewählte Log-Datei enthält %1 ungültige Zeilen von %2 Gesamtzeilen</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>Dauer</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7355,736 +7347,736 @@ Die Spalten für Höhe &quot;GAlt&quot; und für Geschwindigkeit &quot;GSpd&quot
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Datei geladen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Datei gespeichert</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Lese Modell und Einstellungen vom Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>Speichere Sender Backup in Datei</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Lese Sender Firmware in Datei</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>Die neue Oberfläche wird erst beim nächsten Start von Companion aktiv.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Öffne Modelle und Einstellungs Datei</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>Über Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Vergleiche Modelle</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Beendet die Anwendung</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>Öffnen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Speichern als...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation>Kein Sender oder SD-Karte gefunden!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation>Schliessen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Klein</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Groß</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Riesig</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Erzeuge eine neue Modell-und Einstellungen-Datei</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Speichere Modell und Einstellungen in Datei</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>Klassisch</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation>Yerico</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>Monochrom</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>Weiß</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>Blau</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>Systemsprache</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>Anzeige Log Datei...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Öffne und zeige Log Datei an</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Einstellungen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Editiere Einstellungen </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Vergleiche Modelle...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Editiere Sender Start Bild...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>Editiere das Starthbild für den Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Lese Firmware aus dem Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>Lese Firmware aus dem Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Schreibe Firmware in den Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Schreibe Firmware in den Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Füge Senderprofil hinzu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Schreibe Modelle und Einstellungen in den Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Schreibe Modelle und Einstellungen in den Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>Synchronisiere mit SD-Karte</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Lese Modelle und Einstellungen aus dem Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>Kommunikation einstellen...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Schreibe Backup in den Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Schreibe Backup aus Datei in den Sender</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Mach Backup von Sender in Datei</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>SD-Karte Synchronisation</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>Kürzlich verw. Dateien</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Icon setzen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Icon Größen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>Zeige das Infofenster</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Menüsprache einstellen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>Schreibe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation>%2</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation>Alt+%1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Datei</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Lesen/Schreiben</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Fertig</translation>
     </message>
@@ -8092,123 +8084,123 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Modell %1 bearbeiten :</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished">Add</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation>Wollen sie wirklich die Sender Grundeinstellungen überschreiben?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Kann die Datei %1 nicht finden !</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Speichern unter</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8217,7 +8209,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8226,236 +8218,236 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation>Nicht gewählt</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation>Editiere Modell</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation>Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation>Kopieren</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation>Einfügen</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation>Editieren Sender Grundeinstellungen</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation>Kopiere Sender Grundeinstellungen</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation>Einfügen Sender Grundeinstellungen</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation>Simulieren Sender</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Bearbeiten</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation>Wiederherstellen aus Backup</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation>Modell Wizard</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -8463,88 +8455,88 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>Öffne Backup Modelle-und Einstellungs Datei</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Fehler beim Öffnen der Datei %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Fehler beim Lesen der Datei%1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 wurde verändert.
 Sollen die Änderungen gespeichert werden?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>Ungültige Binär Backup Datei %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Kann temporäre Datei nicht schreiben! </translation>
     </message>
@@ -8552,143 +8544,148 @@ Sollen die Änderungen gespeichert werden?</translation>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8696,12 +8693,12 @@ Sollen die Änderungen gespeichert werden?</translation>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation>Mix</translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation> (@%1)</translation>
     </message>
@@ -8714,105 +8711,110 @@ Sollen die Änderungen gespeichert werden?</translation>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Quelle</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>Die Mischerquelle</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Gewichtung</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Offset</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">Precision</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Trimmung einschließen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Die Mischerkurve</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Schalter</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>AUS</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 Piepston</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2 Piepstöne</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 Piepstöne</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Mixer verrechnen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8837,124 +8839,85 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Wenn die Verlangsamung nicht 0 ist, wird der Ausgang des Mixers um den gegebenen Wert verlangsamt -&amp;gt; Der Wert stellt die Zeit in Sekunden dar, die der Ausgangswert des Mischers benötigt, um sich von -100 auf 100 zu ändern.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translatorcomment>Ich bin mir nicht sicher ob der </translatorcomment>
-        <translation>Mixerwarnung.
-Diese Einstellung sorgt dafür, dass ein Piepton abgespielt wird, sobald dieser Mixer aktiviert wird.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Mixer verrechnen
-
-Diese Einstellung bestimmt wie die Mischerwerte behandelt werden.
-
-&quot;+&quot; bedeutet der Wert des aktuellen Mischers wird zu dem vorhergehenden Mischer im gleichen Kanal addiert.
-&quot;*&quot; bedeutet der Wert des aktuellen Mischers wird mit dem vorhergehenden Mischer im gleichen Kanal multipliziert.
-&quot;R&quot; bedeutet der Wert des aktuellen Mischers ersetzt den vorhergehenden Mischer. Wenn der Schalter aus ist wird der Wert ignoriert.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>ADDIEREN</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>MULTIPLIZIEREN</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>ERSETZEN</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Mischerschalter. Wenn leer ist der Mischer immer aktiv.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Flugphasen</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>DR/Expo einschließen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">5x {0.00?}</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Verzögerung</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translatorcomment>Man könnte auch Hemmung sagen</translatorcomment>
         <translation>Verlangsamung</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation>DEST -&gt; %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation>Klick für Fenster öffnen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation>Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation>Alles Setzen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation>Alles invertieren</translation>
     </message>
@@ -8962,22 +8925,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8985,136 +8948,136 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Mischer löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>Nicht genügend Mischer verfügbar!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;Addieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+a</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>Eingabe</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>&amp;Toggle highlight</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>&amp;Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>Ein&amp;fügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>Du&amp;plizieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>Mischer löschen?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>Wirklich alle Mischer löschen ?</translation>
     </message>
@@ -9122,19 +9085,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation>Modell: </translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation>Gas-Quelle</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation type="unfinished">Gas</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9182,32 +9150,49 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
+        <translation type="unfinished">SW</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
+        <translation type="unfinished">Aus</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished">---</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9220,45 +9205,40 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>Heli TS-Mischer</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Inputs(Geber)</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Logische Schalter</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Spezial Funktionen</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Telemetrie</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Flugphasen</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.ui" line="51"/>
@@ -9266,22 +9246,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>Simulation</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Konfiguration</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Mischer</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>Ausgaben(Servos)</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Kurven</translation>
     </message>
@@ -9335,8 +9315,8 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Flugphasen</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9372,585 +9352,595 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation>Exponential</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>Sehr fein</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>Fein</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>Mittel</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>Grob</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation>Freigabe</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation>Sperren</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation>Wahr</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation>Falsch</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation>EIN</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation>AUS</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation>Bytes</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation>Modus</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation>Kanäle</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation>Framelänge</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation>PPM Puls</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation>Polarität</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation>Protokoll</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation>Verzögerung</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation>Empfänger</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation>Senderprotokoll</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation>Subtyp</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation>Optionswert</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation>Subtyp</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation>HF Sendeleistung</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation>120X</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation>140</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation>MULTI!</translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation>Flugphasen</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation>Flugphase</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation>Puls</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation>SRFF</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation>Takt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation> fehlt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation>Dauer</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation>Erw. Wege 100% --&gt; 150%</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation>Anzeige Checkliste</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation>Globale Funktionen</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation>Manuell</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation>Automatisch</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation>Failsafe Mode</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation>Halte Servopos</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation>Kein Signal</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation>Nicht eingestellt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation>Keine Signale</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation>Schritt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation>Anzeige</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation>Erweitert</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished">Joystick Modus</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation>Bei Änderung</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation>Immer</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished">Nur Trimmung</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished">Nur Tasten</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished">Umschaltbar</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished">Global</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation>Quelle</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation>Nur Leerlauftrimmung</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation>Invertiert</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation>FrSky S.PORT</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation>FrSky D</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation>FrSky D (Kabel)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation>Höhe</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation>Höhe+</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation>VSpeed</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation>A1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation>A2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation>A3</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation>A4</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation>FAS</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation>Zellen</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation>Nummern</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation>Balken</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation>Dateiname</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation>Kein</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation>FM%1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation>FM%1%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation>Kein DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation>Offset(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>Abgewählt in allen Flugphasen</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation>sofort</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>Eigener</translation>
     </message>
@@ -9958,27 +9948,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Flächenmodell</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>Multicopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Hubschrauber</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Modellname:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Modelltyp:</translation>
     </message>
@@ -9986,27 +9976,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished">Index</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Name</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished">RX #</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished">Modell %1</translation>
@@ -10262,285 +10252,290 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation>Positiv</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation>Negativ</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished">Trainer Port</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished">Internes HF Modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished">Externes HF Modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished">Sender System</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished">AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished">PPM</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10548,57 +10543,57 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished">Profile</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation>Wert</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>Halte Servopos</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>keine Pulse</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
@@ -10606,456 +10601,456 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>Eingang</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>Gewichtung</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation>Nick cyc u. Gew</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation>Roll cyc u. Gew</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>Kollektiv Pitch-Quelle u. Gew</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>Flugphasen</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>Flugphase</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>Schalter</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation>Modellbild</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation>Gas</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation>Trimmung</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation>MittenBeeps</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation>Schalter Warnungen</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation>Poti Warnungen</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation>Weitere</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation>Timer</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation>Countdown</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">Modus</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished">Start</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation>Module</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation>Hubschrauber</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation>Taumelscheibe</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation>Ring</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Funktion</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation>Protokoll</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation>Kritisch</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation>Höhenanzeige</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation>Varioquelle</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation>Variogrenzen &gt;</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation>Sinkrate max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation>Sinkrate min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation>Steigrate min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation>Steigrate max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation>Mitte Ruhe</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation>Obere Infozeile am Sender</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation>Spannung Quelle</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation>Höhe Quelle</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>Anpassbare Schalter</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation>Parameter</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation>Telemetriesensoren</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation>Telemetrieanzeigen</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished">GF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished">Globale Funktionen</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation>GV%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation>RE%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>Kanal</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation>Prec</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation>Popup</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation>Ausgaben(Servos)</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation>Mitte</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation>Direkt</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation>Kurve</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation>PPM</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation>Linear</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation>Telemetrie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished">Dauerhaft</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>Globale Variablen</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>Inputs(Geber)</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>Mischer</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>Kurven</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation>L%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>Logische Schalter</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>Spezial Funktionen</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>Einheit</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>HF Qualität Alarme</translation>
     </message>
@@ -11063,7 +11058,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11071,22 +11066,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Gas-Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Yaw-Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Pitch-Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Roll-Kanal:</translation>
     </message>
@@ -11094,22 +11089,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation>Unbekannter Fehler</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation> ... plus %1 Fehler</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation>Kann Sender-Grundeinstellungen nicht speichern</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation>Kann Model nicht speichern %1</translation>
     </message>
@@ -11117,17 +11112,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Gas-Freigabeschalter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Gas-Timer starten</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Flug-Timer starten</translation>
     </message>
@@ -11135,40 +11130,40 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Fehler beim Öffnen der Datei %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Fehler beim Schreiben der Datei %1:
@@ -11198,17 +11193,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>Druck in Datei</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Drucke Dokument</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11235,12 +11230,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>Schliessen</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -11256,22 +11251,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished">Diese Nachricht beim nächsten Starten erneut anzeigen?</translation>
     </message>
@@ -11279,24 +11274,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11304,97 +11299,107 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation>Aktion</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation>Neu</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11402,30 +11407,30 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Kann Datei nicht schreiben%1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation>Kann temporäre Datei nicht löschen: %1</translation>
     </message>
@@ -11433,12 +11438,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Wert (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation>Doppelklick Rechts für Reset in die Mitte.</translation>
     </message>
@@ -11554,12 +11559,17 @@ e
 r</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation type="unfinished">FM%1</translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished">FM</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished">GV%1</translation>
     </message>
@@ -11575,358 +11585,458 @@ r</translation>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation>TrmS</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation>TrmH</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation>TrmG</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation>TrmQ</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
-        <translation>Trm5</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
-        <translation>Trm6</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
-        <translation type="unfinished">Trm7</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
-        <translation type="unfinished">Trm8</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished">TrmV</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation>TX-Akku</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation>DGa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation>DGb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation>LUA%1%2</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation>CYC%1</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Quelle</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">Kein</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
+        <translation type="unfinished">-</translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation>↑</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation>↓</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation>-</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation>!</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation>Trimmer H links</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation>Trimmer H rechts</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation>Trimmer V runter</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation>Trimmer V hoch</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation>DGa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation>DGb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation>AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation>EIN</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation>GSs</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation>GS%</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation>GSt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation>Einmal</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation>----</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation>Telemetrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
-        <translation>SW</translation>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished">Schalter</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">Kein</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt; Seitenruderkanal:</translation>
     </message>
@@ -11934,21 +12044,21 @@ r</translation>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Fehler beim Öffnen der Datei %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation>Fehler beim Öffnen der Datei %1 im Schreibmodus:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11956,319 +12066,334 @@ r</translation>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished">Formel</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished">ID</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished">SubID</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished">sensor</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished">Quellen</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished">Alt</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished">Einheit</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished">Precision</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished">Offset</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished">Auto Offset</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished">Rotorblätter</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished">Muliplikator</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished">Filter</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished">Dauerhaft</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished">Positiv</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished">Berechnung</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished">Add</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished">Mittelwert</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished">Multiplizeren</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished">Gesamt</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished">Zelle</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished">Verbrauch</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished">Distanz</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished">Niedrigster</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished">Zelle %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished">Höchster</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished">Differenz</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished">Roh (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation>A</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation>mA</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation>kts</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation>m/s</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation>m</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation>f</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation>°C</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation>°F</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation>%</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation>mAh</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation>W</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation>mW</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation>dB</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation>rpm</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation>g</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation>°</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation>rad</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation>Std</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation>sec</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation>Tele</translation>
     </message>
@@ -12492,87 +12617,87 @@ ebenfalls umgekehrt.
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>Timer %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished">Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished">Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished">Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12580,7 +12705,7 @@ ebenfalls umgekehrt.
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Höheruderkanal:</translation>
     </message>
@@ -12588,204 +12713,204 @@ ebenfalls umgekehrt.
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12793,121 +12918,121 @@ ebenfalls umgekehrt.
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation>Verfügbare Profile:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation>ID: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation>Name: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation>Verfügbare Sender:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation>Senderprofil ID oder Name für die Simulation.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation>Profile</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation>Sendertyp für die Simulation (normal wie im Profil).</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation>Sender</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation>Pfad</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation>Tayp</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
@@ -12917,8 +13042,8 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
-        <translation type="unfinished">OpenTX Simulator</translation>
+        <source>EdgeTX Simulator</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
@@ -13066,74 +13191,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation>F2</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation>Telemetrie Simulator</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation>F4</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation>Trainer Simulator</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation>F5</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation>Debug Ausgabe</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation>F6</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13258,32 +13383,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13296,67 +13421,72 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished">Companion Simulator</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished">Daten Ladefehler</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished">Kann joystick nicht öffnen, joystick ausgeschaltet</translation>
     </message>
@@ -13383,17 +13513,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>Startbild Bibliothek - Seite %1 von %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>ungültige Bilddatei in Bibliothek %1</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>keine gültige Bilddatei gefunden in Bibliothek, bitte Einstellungen prüfen</translation>
     </message>
@@ -13401,7 +13531,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>Kanal %1</translation>
     </message>
@@ -13409,7 +13539,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation>Kann Datei nicht finden%1!</translation>
     </message>
@@ -13418,9 +13548,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13445,19 +13575,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13466,47 +13596,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation>Die Stylesheet-Daten wurden aus der Datei %1 eingelesen</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation>Die Stylesheet-Daten konnten nicht aus der Datei %1 eingelesen werden</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation>Der Ordner %1 konnte nicht erstellt werden</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation>Die Datei %1 konnte nicht zum schreiben geöffnet werden. Fehler: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation>In die Datei %1 konnte nicht geschrieben werden. Fehler: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation>Der Pufferinhalt konnte nicht in die Datei %1 übernommen werden: Fehler %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation>Die Stylesheet-Daten wurde in der Datei %1 geschrieben</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation>Das benutzerdefinierte Stylesheet %1 wurde gelöscht</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation>Das benutzerdefinierte Stylesheet %1 konnte nicht gelöscht werden</translation>
     </message>
@@ -13514,141 +13644,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13656,17 +13786,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>Seitenruder Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Höhenruder Kanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>Nur noch ein Kanal verfügbar!&lt;br&gt;Sie sollten das Model eher nicht mit dem Wizard erzeugen.</translation>
     </message>
@@ -13674,22 +13804,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Höhen- und Seiteruder</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Nur Höheruder</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>V-Leitwerk</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Leitwerkstyp:</translation>
     </message>
@@ -14021,7 +14151,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">Telemetrie Bild %1</translation>
     </message>
@@ -14029,28 +14159,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Voralarm</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Kritischer Alarm</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation>Winged Shadow How High</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (nicht unterstützt)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished">km/h</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">V-Speed</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished">FM</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished">mAh</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">Strom</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished">Zellen</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished">Füllstand</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished">VFAS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished">A4</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished">°C</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished">km/h</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished">RPM</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">V-Speed</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished">A3</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Fuel</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">Strom</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Fuel</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished">RPM</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">V-Speed</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished">°C</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished">Datum</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished">TX-Akku</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished">VFAS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">Strom</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14167,72 +15230,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished">Kopieren</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished">Ausschneiden</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished">Alles löschen</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14245,355 +15308,124 @@ Too many errors, giving up.</source>
         <translation>Telemetrie Simulator</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation>VFAS</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation>RSSI</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation>A1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation>A2</translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
         <translation>Simulation</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished">dB</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished">25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation>Lade</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation>&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation>1/5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation>5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Kein</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation>A3</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation>A4</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>Fuel</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation>°C</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation>%</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation>Alt</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation>V-Speed</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation>m/s</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation>Füllstand</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation>km/h</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation>GPS</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation>AccX</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation>Datum</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation>AccZ</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation>V</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation>Zellen</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation>Strom</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation>AccY</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation>RPM</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
@@ -14601,78 +15433,35 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation>Logdatei</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation>Logdateien (*.csv)</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
         <translation>Fehler ungültige Datei</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Ja</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;Gaskanal:</translation>
     </message>
@@ -14698,138 +15487,138 @@ Timestamp</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation>TMR</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation>Timer %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished">TMR</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">Pieps</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">Stimme</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">Haptik</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished">5s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished">10s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished">20s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished">30s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">Nicht dauerhaft</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">Dauerhaft für Flug</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished">Flug</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">Dauerhaft (per Hand reset)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished">Manual Reset</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished">AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">EIN</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished">Start</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished">GSs</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished">GS%</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished">GSt</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14837,22 +15626,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished">AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Add)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Ersetzen)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
@@ -14860,27 +15649,27 @@ Timestamp</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">Modus</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Gewichtung</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Quelle</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished">Muliplikator</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished">Kalibrierung</translation>
     </message>
@@ -14891,6 +15680,210 @@ Timestamp</source>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
         <translation>Trainer Simulator</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">unbekannt</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14917,47 +15910,47 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14970,22 +15963,42 @@ Timestamp</source>
         <translation type="unfinished">Firmware</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14993,285 +16006,317 @@ Timestamp</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished">unbekannt</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15287,63 +16332,90 @@ Timestamp</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15436,32 +16508,32 @@ Timestamp</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15474,22 +16546,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15502,22 +16574,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15541,17 +16613,17 @@ Timestamp</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15559,37 +16631,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15705,32 +16777,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15738,32 +16810,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15771,12 +16843,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>Erster Leitwerkskanal:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>Zweiter Leitwerkskanal:</translation>
     </message>
@@ -15784,55 +16856,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation>Hold Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
-        <translation>Halte vertikale Knüppelposition.</translation>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation>Fixiere Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation>Verhindert vertikale Bewegung des Knüppel.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation>Fixiere X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation>Verhindert horizontale Bewegung des Knüppels.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
         <translation>Hold X</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
-        <translation>Halte horizontale Knüppelposition.</translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Normaler Flügel</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Nurflügler / Deltaflügel</translation>
     </message>
@@ -15840,22 +16912,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15863,273 +16935,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Modell-Wizard</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Modelltyp</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Modellname und Modelltyp eingeben.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Antrieb</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>Hat das Modell einen Antriebsmotor (Elektro oder Verbrenner)?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Flächentyp</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>Ist das Modell ein Nurflügel/Delta oder hat es eine normale Fläche?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>Querruder</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>Hat das Modell Querruder?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Wölbklappen</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>Hat das Modell Wölbklappen?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Bremsklappen</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>Hat das Modell Bremsklappen?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Nurflügler / Deltaflügel</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Wähle die Elevon Kanäle</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Seitenruder</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>Hat das Modell ein Seitenruder?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Leitwerkstyp</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Welchen Leitwerktyp hat das Modell.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Leitwerk</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Wähle die Kanäle für das Leitwerk.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>V-Leitwerk</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Wähle den Höhenruder Kanal.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>Zyklisch</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>Welche Art von Taumelscheibe ist verbaut?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>Heckkreisel</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>Hat der Heli einen einstellbaren Heckkreisel?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>Rotorkopf-Typ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>Hat der Hubschrauber eine Flybar?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Hubschrauber</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>Wähle die Steuerkanäle für den Heli</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>Multikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Wähle die Steuerkanäle für den Multikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Modell Optionen</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Auswahl von zusätzlichen Optionen</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>Änderungen speichern</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Überprüfe, ob alle Steuerflächen sich in die richtige Richtung bewegen und invertiere diese gegebenenfalls. Entferne den oder die Propeller bevor du das Modell zum ersten mal steuerst.&lt;br&gt;Bitte beachte, dass das Fortfahren alle alten Einstellungen überschreibt!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Modellname eingeben und Modelltype auswählen.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Wähle den Empfängerkanal, an den der ESC oder der Gasservo angeschlossen ist.&lt;br&gt;&lt;br&gt;Gas - Spektrum: CH1, Futaba: CH3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>Der Wizard geht davon aus, dass die Wölbklappen durch einen Schalter gesteuert werden. Sollen die Wölbklappen durch ein Poti gesteuert werden, kann dies später noch geändert werden.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>Störklappen werden eingesetzt um den Widerstand zu erhöhen und damit den Gleitwinkel  bei Seglern zu verschlechtern.&lt;br&gt;Für ander Arten von Flugzeugen sind sie eher ungewöhnlich.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Wähle den Empfängerkanal, an den das Seitenruderservo angeschlossen ist.&lt;br&gt;&lt;br&gt;Seitenruder - Spektrum: CH4, Futaba: CH4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Wähle den Leitwerkstyp des Flugzeugs.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Wähle den Empfängerkanal, an den Seiten- und das Höhenruderservo angeschlossen ist.&lt;br&gt;&lt;br&gt;Seitenruder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Höhenruder - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Wähle den Kanal für das Höhenleitwerk.&lt;br&gt;&lt;br&gt;Höhenleitwerk - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation>TBS.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Wähle die Steuerkanäle für deinen Multikopter.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>Für diese Seite steht keine Hilfe zur Verfügung.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Modell Wizard Hilfe</translation>
     </message>
@@ -16137,37 +17209,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>Flächenmodell</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>Multikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>Hubschrauber</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>Modelname: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>Modelltyp: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>Optionen: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>Kanal %1: </translation>
     </message>
@@ -16175,47 +17247,47 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Fehler beim Öffnen der Datei %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished">Fehler beim Öffnen der Datei %1 im Schreibmodus:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16223,16 +17295,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16241,10 +17316,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16343,18 +17433,18 @@ Please only use this if you know what you are doing.  There are no error checks 
         <translation>sam-ba serialer port</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>DFU-UTIL Konfiguration</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>SAM-BA Konfiguration</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Wähle Speicherort</translation>
     </message>
@@ -16372,57 +17462,57 @@ Please only use this if you know what you are doing.  There are no error checks 
         <translation>Joystick konfigurieren</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation>Nicht zugewiesen</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation>Kein Joystick gefunden</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation>Bewege alle Knüppel und Potis in alle Richtungen auf Vollausschlag
 Drücken Next wenn soweit</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation>Erst alle Knüppel und Potis in die Mittestellung.
 dann Next wenn soweit</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation>OK um die Einstellungen zu speichern
 Cancel zum abbrechen der Joystickkalibrierung ohne speichern.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation>Kalibrierung nciht fertig trotzdem speichern?</translation>
     </message>
@@ -16452,7 +17542,7 @@ Cancel zum abbrechen der Joystickkalibrierung ohne speichern.</translation>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>weiter</translation>
     </message>
@@ -16462,7 +17552,7 @@ Cancel zum abbrechen der Joystickkalibrierung ohne speichern.</translation>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>kann Joystick nicht öffnen.</translation>
     </message>

--- a/companion/src/translations/companion_de.ts
+++ b/companion/src/translations/companion_de.ts
@@ -5273,22 +5273,22 @@ Dieses sind für alle Modelle im gleichen EEPROM gültig.</translation>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1003"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mode 1 (Seite Höhe Gas Quer)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1005"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mode 2 (Seite Gas Höhe Quer)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1007"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mode 3 (Quer Höhe Gas Seite)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1009"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mode 4 (Quer Gas Höhe Seite)</translation>
     </message>
 </context>
 <context>

--- a/companion/src/translations/companion_en.ts
+++ b/companion/src/translations/companion_en.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,23 +60,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -169,69 +169,69 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -254,615 +254,610 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,29 +865,29 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -930,33 +925,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -967,255 +962,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1223,17 +1228,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1241,132 +1246,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1409,56 +1414,56 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1474,12 +1479,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,173 +1492,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1691,22 +1706,22 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1732,7 +1747,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1740,17 +1755,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1758,22 +1773,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1856,32 +1871,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1889,7 +1904,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1897,22 +1912,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1920,113 +1935,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2034,343 +2049,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2378,123 +2413,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2502,22 +2537,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,47 +2560,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2622,82 +2657,82 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2705,22 +2740,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2728,53 +2763,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2782,52 +2817,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2906,101 +2941,82 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3009,12 +3025,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3022,12 +3038,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3035,12 +3051,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3048,40 +3064,40 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,23 +3105,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3113,110 +3129,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3226,22 +3227,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3249,22 +3250,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,262 +3273,262 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3535,367 +3536,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3903,27 +3948,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3932,7 +3977,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3997,49 +4042,49 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4117,103 +4162,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4221,83 +4266,83 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4305,7 +4350,7 @@ You are currently using:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4356,225 +4401,240 @@ You are currently using:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4582,17 +4642,17 @@ You are currently using:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4600,17 +4660,17 @@ You are currently using:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4618,17 +4678,17 @@ You are currently using:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4636,13 +4696,13 @@ You are currently using:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4660,17 +4720,18 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4680,7 +4741,12 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4688,8 +4754,13 @@ You are currently using:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4785,13 +4856,13 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4799,43 +4870,33 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4863,57 +4924,57 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4952,7 +5013,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
+        <source>%1 Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4989,184 +5050,207 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5183,196 +5267,194 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5380,7 +5462,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5390,57 +5472,57 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5463,273 +5545,133 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5737,289 +5679,322 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6034,67 +6009,67 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6105,12 +6080,14 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,179 +6095,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6298,17 +6275,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6316,118 +6293,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6508,22 +6495,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6531,18 +6518,18 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
@@ -6551,159 +6538,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="52"/>
         <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <source>Ctrl+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,96 +6731,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6841,17 +6828,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6859,7 +6846,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6867,122 +6854,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6990,112 +6977,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7148,125 +7140,125 @@ Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7274,736 +7266,736 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8011,27 +8003,27 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
             <numerusform>Delete %n selected model?</numerusform>
@@ -8039,265 +8031,265 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8306,7 +8298,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8315,152 +8307,152 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8468,143 +8460,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8612,12 +8609,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8630,50 +8627,67 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8688,170 +8702,127 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8859,22 +8830,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8882,136 +8853,136 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="47"/>
         <location filename="../modeledit/mixes.cpp" line="441"/>
+        <source>Ctrl+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9019,18 +8990,23 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9079,32 +9055,49 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9122,63 +9115,58 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9232,7 +9220,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
+        <source>%1 Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9269,585 +9257,595 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9855,27 +9853,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9883,27 +9881,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10159,285 +10157,290 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10445,57 +10448,57 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10503,456 +10506,456 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10960,7 +10963,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10968,22 +10971,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10991,22 +10994,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11014,17 +11017,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11032,39 +11035,39 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
@@ -11093,17 +11096,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11130,12 +11133,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11151,22 +11154,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11174,24 +11177,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11199,97 +11202,107 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11297,29 +11310,29 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11327,12 +11340,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11428,12 +11441,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11449,358 +11467,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11808,19 +11926,19 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11828,319 +11946,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12359,87 +12492,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12447,7 +12580,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12455,204 +12588,204 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12660,121 +12793,121 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
@@ -12784,7 +12917,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12933,74 +13066,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13125,32 +13258,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13163,68 +13296,73 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13250,17 +13388,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13268,7 +13406,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13276,7 +13414,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13285,9 +13423,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13312,19 +13450,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13333,47 +13471,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13381,141 +13519,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13523,17 +13661,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13541,22 +13679,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13888,7 +14026,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13896,28 +14034,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14034,72 +15105,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14122,424 +15193,150 @@ Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14565,138 +15362,138 @@ hh:mm:ss</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14704,22 +15501,22 @@ hh:mm:ss</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14727,27 +15524,27 @@ hh:mm:ss</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14757,6 +15554,210 @@ hh:mm:ss</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14784,47 +15785,47 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14837,22 +15838,42 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14860,285 +15881,317 @@ hh:mm:ss</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15154,63 +16207,90 @@ hh:mm:ss</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15303,32 +16383,32 @@ hh:mm:ss</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15341,22 +16421,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15369,22 +16449,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15408,17 +16488,17 @@ hh:mm:ss</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15426,37 +16506,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15572,32 +16652,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15605,32 +16685,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15638,12 +16718,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15651,55 +16731,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15707,22 +16787,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15730,273 +16810,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16004,37 +17084,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -16042,45 +17122,45 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16088,16 +17168,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16106,10 +17189,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16211,18 +17309,18 @@ m2560 for v4.1 boards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16265,64 +17363,64 @@ m2560 for v4.1 boards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_en.ts
+++ b/companion/src/translations/companion_en.ts
@@ -11,22 +11,22 @@
     <message>
         <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -34,27 +34,27 @@
     <message>
         <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -63,97 +63,97 @@
         <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="656"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="656"/>
         <source>Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="656"/>
         <source>Editor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="656"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="656"/>
         <source>Prompt</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="657"/>
         <source>Manual</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="657"/>
         <source>Startup</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="657"/>
         <source>Daily</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="657"/>
         <source>Weekly</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="657"/>
         <source>Monthly</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="659"/>
         <source>Debug</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="659"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="659"/>
         <source>Critical</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="659"/>
         <source>Fatal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="659"/>
         <source>Information</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -161,74 +161,74 @@
     <message>
         <location filename="../apppreferencesdialog.ui" line="20"/>
         <source>Edit Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="52"/>
         <source>Radio Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="296"/>
         <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="606"/>
         <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="533"/>
@@ -251,287 +251,287 @@ Mode 4:
   Right stick:  Elevator, Rudder
 
 </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="299"/>
@@ -544,322 +544,322 @@ Mode 4:
         <location filename="../apppreferencesdialog.ui" line="1536"/>
         <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="83"/>
         <location filename="../apppreferencesdialog.ui" line="1560"/>
         <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="754"/>
         <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="284"/>
         <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="568"/>
         <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -867,29 +867,29 @@ Mode 4:
     <message>
         <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -897,32 +897,32 @@ Mode 4:
     <message>
         <location filename="../firmwares/boardjson.cpp" line="57"/>
         <source>Rud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="58"/>
         <source>Ele</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="59"/>
         <source>Thr</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="60"/>
         <source>Ail</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="61"/>
         <source>ST</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="62"/>
         <source>TH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="875"/>
@@ -930,25 +930,25 @@ Mode 4:
         <location filename="../firmwares/boardjson.cpp" line="890"/>
         <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="901"/>
@@ -956,7 +956,7 @@ Error: Unable to read file %2</source>
 Error: %2 is not a valid json formatted file.
 Error code: %3
 Error description: %4</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -964,64 +964,64 @@ Error description: %4</source>
     <message>
         <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="437"/>
         <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="438"/>
         <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="445"/>
@@ -1032,13 +1032,13 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="514"/>
         <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="453"/>
         <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
@@ -1048,49 +1048,49 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="515"/>
         <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="457"/>
         <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="1095"/>
@@ -1115,7 +1115,7 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="507"/>
         <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="451"/>
@@ -1128,7 +1128,7 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="508"/>
         <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="452"/>
@@ -1138,91 +1138,91 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="501"/>
         <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="433"/>
         <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="434"/>
         <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="642"/>
         <location filename="../firmwares/boards.cpp" line="855"/>
         <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1230,17 +1230,17 @@ Error description: %4</source>
     <message>
         <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1248,132 +1248,132 @@ Error description: %4</source>
     <message>
         <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1381,47 +1381,47 @@ Error description: %4</source>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="14"/>
         <source>Edit Checklist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="71"/>
         <source>Line nn, Col nn</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="100"/>
         <source>&amp;Import...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="113"/>
         <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="126"/>
         <source>&amp;OK</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="141"/>
         <source>Please note, the maximum width displayable is radio model limited. Also, renaming the model will break the link to this checklist file.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="151"/>
         <source>File: unknown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="77"/>
@@ -1430,42 +1430,42 @@ Error description: %4</source>
         <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1473,7 +1473,7 @@ Error description: %4</source>
     <message>
         <location filename="../updates/chooserdialog.ui" line="14"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1481,12 +1481,12 @@ Error description: %4</source>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1494,17 +1494,17 @@ Error description: %4</source>
     <message>
         <location filename="../constants.h" line="63"/>
         <source>Information</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="64"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="65"/>
         <source>Error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="66"/>
@@ -1519,158 +1519,158 @@ Error description: %4</source>
     <message>
         <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="69"/>
         <source>files</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1678,52 +1678,52 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../comparedialog.ui" line="29"/>
         <source>Compare Models</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="44"/>
         <source>To compare models, drag and drop them anywhere in this window.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="67"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="74"/>
         <source>Style</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="81"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="88"/>
         <source>Print to file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1731,17 +1731,17 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../storage/appdata.h" line="590"/>
         <source>Releases</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="590"/>
         <source>Pre-release</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="590"/>
         <source>Nightly</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1749,7 +1749,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1757,17 +1757,17 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1775,22 +1775,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1798,107 +1798,107 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../shared/curvedialog.ui" line="60"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="77"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="93"/>
         <source>Smooth</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="142"/>
         <source>Curve Creator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="148"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="158"/>
         <source>Coefficient</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="181"/>
         <source>Y at X=-100</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="204"/>
         <source>Y at X=0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="227"/>
         <source>Y at X=100</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="250"/>
         <source>Side</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="258"/>
         <source>Both</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="263"/>
         <source>x&gt;0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="268"/>
         <source>x&lt;0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="276"/>
         <source>Apply</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="290"/>
         <source>Point size</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1906,7 +1906,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1914,22 +1914,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -1937,113 +1937,113 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="53"/>
         <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2051,112 +2051,112 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
@@ -2171,33 +2171,33 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
@@ -2207,87 +2207,87 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
@@ -2302,112 +2302,112 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2415,123 +2415,123 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2539,22 +2539,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2562,22 +2562,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
@@ -2587,22 +2587,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
         <source>Sliders</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
         <source>Trims</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
         <source>Mirror</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2610,19 +2610,19 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../customizesplashdialog.ui" line="23"/>
         <source>Transmitter Splash Screen Editor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="209"/>
         <location filename="../customizesplashdialog.ui" line="517"/>
         <source>Invert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="232"/>
         <location filename="../customizesplashdialog.ui" line="540"/>
         <source>Open Splash Library</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="235"/>
@@ -2630,111 +2630,111 @@ Do you want to import settings from a file?</source>
         <location filename="../customizesplashdialog.ui" line="345"/>
         <location filename="../customizesplashdialog.ui" line="543"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="262"/>
         <location filename="../customizesplashdialog.ui" line="570"/>
         <source>Load Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="272"/>
         <location filename="../customizesplashdialog.ui" line="583"/>
         <source>Load FW</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="282"/>
         <location filename="../customizesplashdialog.ui" line="593"/>
         <source>Load Pict</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="308"/>
         <location filename="../customizesplashdialog.ui" line="619"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2742,22 +2742,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2765,53 +2765,53 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2819,52 +2819,52 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2872,83 +2872,83 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../simulation/debugoutput.ui" line="20"/>
         <source>Debug Output</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="68"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable the filter. If the button won&apos;t stay enabled, it is likely there is a syntax error in the Regular Expression entered.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="74"/>
         <source>Filter:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="105"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter filter text here. Click the help/info button for details about using the filter. &lt;/p&gt;&lt;p&gt;
 To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first choose it, and then press &lt;code&gt;Shift-Delete&lt;/code&gt; (or &lt;code&gt;Shift-Backspace&lt;/code&gt;) key combination.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="164"/>
         <source>Buffer:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="177"/>
         <source>Number of lines to keep in display.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="274"/>
         <source>Filter &amp;Help</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="277"/>
         <source>Show information about using the filter.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="289"/>
         <source>Word &amp;Wrap</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="292"/>
         <source>Toggle word wrapping on/off.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="301"/>
         <source>&amp;Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="304"/>
         <source>Clear the output window of all text.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="316"/>
         <source>Enable &amp;Filter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="319"/>
         <source>Turn the filter on/off.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -2956,70 +2956,70 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="91"/>
         <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3027,12 +3027,12 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3040,12 +3040,12 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3053,12 +3053,12 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3067,39 +3067,39 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3107,23 +3107,23 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/input_data.cpp" line="43"/>
         <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3131,67 +3131,67 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="38"/>
@@ -3199,12 +3199,12 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <location filename="../modeledit/expodialog.ui" line="373"/>
         <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="86"/>
@@ -3214,37 +3214,37 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="52"/>
         <source>Edit %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3252,22 +3252,22 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3275,262 +3275,262 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3538,22 +3538,22 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
@@ -3571,7 +3571,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
@@ -3590,7 +3590,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
@@ -3609,154 +3609,154 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
@@ -3765,7 +3765,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
@@ -3800,7 +3800,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
@@ -3810,12 +3810,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
@@ -3825,88 +3825,88 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
@@ -3916,33 +3916,33 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3950,27 +3950,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -3979,114 +3979,114 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../flasheepromdialog.ui" line="26"/>
         <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="66"/>
         <source>Load...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="81"/>
         <source>Current Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="97"/>
         <source>Allows Companion to write to older version of the firmware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="100"/>
         <source>Check Firmware compatibility</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="113"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Saves a dated copy of your eeprom to the backup folder you specified in the Companion settings before writing the current model to the radio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="116"/>
         <source>Backup before Write</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="123"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modify calibration parameters using settings from current profile&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="126"/>
         <source>Patch calibration setting from profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="133"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modify HW parameters using settings from current profile&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="136"/>
         <source>Patch HW settings from profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="164"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.ui" line="180"/>
         <source>Write to TX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4094,173 +4094,173 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="26"/>
         <source>Flash Firmware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="66"/>
         <source>Load...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="90"/>
         <source>Date &amp; Time</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="104"/>
         <source>Variant</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="118"/>
         <source>Version</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="152"/>
         <source>Use profile start screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="159"/>
         <source>Use firmware start screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="166"/>
         <source>Use library start screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="173"/>
         <source>Use another start screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="228"/>
         <source>Allows Companion to write to older version of the firmware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="231"/>
         <source>Check Hardware compatibility</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="241"/>
         <source>Backup and restore Models and Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="285"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="301"/>
         <source>Write to TX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4268,83 +4268,83 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4352,7 +4352,7 @@ You are currently using:
     <message>
         <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4360,42 +4360,42 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmode.ui" line="22"/>
         <source>Fade In</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="43"/>
         <source>Fade Out</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="57"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="77"/>
         <source>Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="444"/>
         <source>trim6</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="510"/>
         <source>trim8</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="589"/>
         <source>trim5</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="655"/>
         <source>trim7</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4403,7 +4403,7 @@ You are currently using:
     <message>
         <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/flightmodedata.cpp" line="46"/>
@@ -4416,78 +4416,78 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="41"/>
         <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="123"/>
@@ -4528,49 +4528,49 @@ You are currently using:
         <location filename="../modeledit/flightmodes.cpp" line="695"/>
         <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="696"/>
         <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="697"/>
         <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="700"/>
         <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="701"/>
         <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="702"/>
         <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="703"/>
         <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="705"/>
         <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="740"/>
@@ -4620,23 +4620,23 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="698"/>
         <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4649,12 +4649,12 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4662,17 +4662,17 @@ You are currently using:
     <message>
         <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4680,17 +4680,17 @@ You are currently using:
     <message>
         <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4699,12 +4699,12 @@ You are currently using:
         <location filename="../firmwares/telem_data.cpp" line="45"/>
         <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4712,33 +4712,33 @@ You are currently using:
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="47"/>
         <source>Customizable Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
         <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="96"/>
         <source>Group</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="128"/>
@@ -4748,7 +4748,7 @@ You are currently using:
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4756,7 +4756,7 @@ You are currently using:
     <message>
         <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="1341"/>
@@ -4769,7 +4769,7 @@ You are currently using:
     <message>
         <location filename="../fusesdialog.ui" line="14"/>
         <source>Fuses</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="20"/>
@@ -4786,12 +4786,12 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;Proper states for AtMega 2560 :&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;EEPROM erase fuse not set: D7, 11, FC&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;EEPROM erase fuse set: D7, 19, FC&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="35"/>
         <source>Read Fuses</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="42"/>
@@ -4810,13 +4810,13 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;When in doubt consult either the project&apos;s page or the 9xforum (http://9xforums.com/forum/)&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;If you do get locked out - google lookup for &amp;quot;dealing with Fuse Bricks&amp;quot;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="59"/>
         <source>Reset Fuses
 EEPROM - PROTECT</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="67"/>
@@ -4835,13 +4835,13 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;When in doubt consult either the project&apos;s page or the 9xforum (http://9xforums.com/forum/)&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;If you do get locked out - google lookup for &amp;quot;dealing with Fuse Bricks&amp;quot;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="84"/>
         <source>Reset Fuses
 EEPROM - DELETE</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="101"/>
@@ -4853,18 +4853,18 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600; text-decoration: underline;&quot;&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Changing the fuses can mess up your radio.&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Proceed only if you know what you are doing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.cpp" line="43"/>
         <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4872,32 +4872,32 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4905,78 +4905,78 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generaledit.ui" line="20"/>
         <source>Radio settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.ui" line="55"/>
         <source>Retrieve calib. and hw settings from profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.ui" line="84"/>
         <source>Store calib. and hw settings in selected profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.ui" line="105"/>
         <source>General settings used throught the transmitter.
 These will be relevant for all models in the same EEPROM.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4984,32 +4984,32 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="37"/>
         <source>Radio Menus</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="40"/>
         <source>Themes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="47"/>
         <source>Global Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="53"/>
         <source>Trainer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="61"/>
         <source>Model Menus</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="64"/>
         <source>Heli</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
@@ -5019,32 +5019,32 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
         <source>Curves</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="84"/>
         <source>Global Variables</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="91"/>
         <source>Logical Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="97"/>
         <source>Special Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="103"/>
         <source>Custom Mix Scripts</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="109"/>
         <source>Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -5052,186 +5052,186 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="467"/>
         <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="468"/>
         <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="468"/>
         <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="571"/>
         <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1003"/>
@@ -5259,206 +5259,206 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="20"/>
         <source>Readonly Unlock</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1039"/>
         <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="757"/>
         <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
@@ -5469,57 +5469,57 @@ p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;LCD Screen Contrast&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Values can be 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1887"/>
@@ -5542,133 +5542,133 @@ Mode 4:
   Right stick:  Elevator, Rudder
 
 </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1544"/>
         <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1701"/>
@@ -5676,213 +5676,213 @@ Mode 4:
 This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2041"/>
         <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2386"/>
         <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1806"/>
         <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1816"/>
         <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1821"/>
         <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1864"/>
         <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1212"/>
@@ -5901,39 +5901,39 @@ Acceptable values are 3v..12v</source>
         <location filename="../generaledit/generalsetup.ui" line="1378"/>
         <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1232"/>
         <location filename="../generaledit/generalsetup.ui" line="1383"/>
         <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1418"/>
@@ -5948,42 +5948,42 @@ Acceptable values are 3v..12v</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2519"/>
@@ -6006,67 +6006,67 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there&apos;s not a lot of memory left&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1587"/>
         <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1592"/>
         <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1597"/>
         <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1602"/>
         <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1607"/>
         <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2107"/>
@@ -6077,19 +6077,19 @@ p, li { white-space: pre-wrap; }
 2 - Normal.
 3 - Loud.
 4 - Extra loud.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1222"/>
         <location filename="../generaledit/generalsetup.ui" line="1639"/>
         <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6097,107 +6097,107 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
@@ -6212,64 +6212,64 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6277,17 +6277,17 @@ Are you sure ?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6295,113 +6295,113 @@ Are you sure ?</source>
     <message>
         <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="302"/>
         <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="361"/>
@@ -6416,7 +6416,7 @@ Are you sure ?</source>
     <message>
         <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6424,72 +6424,72 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/heli.ui" line="24"/>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="29"/>
         <source>120</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="34"/>
         <source>120X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="39"/>
         <source>140</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="44"/>
         <source>90</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="54"/>
         <source>Invert Elevator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="61"/>
         <source>Invert Aileron</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="68"/>
         <source>Invert Collective</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="77"/>
         <source>Long. cyc</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="103"/>
         <source>Invert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="123"/>
         <source>Swash Ring</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="130"/>
         <source>Swash Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="166"/>
         <source>Lateral cyc</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="231"/>
         <source>Collective</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6497,22 +6497,22 @@ Are you sure ?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6520,19 +6520,19 @@ Are you sure ?</source>
     <message>
         <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6542,157 +6542,157 @@ Are you sure ?</source>
         <location filename="../modeledit/inputs.cpp" line="416"/>
         <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="52"/>
         <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="53"/>
         <location filename="../modeledit/inputs.cpp" line="417"/>
         <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="55"/>
         <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="410"/>
         <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6700,32 +6700,32 @@ Are you sure ?</source>
     <message>
         <location filename="../labels.cpp" line="74"/>
         <source>Unable to add label &quot;%1&quot; to model &quot;%2&quot; not enough room</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="95"/>
         <source>Unable to rename &quot;%1&quot; to &quot;%2&quot; not enough room in model %3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="107"/>
         <source>Unable to rename &quot;%1&quot; to &quot;%2&quot; the label already exists</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="176"/>
         <source>Labels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="190"/>
         <source>New%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="192"/>
         <source>New</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6733,96 +6733,96 @@ Are you sure ?</source>
     <message>
         <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="146"/>
         <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="207"/>
         <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="229"/>
         <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="294"/>
         <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6830,17 +6830,17 @@ Are you sure ?</source>
     <message>
         <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6848,7 +6848,7 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6856,122 +6856,122 @@ Are you sure ?</source>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -6979,32 +6979,32 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="51"/>
@@ -7014,82 +7014,82 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -7097,170 +7097,170 @@ Are you sure ?</source>
     <message>
         <location filename="../logsdialog.ui" line="14"/>
         <source>Companion Log Viewer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="25"/>
         <source>Fly sessions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="42"/>
         <source>Save session CSV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="152"/>
         <source>Zoom</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="159"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="166"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="173"/>
         <source>Reset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="232"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="246"/>
         <source>Open LogFile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -7269,735 +7269,735 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
         <location filename="../mainwindow.cpp" line="132"/>
         <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="379"/>
         <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="386"/>
         <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="502"/>
         <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="564"/>
         <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="574"/>
         <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="590"/>
         <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="819"/>
         <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="249"/>
         <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="858"/>
         <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="857"/>
         <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="864"/>
         <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -8005,22 +8005,22 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message numerus="yes">
         <location filename="../mdichild.cpp" line="1125"/>
@@ -8033,260 +8033,260 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="365"/>
         <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="227"/>
         <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="363"/>
         <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message numerus="yes">
         <location filename="../mdichild.cpp" line="338"/>
@@ -8309,152 +8309,152 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="384"/>
         <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1326"/>
         <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -8462,108 +8462,108 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="57"/>
         <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="222"/>
@@ -8573,37 +8573,37 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -8611,12 +8611,12 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -8624,29 +8624,29 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="20"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="662"/>
         <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="667"/>
         <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="278"/>
@@ -8666,17 +8666,17 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="651"/>
@@ -8699,27 +8699,27 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If Delay is not zero the actuation of the mix will be delayed by the specified amount of seconds.&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If Slow is not zero then the speed of the mix will be set by the value specified -&amp;gt; the value states the number of seconds it takes to transit from -100 to 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="37"/>
@@ -8727,104 +8727,104 @@ p, li { white-space: pre-wrap; }
         <location filename="../modeledit/mixerdialog.ui" line="163"/>
         <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="44"/>
         <location filename="../modeledit/mixerdialog.ui" line="91"/>
         <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -8832,22 +8832,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -8856,135 +8856,135 @@ p, li { white-space: pre-wrap; }
         <location filename="../modeledit/mixes.cpp" line="45"/>
         <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="47"/>
         <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="48"/>
         <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="50"/>
         <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -8992,17 +8992,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1504"/>
@@ -9012,62 +9012,62 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1622"/>
         <source>Master/Jack</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1624"/>
         <source>Slave/Jack</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1626"/>
         <source>Master/SBUS Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1628"/>
         <source>Master/CPPM Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1630"/>
         <source>Master/Serial</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1632"/>
         <source>Master/Bluetooth</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1634"/>
         <source>Slave/Bluetooth</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1636"/>
         <source>Master/Multi</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1752"/>
@@ -9099,7 +9099,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../firmwares/modeldata.cpp" line="1750"/>
         <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -9107,68 +9107,68 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/modeledit.ui" line="20"/>
         <source>Dialog</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.ui" line="51"/>
         <source>Simulate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="114"/>
         <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -9176,47 +9176,47 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="42"/>
         <source>Global</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="43"/>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="44"/>
         <source>On</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="47"/>
         <source>Radio Menus</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="50"/>
         <source>Themes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="58"/>
         <source>Global Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="65"/>
         <source>Trainer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="74"/>
         <source>Model Menus</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="77"/>
         <source>Heli</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
@@ -9226,32 +9226,32 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
         <source>Curves</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="100"/>
         <source>Global Variables</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="108"/>
         <source>Logical Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="115"/>
         <source>Special Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="122"/>
         <source>Custom Mix Scripts</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="129"/>
         <source>Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -9259,191 +9259,191 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="151"/>
         <location filename="../modelprinter.cpp" line="291"/>
         <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="196"/>
         <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="199"/>
         <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="200"/>
         <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="202"/>
         <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="217"/>
         <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="222"/>
         <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="211"/>
         <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="283"/>
@@ -9452,47 +9452,47 @@ p, li { white-space: pre-wrap; }
         <location filename="../modelprinter.cpp" line="1018"/>
         <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="539"/>
@@ -9502,145 +9502,145 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="835"/>
         <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
         <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="942"/>
@@ -9650,169 +9650,169 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="981"/>
         <location filename="../modelprinter.cpp" line="998"/>
         <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="983"/>
         <location filename="../modelprinter.cpp" line="1000"/>
         <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1002"/>
         <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1004"/>
         <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1006"/>
         <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="301"/>
         <location filename="../modelprinter.cpp" line="323"/>
         <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="391"/>
         <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="371"/>
         <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="380"/>
         <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="443"/>
@@ -9822,32 +9822,32 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -9855,27 +9855,27 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -9883,28 +9883,28 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -9912,246 +9912,246 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/setup_module.ui" line="454"/>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="482"/>
         <source>CH </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="557"/>
         <source>Polarity</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="583"/>
         <source>Negative</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="588"/>
         <source>Positive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="606"/>
         <source>Receiver 1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="651"/>
         <location filename="../modeledit/setup_module.ui" line="687"/>
         <location filename="../modeledit/setup_module.ui" line="723"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="663"/>
         <source>Receiver 2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="699"/>
         <source>Receiver 3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="772"/>
         <source>WARNING: changing RF Output Power needs RE-BIND</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="788"/>
         <source>Low power mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="988"/>
         <source>Antenna</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1017"/>
         <source>RX Frequency</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1050"/>
         <source>Output type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1067"/>
         <source>Open Drain</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1072"/>
         <source>Push Pull</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1108"/>
         <source> Hz</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1024"/>
         <source>Option value</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="377"/>
         <source>Disable Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="384"/>
         <source>Disable Ch. Map</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="391"/>
         <source>Racing Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="398"/>
         <source>Raw 12 bits</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="835"/>
         <source>Channels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="507"/>
         <source>Receiver No.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="596"/>
         <source>RF Output Power</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="885"/>
         <source>PPM delay</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="910"/>
         <source> us</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="935"/>
         <source>PPM Frame Length</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="960"/>
         <source> ms</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="127"/>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="163"/>
         <source>Registration ID</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="183"/>
         <source>Multi Radio Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="212"/>
         <source>Sub Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="275"/>
         <source>WARNING: Requires non-certified firmware!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="288"/>
         <source>Failsafe Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="314"/>
         <source>Not set</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="319"/>
         <source>Hold</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="324"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="329"/>
         <source>No Pulses</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="334"/>
         <source>Receiver</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="348"/>
         <source>Trainer Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="418"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1121"/>
         <source>Option check</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1135"/>
         <source>Option combo</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1161"/>
         <source>Failsafe Positions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1203"/>
         <source>Show values in:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1210"/>
         <source>%</source>
         <extracomment>abbreviation for percent</extracomment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1223"/>
         <source>μs</source>
         <extracomment>abbreviation for microseconds</extracomment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -10159,12 +10159,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="59"/>
@@ -10174,275 +10174,275 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="334"/>
         <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="335"/>
         <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="335"/>
         <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -10450,57 +10450,57 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -10508,38 +10508,38 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="432"/>
         <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
@@ -10547,277 +10547,277 @@ p, li { white-space: pre-wrap; }
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="399"/>
         <location filename="../multimodelprinter.cpp" line="838"/>
         <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="793"/>
         <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="838"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="464"/>
         <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="318"/>
@@ -10825,139 +10825,139 @@ p, li { white-space: pre-wrap; }
         <location filename="../multimodelprinter.cpp" line="838"/>
         <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="488"/>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="493"/>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -10965,7 +10965,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -10973,22 +10973,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -10996,22 +10996,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11019,17 +11019,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11038,39 +11038,39 @@ p, li { white-space: pre-wrap; }
         <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11078,37 +11078,37 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../printdialog.ui" line="54"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../printdialog.ui" line="61"/>
         <source>Style</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../printdialog.ui" line="68"/>
         <source>Print</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../printdialog.ui" line="75"/>
         <source>Print to file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11116,12 +11116,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../profilechooser.ui" line="20"/>
         <source>Select Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../profilechooser.ui" line="43"/>
         <source>Profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11129,18 +11129,18 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../progressdialog.ui" line="20"/>
         <source>Flash Firmware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
         <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11148,7 +11148,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../progresswidget.ui" line="107"/>
         <source>Show Details</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11156,22 +11156,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11179,24 +11179,24 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodata.cpp" line="321"/>
         <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodata.cpp" line="325"/>
         <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11204,17 +11204,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
@@ -11224,32 +11224,32 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
@@ -11259,52 +11259,52 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11313,28 +11313,28 @@ p, li { white-space: pre-wrap; }
         <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="141"/>
         <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11342,12 +11342,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11355,17 +11355,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../radionotfound.ui" line="32"/>
         <source>No Radio Found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../radionotfound.ui" line="40"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No Radio was found!&lt;/p&gt;&lt;p&gt;Make sure that you hold the lower trim buttons towards the center while you turn it on.&lt;/p&gt;&lt;p&gt;Then connect the USB wire.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:&apos;arial,sans-serif&apos;; font-size:13px; font-style:italic; color:#222222; background-color:#ffffff;&quot;&gt;Note: if you have a Taranis that has not had the firmware upgraded to 2.0 then this version of Companion will not work.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../radionotfound.ui" line="92"/>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11373,32 +11373,32 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="68"/>
         <source>View:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="75"/>
         <source>Logical Switches</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="94"/>
         <source>Global Variables</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="113"/>
         <source>Channel Outputs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="132"/>
         <source>Mix Outputs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="210"/>
@@ -11407,7 +11407,7 @@ o
 g
 i
 c</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="287"/>
@@ -11417,7 +11417,7 @@ o
 b
 a
 l</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="362"/>
@@ -11429,7 +11429,7 @@ n
 e
 l
 s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="439"/>
@@ -11438,7 +11438,7 @@ i
 x
 e
 s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
@@ -11453,7 +11453,7 @@ s</source>
     <message>
         <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11461,7 +11461,7 @@ s</source>
     <message>
         <location filename="../simulation/widgets/radioswitchwidget.h" line="77"/>
         <source>Latch/unlatch the momentary switch.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11469,13 +11469,13 @@ s</source>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="99"/>
         <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
@@ -11544,94 +11544,94 @@ s</source>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="268"/>
@@ -11659,52 +11659,52 @@ s</source>
     <message>
         <location filename="../constants.h" line="92"/>
         <source>↑</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="93"/>
         <source>↓</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="94"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../constants.h" line="95"/>
         <source>!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
@@ -11838,53 +11838,53 @@ s</source>
         <location filename="../firmwares/rawswitch.cpp" line="68"/>
         <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="68"/>
         <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="223"/>
@@ -11910,17 +11910,17 @@ s</source>
     <message>
         <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11929,18 +11929,18 @@ s</source>
         <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11948,199 +11948,199 @@ s</source>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="141"/>
         <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="352"/>
         <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="362"/>
@@ -12150,77 +12150,77 @@ s</source>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="394"/>
@@ -12235,47 +12235,47 @@ s</source>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -12283,97 +12283,97 @@ s</source>
     <message>
         <location filename="../modeledit/setup.ui" line="28"/>
         <source>Timer 1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="245"/>
         <source>Top LCD Timer</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="71"/>
         <source>Model Image</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="267"/>
         <source>Warnings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="341"/>
         <source>Switch Warnings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="391"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="401"/>
         <source>Auto</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="145"/>
         <source>Model</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="454"/>
         <source>Center beep</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="588"/>
         <source>Interactive Checklist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="601"/>
         <source>ADC filter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="615"/>
         <source>Global</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="620"/>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="625"/>
         <source>On</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="642"/>
         <source>Edit Checklist...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="675"/>
         <source>Throttle trim switch</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="685"/>
         <source>Extended Trims</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="571"/>
         <source>Display Checklist</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="695"/>
         <source>Extended Limits</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="659"/>
@@ -12381,112 +12381,112 @@ s</source>
 If this is checked the throttle will be reversed.  Idle will be forward, trim will also be reversed and the throttle warning will be reversed as well.
 
 </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="668"/>
         <source>Reverse Throttle</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="652"/>
         <source>Throttle Trim Idle Only</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="535"/>
         <source>Throttle Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="479"/>
         <source>Exponential</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="195"/>
         <source>Hats Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="381"/>
         <source>Pot/Slider Warnings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="396"/>
         <source>ON</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="484"/>
         <source>Extra Fine</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="489"/>
         <source>Fine</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="494"/>
         <source>Medium</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="499"/>
         <source>Coarse</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="514"/>
         <source>Never</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="519"/>
         <source>On change</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="524"/>
         <source>Always</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="545"/>
         <source>Custom Throttle Warning</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="578"/>
         <source>Global Functions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="179"/>
         <source>Throttle Source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="211"/>
         <source>Trim Step</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="227"/>
         <source>Trims Display</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="320"/>
         <source>Timer 2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="161"/>
         <source>Timer 3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -12494,87 +12494,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -12582,7 +12582,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -12591,203 +12591,203 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
         <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="46"/>
         <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -12795,122 +12795,122 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -12923,219 +12923,219 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="52"/>
         <source>Radio Window</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="63"/>
         <source>Reload...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="70"/>
         <source>Tools</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="82"/>
         <source>Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="103"/>
         <source>Reload Lua Scripts</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="106"/>
         <source>Reload the Lua environment on the simulated radio.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="109"/>
         <source>F7</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="118"/>
         <source>Reload Radio Data</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="121"/>
         <source>Reload all radio data without restarting the simulator.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="124"/>
         <source>F9</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="133"/>
         <source>Key Mapping</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="136"/>
         <source>Show keyboard maping reference.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="139"/>
         <source>F1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="148"/>
         <source>Joystick Settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="151"/>
         <source>Open joystick configuration settings dialog.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="154"/>
         <source>F3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="163"/>
         <source>LCD Screenshot</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="166"/>
         <source>Save a screenshot of the current simulated LCD screen.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="169"/>
         <source>F8</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="177"/>
         <source>Dock In Main Window</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="180"/>
         <source>Show the radio in the main window or as a separate &quot;floating&quot; window.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="188"/>
         <source>Menu Bar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="191"/>
         <source>Show or hide the top menu bar.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="194"/>
         <source>Alt+M</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="202"/>
         <source>Constrain Width</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="205"/>
         <source>Set radio widget width to be a fixed size.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="213"/>
         <source>Constrain Height</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="216"/>
         <source>Set radio widget height to be a fixed size.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13143,149 +13143,149 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="20"/>
         <source>EdgeTX Simulator - Startup Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="74"/>
         <source>Radio Profile:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="87"/>
         <source>Existing radio profiles are shown here.&lt;br /&gt;
 Create or edit profiles using the Companion application.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="95"/>
         <source>Radio Type:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="108"/>
         <source>Existing radio simulators are shown here.&lt;br /&gt;
 The radio type specified in the selected profile is used by default.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="116"/>
         <source>Data Source:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="123"/>
         <source>Data File:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="130"/>
         <source>Data Folder:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="137"/>
         <source>SD Image Path:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="168"/>
         <source>Radio data (.etx) settings file to use. A new file with default settings will be created if necessary.&lt;br /&gt;
 &lt;b&gt;NOTE&lt;/b&gt;: any existing data incompatible with the selected radio type may be overwritten!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="360"/>
         <source>Simulator:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="176"/>
         <source>Select data file...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="38"/>
         <source>Simulator Startup Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="179"/>
         <location filename="../simulation/simulatorstartupdialog.ui" line="231"/>
         <location filename="../simulation/simulatorstartupdialog.ui" line="283"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="220"/>
         <source>Directory containing RADIO and MODELS folders to use.&lt;br /&gt;
 New folder(s) with default radio/model will be created here if necessary.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="228"/>
         <source>Select data folder...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="272"/>
         <source>Directory containing the SD card image to use.&lt;br/&gt;
 The default is configured in the chosen Radio Profile.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="280"/>
         <source>Select SD card image folder...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="306"/>
         <source>Select which of the data sources (File/Folder/SD Card) you would like to start the simulator with.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="327"/>
         <source>File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="337"/>
         <source>Folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="347"/>
         <source>SD Path</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13293,67 +13293,67 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../simulation/simulatorwidget.ui" line="20"/>
         <source>Companion Simulator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="842"/>
@@ -13371,12 +13371,12 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../simulation/widgets/sliderwidget.h" line="37"/>
         <source>Right-double-click to reset to center.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/widgets/sliderwidget.h" line="37"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13385,22 +13385,22 @@ The default is configured in the chosen Radio Profile.</source>
         <location filename="../splashlibrarydialog.ui" line="47"/>
         <location filename="../splashlibrarydialog.ui" line="879"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13408,7 +13408,7 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13416,7 +13416,7 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13427,45 +13427,45 @@ The default is configured in the chosen Radio Profile.</source>
         <location filename="../styleeditdialog.cpp" line="61"/>
         <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../styleeditdialog.ui" line="88"/>
         <source>&amp;Reset to default</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../styleeditdialog.ui" line="101"/>
         <source>&amp;Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../styleeditdialog.ui" line="114"/>
         <source>&amp;OK</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../styleeditdialog.ui" line="129"/>
         <source>This feature does not validate your changes and assumes you are familiar with CSS syntax for QT.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13473,47 +13473,47 @@ Error: %2</source>
     <message>
         <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13521,141 +13521,141 @@ Error: %2</source>
     <message>
         <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13663,17 +13663,17 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13681,22 +13681,22 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13704,86 +13704,86 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry.ui" line="75"/>
         <source>Alarm 1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="117"/>
         <location filename="../modeledit/telemetry.ui" line="214"/>
         <source>----</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="122"/>
         <location filename="../modeledit/telemetry.ui" line="219"/>
         <source>Yellow</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="127"/>
         <location filename="../modeledit/telemetry.ui" line="224"/>
         <source>Orange</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="132"/>
         <location filename="../modeledit/telemetry.ui" line="229"/>
         <source>Red</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="200"/>
         <source>Alarm 2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="181"/>
         <source>Disable telemetry audio warnings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="276"/>
         <source>A1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="310"/>
         <source>A2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="352"/>
         <source>Sink Max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="462"/>
         <source>Climb Max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="478"/>
         <source>Sink Min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="494"/>
         <source>Climb Min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="510"/>
         <source>Center Silent</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="532"/>
         <source>Vario limits</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="545"/>
         <source>Vario source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="53"/>
@@ -13793,97 +13793,97 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry.ui" line="568"/>
         <source>Altimetry</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="602"/>
         <source>Altitude source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="615"/>
         <source>Volts source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="638"/>
         <source>Top Bar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="706"/>
         <source>Volt source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="748"/>
         <source>Current source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="783"/>
         <source>Blades</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="790"/>
         <source>mAh count</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="803"/>
         <source> mAh</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="819"/>
         <source> A</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="844"/>
         <source>FAS Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="851"/>
         <source>Persistent mAh</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="870"/>
         <source>Various</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="883"/>
         <source>Serial Protocol</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="897"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="902"/>
         <source>FrSky Sensor Hub</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="945"/>
         <source>Sensors</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="952"/>
         <source>Disable multi sensor handling</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="959"/>
         <source>Show Instance IDs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -13891,108 +13891,108 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="34"/>
         <source>Unit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="47"/>
         <source>Max Value</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="60"/>
         <source>Alarm 1    </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="74"/>
         <location filename="../modeledit/telemetry_analog.ui" line="137"/>
         <source>----</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="79"/>
         <location filename="../modeledit/telemetry_analog.ui" line="142"/>
         <source>Yellow</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="84"/>
         <location filename="../modeledit/telemetry_analog.ui" line="147"/>
         <source>Orange</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="89"/>
         <location filename="../modeledit/telemetry_analog.ui" line="152"/>
         <source>Red</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="104"/>
         <location filename="../modeledit/telemetry_analog.ui" line="167"/>
         <source>&lt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="109"/>
         <location filename="../modeledit/telemetry_analog.ui" line="172"/>
         <source>&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="123"/>
         <source>Alarm 2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="265"/>
         <source>Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="279"/>
         <source>Volts (V)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="284"/>
         <source>Amps (A)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="289"/>
         <source>Speed (m/s or ft/s)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="294"/>
         <source>Raw (-)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="299"/>
         <source>Speed (km/h or miles/h)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="304"/>
         <source>Meters (m or ft)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="309"/>
         <source>Temp (°)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="314"/>
         <source>Fuel (%)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="319"/>
         <source>mAmps (mA)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -14000,27 +14000,27 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="34"/>
         <source>Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="82"/>
         <source>Min</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="92"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="102"/>
         <source>Gauge</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="112"/>
         <source>Max</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -14028,7 +14028,7 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -14036,27 +14036,27 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -14997,27 +14997,27 @@ hh:mm:ss</source>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="80"/>
         <source>Id</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="109"/>
         <source>Instance</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="135"/>
         <source>Rx</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="186"/>
         <source>Cells Sensor :</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="200"/>
@@ -15029,77 +15029,77 @@ hh:mm:ss</source>
         <location filename="../modeledit/telemetry_sensor.ui" line="339"/>
         <location filename="../modeledit/telemetry_sensor.ui" line="354"/>
         <source>---</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="224"/>
         <source>GPS Sensor :</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="252"/>
         <source>Alt. Sensor :</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="280"/>
         <source>Sensor :</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="38"/>
         <source>TELE##</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="378"/>
         <source>Precision</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="394"/>
         <source>Ratio</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="401"/>
         <source>Blades</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="436"/>
         <source>Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="443"/>
         <source>Multiplier</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="475"/>
         <source>Auto Offset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="485"/>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="495"/>
         <source>Persistent</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="505"/>
         <source>Positive</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="515"/>
         <source>Logs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15107,72 +15107,72 @@ hh:mm:ss</source>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15180,78 +15180,78 @@ hh:mm:ss</source>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="19"/>
         <source>Telemetry Simulator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
         <source>When enabled, sends any non-blank values as simulated telemetry data.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="482"/>
@@ -15290,37 +15290,37 @@ Timestamp</source>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15328,17 +15328,17 @@ Timestamp</source>
     <message>
         <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
-        <translation type="unfinished">No</translation>
+        <translation>No</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15346,17 +15346,17 @@ Timestamp</source>
     <message>
         <location filename="../modeledit/setup_timer.ui" line="67"/>
         <source>Countdown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_timer.ui" line="77"/>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_timer.ui" line="87"/>
         <source>Minute Call</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15364,138 +15364,138 @@ Timestamp</source>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15503,22 +15503,22 @@ Timestamp</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15526,27 +15526,27 @@ Timestamp</source>
     <message>
         <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15554,7 +15554,7 @@ Timestamp</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15766,68 +15766,68 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="36"/>
         <source>Would you like to open the disk image to install the new version of Companion?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="41"/>
         <location filename="../updates/updatecompanion.cpp" line="46"/>
         <source>Would you like to launch the Companion installer?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="52"/>
         <source>No install process support for your operating system</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="56"/>
         <source>Companion</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15835,7 +15835,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="26"/>
         <source>Firmware</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="56"/>
@@ -15855,7 +15855,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="64"/>
@@ -15865,17 +15865,17 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -15883,12 +15883,12 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="137"/>
@@ -15897,28 +15897,28 @@ Timestamp</source>
         <location filename="../updates/updateinterface.cpp" line="523"/>
         <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="699"/>
         <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="121"/>
@@ -15933,7 +15933,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="419"/>
@@ -15968,12 +15968,12 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="719"/>
@@ -16019,17 +16019,17 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="1161"/>
@@ -16055,145 +16055,145 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="205"/>
         <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="209"/>
         <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="210"/>
         <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="252"/>
         <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="259"/>
         <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="263"/>
         <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="275"/>
         <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="613"/>
         <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16201,7 +16201,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatemultiprotocol.cpp" line="25"/>
         <source>Multiprotocol</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16209,22 +16209,22 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="218"/>
@@ -16234,7 +16234,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="297"/>
@@ -16262,7 +16262,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="101"/>
         <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="93"/>
@@ -16272,28 +16272,28 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="266"/>
         <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="270"/>
         <source>URL: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="67"/>
         <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="72"/>
         <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16301,83 +16301,83 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="20"/>
         <source>Advanced Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="28"/>
         <source>Current Release:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="41"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="54"/>
         <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="63"/>
         <source>Assets</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="51"/>
         <source>Clear current release information. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="80"/>
         <location filename="../updates/updateoptionsdialog.cpp" line="149"/>
         <source>Filter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="115"/>
         <source>Max.Expected</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="119"/>
         <source>No Limit</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="123"/>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="127"/>
         <source>Decompress</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="132"/>
         <source>Install</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="144"/>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="179"/>
         <source>Sub folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16385,32 +16385,32 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16418,27 +16418,27 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="27"/>
         <source>SD Card</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16446,27 +16446,27 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatesounds.cpp" line="31"/>
         <source>Sounds</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16474,7 +16474,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatestatus.cpp" line="59"/>
         <source>Update Interface</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16482,7 +16482,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatethemes.cpp" line="25"/>
         <source>Themes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16490,12 +16490,12 @@ Timestamp</source>
     <message>
         <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="89"/>
@@ -16503,42 +16503,42 @@ Timestamp</source>
   - %1
 
 Process now?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16546,140 +16546,140 @@ Process now?</source>
     <message>
         <location filename="../updates/updatesdialog.ui" line="23"/>
         <source>Process Updates</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="35"/>
         <source>Folders</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="41"/>
         <source>Download</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="51"/>
         <source>Update</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="58"/>
         <source>Create sub-folders in Download folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="75"/>
         <source>Decompress</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="82"/>
         <source>Use Radio Profile SD structure</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="102"/>
         <location filename="../updates/updatesdialog.ui" line="112"/>
         <location filename="../updates/updatesdialog.ui" line="119"/>
         <source>Select folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="135"/>
         <source>Components</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="142"/>
         <location filename="../updates/updatesdialog.cpp" line="207"/>
         <source>Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="148"/>
         <source>Delete downloads</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="155"/>
         <source>Delete decompressions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="39"/>
         <source>Downloading Release Metadata</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="105"/>
         <source>Select your download folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="112"/>
         <source>Select your decompress folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="119"/>
         <source>Select your update destination folder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="145"/>
         <source>Name</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="148"/>
         <source>Channel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="151"/>
         <source>Current</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="154"/>
         <source>Update to</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="174"/>
         <source>Retrieving latest release information for %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16687,32 +16687,32 @@ Process now?</source>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16720,12 +16720,12 @@ Process now?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16733,7 +16733,7 @@ Process now?</source>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
@@ -16758,17 +16758,17 @@ Process now?</source>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16776,12 +16776,12 @@ Process now?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16789,22 +16789,22 @@ Process now?</source>
     <message>
         <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -16812,247 +16812,247 @@ Process now?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="43"/>
         <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="43"/>
         <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="49"/>
         <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="49"/>
         <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="113"/>
         <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="127"/>
@@ -17063,22 +17063,22 @@ Process now?</source>
         <location filename="../wizarddialog.cpp" line="149"/>
         <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -17086,37 +17086,37 @@ Process now?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -17125,44 +17125,44 @@ Process now?</source>
         <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="93"/>
         <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -17186,14 +17186,14 @@ Model and radio settings may be corrupted if you continue.</source>
 Current firmware profile board will be used.
 
 Do you wish to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -17216,42 +17216,42 @@ Model settings may be corrupted if you continue.</source>
     <message>
         <location filename="../burnconfigdialog.ui" line="26"/>
         <source>Programmer Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="76"/>
         <location filename="../burnconfigdialog.ui" line="106"/>
         <source>Location of sam-ba executable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="79"/>
         <location filename="../burnconfigdialog.ui" line="109"/>
         <location filename="../burnconfigdialog.ui" line="142"/>
         <source>The location of the AVRDUDE executable.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="89"/>
         <source>DFU-Util Location</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="175"/>
         <location filename="../burnconfigdialog.ui" line="185"/>
         <source>Use this button to browse and look for the AVRDUDE executable file.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="178"/>
         <location filename="../burnconfigdialog.ui" line="188"/>
         <source>Browse...</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="159"/>
         <source>Extra arguments that will be passed to AVRDUDE on every call</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="162"/>
@@ -17259,70 +17259,70 @@ Model settings may be corrupted if you continue.</source>
 This can be used for providing extra information to AVRDUDE.
 
 Please only use this if you know what you are doing.  There are no error checks and you could cripple your controller.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="129"/>
         <source>Port</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="51"/>
         <source>CPU of your TX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="54"/>
         <source>CPU present on your 9x radio
 Should be m64 for stock radios
 m2560 for v4.1 boards</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="68"/>
         <source>at91sam3s8-9xr</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="96"/>
         <source>SAM-BA Location</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="119"/>
         <source>ARM MCU</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="139"/>
         <source>sam-ba serial port</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="152"/>
         <source>Alternate device</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="202"/>
         <source>Use advanced controls</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.cpp" line="138"/>
         <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -17330,99 +17330,99 @@ m2560 for v4.1 boards</source>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="20"/>
         <source>Configure Joystick</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="65"/>
         <source>Instructions</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="103"/>
         <source>Enable</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="120"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="149"/>
         <source>Back</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="165"/>
         <source>Start</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="178"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="158"/>
         <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 </TS>

--- a/companion/src/translations/companion_es.ts
+++ b/companion/src/translations/companion_es.ts
@@ -5338,7 +5338,7 @@ Estos puede ser relevantes para todos los modelos en el mismo EEPROM.</translati
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1005"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Modo 2 (RUD THR ELE AIL)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1007"/>

--- a/companion/src/translations/companion_es.ts
+++ b/companion/src/translations/companion_es.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Sí, controlado por un único canal</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Sí, controlado por dos canales</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;Canal primer alerón:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>Canal segundo alerón:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Sí, controlado por un único canal</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Sí, controlado por dos canales</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;Primer canal aerofreno:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>Segundo canal aerofreno:</translation>
     </message>
@@ -60,24 +60,24 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation>Los ajustes de la aplicación han sido grabados a
 .%1</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation>No se han podido grabar los ajustes de la aplicación en el archivo &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation>porque el archivo no se ha podido grabar (revisa los permisos).</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation>por causas desconocidas.</translation>
     </message>
@@ -170,22 +170,22 @@
         <translation>Perfil de radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>Orden prederterminado canales</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>Modo prederterminado sticks</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>Seleccionar imagen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -226,662 +226,657 @@ Modo 4:
 </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Modo 1 (RUD ELE THR AIL)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Modo 2 (RUD THR ELE AIL)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Modo 3 (AIL ELE THR RUD)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Modo 4 (AIL THR ELE RUD)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>Pantalla de inicio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>La carpeta específica del perfil, si está fijada, anulará la carpeta de copia de seguridad general</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>Carpeta de copia de seguridad</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>Si está fijado anulará los ajustes generales de la aplicación&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>si está fijado anulará la copia de seguridad general&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orden de los canales&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Define el orden por defecto de las mezclas en un nuevo modelo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished">Opciones</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>Selecciona carpeta</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation>Mostrar pantalla de inicio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished">Perfiles de radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>Selecciona ejecutable</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation>Canal de distribución</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>Ganancia de volumen del simulador</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation>Controles de simulador</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation>Guardar las posiciones de interruptores/pots al salir del simulador</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation>Limpiar las posiciones guardadas</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>Nombre de perfil</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>Limpiar imagen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>Tipo de radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>Otros ajustes</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>Ajustes generales</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>Estructura de archivos SD</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>Ajustes de la aplicación</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>Activar copia de seguridad automática antes de escribir el firmware</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>Librería de pantallas de inicio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Ejecutable Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>Mostrar sólo pantallas de inicio de usuario</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>Mostrar pantallas de inicio de usuario y companion</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>Pantallas de inicio de usuario</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>Carpeta copia de seguridad automática</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>Ajustes del simulador</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>Luz de fondo del simulador</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>Activado</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation>ficheros usados recientemente</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation>Ajustes de inicio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation>Recordar</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation>Carpeta de reportes</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Esta opción mantiene el comportamiento de las versiones anteriores de OpenTx donde se conservan los slots de modelos vacíos cuando se elimina o mueve un modelo. &lt;/p&gt;&lt;p&gt;Cuando esta opción no está seleccionada, los otros modelos pueden reordenarse para llenar el hueco dejado por el modelo borrado.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation>Reporte de depuración</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation>Aplicación (Companion/simulador)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Mantiene un log para todos los mensajes generados por el firmware de la radio mientras se ejecuta en el simulador. Esta es la misma información que se vería en el simulador &lt;span style=&quot; font-style:italic;&quot;&gt;Salida de depuración&lt;/span&gt; ventana.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation>Radio firmware (en simulador)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation>Accioń en nuevo modelo</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation>Preguntar por perfil de radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>Azul</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>Rojo</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>Naranja</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>Amarillo</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation>Carpeta de capturas de pantalla</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>Joystick</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>Calibrar</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>Sólo capturar al portapapeles</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Mi radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;No puedes cambiar el tipo de radio o las opciones del firmware mientras hay cambios sin guardar ¿Qué quieres hacer?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Guardar todo&lt;/i&gt; - Guardar los archivos abiertos andtes de guardar los ajustes.&lt;li&gt;&lt;li&gt;&lt;i&gt;Resetear&lt;/i&gt; - Volver al tipo de radio y opciones de firmware anteriores antes de salvar los los ajustes.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancelar&lt;/i&gt; - Volver a la ventana de edición de ajustes.&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Selecciona la carpeta de capturas</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>No se han encontrado joysticks</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>VACÍO: No se han guardado ajustes en el perfil de tu radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>DISPONIBLE:Ajustes de radio de antigüedad desconocida</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>DISPONIBLE: Ajustes de radio guardados %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Selecciona tu carpeta de librerías</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Selecciona la carpeta de seguridad de tus modelos y ajustes</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation>Selecciona una carpeta para los reportes de la aplicación</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Selecciona el ejecutable de Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Selecciona la carpeta que replica la estructura de tu tarjeta SD</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Abre imagen para cargar</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Imágenes (%1)</translation>
     </message>
@@ -889,31 +884,31 @@ Modo 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation>Error leyendo %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation>No se puede guardar la EEPROM</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>No se puede abrir el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Error escribiendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation>Archivo binario de la EEPROM no válido %1</translation>
     </message>
@@ -951,33 +946,33 @@ Modo 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -988,255 +983,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation>Izquierda horizontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation>Izquierda vertical</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation>Derecha vertical</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation>Derecha horizontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">Vuelo</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Pos con fijador</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2 posiciones palanca</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 posiciones</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 posiciones</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Función</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">Estándar</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">Pequeño</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">Ambos</translation>
     </message>
@@ -1244,17 +1249,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation>Amp. negativa</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation>Valor medio</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation>Amp. positiva</translation>
     </message>
@@ -1262,132 +1267,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation>Centro PPM</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation>Subtrim lineal</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation>Menú emergente disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation>Borrar canal ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation>Cortar canal ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation>Limpiar canal ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation>Limpiar todos los canales ¿Estás seguro?</translation>
     </message>
@@ -1430,61 +1435,61 @@ Error description: %4</source>
         <translation>Archivo: desconocido</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation>Abrir lista de verificación</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation>Ficheros de verificación (*.txt)</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation>Lista de verificación del modelo</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation>No se puede abrir el archivo para escritura %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation>No se puede escribir en el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>No se puede escribir el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>No se puede abrir el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>No se puede leer el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation>Línea %1, Col %2</translation>
     </message>
@@ -1500,12 +1505,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1513,174 +1518,184 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation>Ajustes aplicación</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation>archivos</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation>Ajustes de radio y modelos</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation>Selecciona o crea un archivo para exportar los ajustes:</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation>Presiona el botón de &apos;Reintentar&apos; para elegir otro archivo.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation>El simulador para este firmware aún no está disponible</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation>Error durante el arranque del simulador.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation>Error del simulador</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation>Error de carga de datos</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation>Ha ocurrido un error al arrancar el simulador.</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;El tipo de radio en el perfil seleccionado no existe. Usando en su lugar el tipo predeterminado.&lt;/p&gt; &lt;p&gt;&lt;b&gt;¡Por favor, actualiza los ajustes del perfil!&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation>Los ajustes guardados no pudieron ser importafos, por favor inténtalo de nuevo con los ajustes actuales.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation>Importar desde archivo</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation>No importar</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation>Se ha encontrado archivo(s) de ajustes de Companion
 ¿Quieres importar los ajustes desde un archivo?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation>Importar ajustes desde un archivo, o empezar con los valores actuales.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation>Selecciona %1:</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation>Guardar ajustes aplicación a archivo...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation>Cargar ajustes de aplicación desde archivo o versión previa...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation>Resetea TODOS los ajustes de la aplicación y eliminar los perfiles de radio...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation>Salir antes de inicializar ajustes y arrancar aplicación.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation>Muestra número de de versión y sale.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation>Muestra este texto de ayuda.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation>Resetea TODOS los ajustes a valores predeterminados y elimina los perfiles de radio, ¿estás seguro?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation>¿Quieres hacer una copia primero?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation>Los ajustes de la aplicación fueron reseteados y guadados.</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation>ajustes</translation>
     </message>
@@ -1718,22 +1733,22 @@ Do you want to import settings from a file?</source>
         <translation>Imprimir a archivo</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation>Modelo sin nombre %1</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation>Presiona para eleminar este modelo.</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Imprimir documento</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>Seleccionar archivo de salida PDF</translation>
     </message>
@@ -1759,7 +1774,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>OK, entiendo.</translation>
     </message>
@@ -1767,17 +1782,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>Error de escritura</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>No se puede escribir %1 (razón: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation>No se puede abrir %1 (razón: %2)</translation>
     </message>
@@ -1785,22 +1800,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished">Estándar</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizado</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished">%1 puntos</translation>
     </message>
@@ -1883,32 +1898,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished">Tamaño punto</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">Lineal</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">Expo único</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">Simétricas f(x)=-f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">Simétricas f(x)=f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1916,7 +1931,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1924,22 +1939,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizado</translation>
     </message>
@@ -1947,113 +1962,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation>Menú emergente disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2061,343 +2076,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation>Invalidar %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation>Entrenador RUD</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation>Entrenador ELE</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation>Entrenador THR</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation>Entrenador AIL</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation>Canales entrenador</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation>Trim instantáneo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation>Reproducir sonido</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation>Reproducir haptic</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation>Resetear</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished">Reproducir una vez, no durante el inicio</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished">No repetir</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished">Valor</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation type="unfinished">Fuente</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation>Variómetro</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation>Reproducir pista</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation>Reproducir ambos</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation>Reproducir valor</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation>Reportes SD</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation>Volumen</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation>Luz de fondo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation>Captura</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation>Música de fondo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation>Pausar música de fondo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation>Ajustar %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation>Bind módulo interno</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation>Bind módulo externo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation>Vuelo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation>Telemetría</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation>DESABILITADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation></translation>
     </message>
@@ -2405,126 +2440,126 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Interruptor</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Parámetros</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation>Menú deplegable disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation>Ha ocurrido un error al reproducir el sonido, posiblemente el archivo ya está abierto. (Err: %1 [%2])</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation>No se puede encontrar o abrir el archivo de sonido:
 %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translatorcomment>Borrar función ¿Estás seguro?</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translatorcomment>Cortar función especial ¿Estás seguro?</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation>Limpiar función ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation>Limpiar todas funciones ¿Estás seguro?</translation>
     </message>
@@ -2532,22 +2567,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished">Números</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">Barras</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished">Script</translation>
     </message>
@@ -2555,47 +2590,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">Modo de vuelo</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2652,82 +2687,82 @@ Do you want to import settings from a file?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation>Nombre de imagen</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>Abrir archivo de firmware</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>No se puede cargar la imagen incrustada en el archivo de firmware %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>Abrir imagen para cargar</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>Imágenes (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>No se puede cargar el archivo de imagen %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>No se puede cargar el archivo de perfil %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>No se puede cargar la librería de imagen %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>Archivo guardado</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>La imagen ha sido guardada al archivo %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>Error en el refresco de Imagen</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>Fallo al refrescar la imagen del archivo %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>Error en el guardado del archivo</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>Fallo al escribir la imagen a %1</translation>
     </message>
@@ -2735,22 +2770,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation></translation>
     </message>
@@ -2758,53 +2793,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation>Error de conversión en el campo %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation>Interruptor</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation>Interruptor </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation> no puede ser exportada en esta placa!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation>¡La fuente %1 no puede ser exportada a esta placa!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation>OpenTX sólo acepta %1 puntos en todas las curvas</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation>OpenTX sólo acepta %1 puntos en todas las curvas</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation>OpenTX en esta placa no acepta esa función</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation>OpenTX no acepta este protocolo de radio</translation>
     </message>
@@ -2812,52 +2847,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished">Activado</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished">APAGADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished">Falso</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished">Verdadero</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished">Sí</translation>
     </message>
@@ -2937,102 +2972,83 @@ Para &lt;b&gt;eliminar una entrada recordada&lt;/b&gt; desde la lista de filtros
         <translation>Apaga/enciende el filtro.</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;El filtro admite dos tipos de sintaxis: coincidencia básica con comodines comunes y  expresiones regulares Perl-style (&lt;code&gt;pcre&lt;/code&gt;).&lt;/p&gt;&lt;p&gt;Por defecto, un filtro solo mostrará líneas que coinciden (&lt;b&gt;inclusivo&lt;/b&gt;). Para hacer un filtro &lt;b&gt;exclusivo&lt;/b&gt; que elimine la lineas con coincidencias, prefija la expresión del filtro con un &lt;kbd&gt;!&lt;/kbd&gt; (símbolo de exclamación).&lt;/p&gt;&lt;p&gt;Para usar &lt;b&gt;expresiones regulares&lt;/b&gt; (RegEx), prefija el filtro de texto con un &lt;kbd&gt;/&lt;/kbd&gt; (barra oblicua) o &lt;kbd&gt;^&lt;/kbd&gt; (et). &lt;ul&gt;&lt;li&gt;Pon el &lt;kbd&gt;/&lt;/kbd&gt; o &lt;kbd&gt;^&lt;/kbd&gt; después del indicador exclusivo &lt;kbd&gt;!&lt;/kbd&gt; si estás usando uno.&lt;/li&gt;&lt;li&gt; Por defecto, la coincidencia distingue entre mayúsculas y minúsculas. Para hacerlo insensible, agrega el operador típico&lt;kbd&gt;/i&lt;/kbd&gt; (barra invertida) al final del RegEx.&lt;/li&gt;&lt;li&gt;Si usas un et (^) para indicar RegEx, se convertirá en parte del Reg. Ex. (esto es, coincidencia desde el incio de línea).&lt;/li&gt;&lt;li&gt;Si el RegEx no es válido, el campo de edición del filtro mostrará un borde rojo y no se podrá habilitar el filtro.&lt;/li&gt;&lt;li&gt;Encuentra un recurso útil para probar RE (con una referencia completa) en &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;Para usar &lt;b&gt;coincidencia básica&lt;/b&gt; simplemente teclee cualquier texto.&lt;ul&gt;&lt;li&gt;Comodines: &lt;kbd&gt;*&lt;/kbd&gt; (asterisco) coincidencia de ningúno o más caracter(es), y &lt;kbd&gt;?&lt;/kbd&gt; (símbolo de interrogación) coincidecia de caracteres individuales.&lt;/li&gt;&lt;li&gt;La coincidecia es insensible a mayús/minus.&lt;/li&gt;&lt;li&gt;La coincidencia siempre empieza desde el inicio de la línea de reporte. Para ignorar caracteres al inicio, usa un comodín de comienzo &lt;kbd&gt;*&lt;/kbd&gt;.&lt;/li&gt;&lt;li&gt;De final &lt;kbd&gt;*&lt;/kbd&gt; está siempre implícito (esto es, cualquier coincidecia hasta el final de la línea de reporte). Para evitar esto, use ub RegEx.&lt;/li&gt;&lt;li&gt;Puedes hacer coincidir con caracteres comodines prefijándolos con el carácter &lt;kbd&gt;\&lt;/kbd&gt; (barra invertida) (ej. &quot;foo\*bar&quot; coincide &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;Después de &lt;b&gt;editar texto&lt;/b&gt;, presiona la tecla ENTER o TAB (o haz click fuera del texto para actualizar el filtro.&lt;/p&gt;&lt;p&gt;Para &lt;b&gt;eliminar una entrada&lt;/b&gt; de la lista de selección de filtro, primero selecciónala, y mientras estás en la linea del editor pulsa la combinación de teclas &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (o &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;). Los filtros predeterminados no se pueden eliminar. Se guardan hasta 50 filtros.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation>Ayuda del filtro de la consola de depuración</translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation>Descargando: </translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation>Descarga fallida: %1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation>Posibles causas de esto:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation>- Eeprom es de una versión más nueva de OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation>- Eeprom no es de OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation>- Eeprom no es de ErSky9X</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation>- Tamaño de eeprom no es válido</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation>- Sistema de archivos de eeprom no es válido</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation>- Eeprom es de una placa desconocida</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation>- Eeprom es de una placa errónea</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation>- Backup de Eeprom no soportado</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation>- Algo que no pudo ser adivinado, lo siento</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation>Advertencia:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation>Tu radio probablemente usa un firmware erróneo,
  el tamaño de la eeprom es de 4096 pero sólo los primeros 2048 son usados</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation>Tu eeprom es de una vesión anterior de OpenTX, actualizando!
@@ -3042,12 +3058,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3055,12 +3071,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation>No se puede abrir %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation>Fichero EEPROM %1 no válido</translation>
     </message>
@@ -3068,12 +3084,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;Primer canal de elevón:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>Segundo canal de elevón:</translation>
     </message>
@@ -3081,42 +3097,42 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Error abriendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Error escribiendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3124,23 +3140,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished">APAGADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3148,111 +3164,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Nombre entrada</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Modos de vuelo</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Interruptor</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Nombre de línea</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Lado stick</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>Escala</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Incluir trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>Curva aplicada a la fuente.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Offset</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>La fuente de la mezcla</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>Fuente para la mezcla.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Interruptor usado para activar la linea.
-Si está en blanco entonces las entradas son consideradas ON todo el tiempo.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>TODO</translation>
     </message>
@@ -3262,22 +3262,22 @@ Si está en blanco entonces las entradas son consideradas ON todo el tiempo.</tr
         <translation>Editar %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation>Disponible menú desplegable</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation>Fijar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation>Invertir todo</translation>
     </message>
@@ -3285,22 +3285,22 @@ Si está en blanco entonces las entradas son consideradas ON todo el tiempo.</tr
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>Canal de acelerador:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>Canal de viraje:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>Canal de inclinación:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>Canal de balanceo:</translation>
     </message>
@@ -3308,109 +3308,109 @@ Si está en blanco entonces las entradas son consideradas ON todo el tiempo.</tr
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation>Sincroniza ficheros</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation>¿Seguro que quieres abortar la sincronización?</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation>Como manejar sobreescritura de archivos que ya existen en la carpte de destino.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation>Sólo copiar si es más reciente y diferente (comparar contenido)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation>Sólo copiar si más reciente (no comparar contenido)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation>Copiar si es diferente (ignora marcas de tiempo del archivo)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation>Siempre copia (fuerza sobreescritura de archivos existentes)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation>Cualquier tamaño</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation>Omitir archivos mayores de este tamaño. Cero para ilimitado.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation>Mínimo nivel de reporte. Eventos de este tipo y de mayor importancia son mostrados.
 ADVERTENCIA: Altos niveles de reporte pueden hace que la interfaz de usuario  no responda temporalemente.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation>Omitido</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation>Creado</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation>Actualizado</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation>Sólo errores</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation>Sólo Test-run</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation>Ejecución normal pero no copia nada. Útil para verificar resultados antes de una sincronización real.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation>Nivel de reporte:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation>Filtros:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
@@ -3419,156 +3419,156 @@ El filtro &quot;Excluye&quot; omitirá archivos que coincidan con el patrón(es)
 El filtro Incluye es evaluado primero.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation>Uno o más patrones de archivos a excluir, separados por comas.
 Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Uno o más patrones de archivos a incluir, separados por comas.
 Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation>Incluye:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation>Excluye:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation>Distingue mayús/minus</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation>Sigue links</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation>Incluye ocultos</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation>Recursivo</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation>Omitir vacíos</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation>Aplica filtros</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation>Opciones de filtro:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation>Opciones de carpeta:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation>Muestra opciones extra</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation>Resetear a predeterminados</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation>Dirección de sinc:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation>Archivos existentes:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation>Max. tamaño archivo:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation>Total: &lt;b&gt;%1&lt;/b&gt;; Creados: &lt;b&gt;%2&lt;/b&gt;; Actualizados: &lt;b&gt;%3&lt;/b&gt;; Omitidos: &lt;b&gt;%4&lt;/b&gt;; Errores: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation>Actual: &lt;b&gt;%1&lt;/b&gt; de </translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3576,367 +3576,411 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation>Sin funciones OverrideCH</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation>Posibilidad de habilitar el MODO FAI (sin telemetría)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation>MODO FAI (sin telemetría) siempre activado</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation>Elimina el soporte para el protocolo D8 FrSky el cual no es de uso legal en EU en radios vendidas después del 1 de enero de 2015</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Desactiva el menú de HELI y el soporte de mezcla de cíclico</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation>Desactiva las variables globales</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Habilita la pantalla de Lua custom scripts</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation>Usa la fuente alternativa SQT5</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation>Usa potenciómetros en los menús de navegación</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation>Habilita firmware no certificado</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation>Habilitar soporte AFHDS3</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation>Desactiva RAS (SWR)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation>Módulo haptic instalado</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Confirmar antes de apagar la radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Gimbals Horus instalados (sensores Hall)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>Usar SÓLO con la primera versión DEV pcb</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation>Soporte para módulo interno MULTI</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation>Soporte para módulo bluetooth</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation>Soporte GPS interno</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation>Activar menú HELI y el soporte de mezcla de cíclico</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation>Variables globales</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation>En el menú de ajuste de modelo se selecciona automáticamente el origen del control moviéndolo</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation>En el menú de ajuste de modelo se selecciona automáticamente el interruptor de control moviéndolo</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation>Sin casillas de verificación ni sliders gráficos</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation>Gráfico batería</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation>No usar la fuente negrita para destacar elementos activos</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation>FrSky Taranis X7 / X7S Access</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>Soporte para módulo interno ACCESS de reemplazo</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation>Activar el reseteo de valores presionando arriva y abajo al mismo tiempo</translation>
     </message>
@@ -3944,27 +3988,27 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Sí, controlado por un único canal</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Sí, controlado por dos canales</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;Canal del primer flap:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>Canal del segundo flap:</translation>
     </message>
@@ -3973,7 +4017,7 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Escribir modelos y ajustes a la radio</translation>
     </message>
@@ -4038,51 +4082,51 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
         <translation>Escribir al TX</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>Perfil actual: %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>Elegir archivo de copia de seguridad de la radio</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>Datos de calibración de radio incorrectos en el perfil, ajustes no corregidos</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>Datos de ajustes de radio incorrectos en el perfil, ajustes no corregidos</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>No se puede escribir el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Error escribiendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>El firmware de la radio pertenece a otro producto, ¡comprueba el archivo y las preferencias!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>El firmware de la radio está obsoleto, ¡por favor actualízalo!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>¡No se puede comprobar la compatibilidad de modelos y ajustes! ¿Continuar de todas maneras?</translation>
     </message>
@@ -4160,103 +4204,103 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
         <translation>Escribir al TX</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>Abrir archivo de firmware</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 puede no ser un archivo de firmware válido</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>El archivo de firmware no es válido.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>No hay imagen de pantalla de inicio en el archivo de firmware.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>El perfil de imagen %1 no es válido.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>Abrir archivo de imagen para usar de pantalla de inicio de la radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>Imágenes (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>La imagen no puede ser cargada desde %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>La librería de imágen no puede ser cargada</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>Imagen de inicio no encontrada</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>No se puede guardar el firmware personalizado</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>Escribir firmware a la radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>Ha fallado la verificación del firmware</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>No se puede verificar el firmware de la radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>¡El nuevo firmware no es compatible con el instalado actualmente!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>Coversión fallida</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>No se puede convertir los modelos y ajustes para usar con este firmware, se usarán los datos originales</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>Restauración fallida</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>No se ha podido restaurar los modelos y ajustes a la radio. Los datos de los modelos y ajustes se pueden encontrar en: %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>Flashing hecho</translation>
     </message>
@@ -4264,47 +4308,47 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation>Ejecutable %1 no encontrado</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation>Escribiendo...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation>Leyendo...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation>Verificando...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>Esto es: OpenTX para placas 9x o OpenTX para placas 9XR</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>Esto es: OpenTX para placas M128 / 9x o OpenTX para placas 9XR con el chip M128</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>Esto es: OpenTX para placas Gruvin9x</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4313,7 +4357,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 Por favor comprueba en las opciones avanzadas de grabado el tipo correcto de cpu.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4322,7 +4366,7 @@ Please select an appropriate firmware type to program it.</source>
 Por favor elige el tipo de firmware apropiado para programarlo.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4331,22 +4375,22 @@ Actualmente estás usando:
  %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>¡¡¡La radio no parece estar conectada al USB o el controlador no está inicializado!!!</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>Flashing hecho (código salida = %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>Flashing hecho con errores</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>FUSIBLES: Low=%1 High=%2 Ext=%3</translation>
     </message>
@@ -4354,7 +4398,7 @@ Actualmente estás usando:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
@@ -4405,225 +4449,240 @@ Actualmente estás usando:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
         <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>Codificador rotativo %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>Valor fuente</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Menú desplegable activado</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation>Menú desplegable disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation>Trim desactivado</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation>Trim propio</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation>Usar trim para modo de vuelo %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation>Usar trim para modo de vuelo %1 + trim propio con compensador</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation>Unidad</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation>Mín</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation>Máx</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
-        <translation>Atención: Variable global linkada a si misma. Usado valor del modo de vuelo 0</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
-        <translation>Atención: Rotary encoder linkado a si mismo. Usado valor del modo de vuelo 0</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Valor propio</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
-        <translation>Limpiar modo de vuelo ¿Estás seguro?</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
-        <translation>Limpiar todos los modos de vuelo ¿Estás seguro?</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
-        <translation>Cortar modo de vuelo ¿Estás seguro?</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
-        <translation>Borrar modo de vuelo ¿Estás seguro?</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Limpiar variable global para todos los modos de vuelo ¿Estás seguro?</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation>Limpiar variable global ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation>Limpiar todas las variables globales para todos los modos de vuelo ¿Estás seguro?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation>Limpiar todas las variables globales para este modo de vuelo ¿Estás seguro?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Cortar variable global para todos los modos de vuelo ¿Estás seguro?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation>Cortar variable global ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation>Borrar variable global ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Pegar a la variable global en todos los modos de vuelo ¿Estás seguro?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
@@ -4631,17 +4690,17 @@ Actualmente estás usando:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>Modo de vuelo %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (predeterminado)</translation>
     </message>
@@ -4649,17 +4708,17 @@ Actualmente estás usando:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>Tiene flybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation></translation>
     </message>
@@ -4667,17 +4726,17 @@ Actualmente estás usando:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation>Amarillo</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation>Naranja</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation>Rojo</translation>
     </message>
@@ -4685,13 +4744,13 @@ Actualmente estás usando:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation></translation>
     </message>
@@ -4709,17 +4768,18 @@ Actualmente estás usando:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Nombre</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4729,7 +4789,12 @@ Actualmente estás usando:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4737,8 +4802,13 @@ Actualmente estás usando:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4882,13 +4952,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Continúa sólo si sabes lo que estás haciendo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>Resetear fusibles de la radio</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>Leer fusibles de la radio</translation>
     </message>
@@ -4896,44 +4966,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation>Valor propio</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation>Valor modo de vuelo %1</translation>
     </message>
 </context>
 <context>
@@ -4951,12 +5011,12 @@ These will be relevant for all models in the same EEPROM.</source>
 Estos puede ser relevantes para todos los modelos en el mismo EEPROM.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Configuración</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Entrenador</translation>
     </message>
@@ -4971,47 +5031,47 @@ Estos puede ser relevantes para todos los modelos en el mismo EEPROM.</translati
         <translation>Recuperar calib. y ajustes hw de un perfil</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>Funciones globales</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation>Hardware</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation>Calibración</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>Datos incorrectos en el perfil, la cablibración de la radio no se ha recuperado</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>Datos erróneos en el perfil, configuración de interruptor/pot no se ha recuperado</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>Datos incorrectos en el perfil, los parámetros de hw no se han recuperado</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>¿Quieres guardar la calibración en el perfil %1&lt;br&gt;¿Sobreescribir la calibración existente?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>Calibración y parámetros de HW guardados.</translation>
     </message>
@@ -5050,8 +5110,8 @@ Estos puede ser relevantes para todos los modelos en el mismo EEPROM.</translati
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Fases de vuelo</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5087,185 +5147,208 @@ Estos puede ser relevantes para todos los modelos en el mismo EEPROM.</translati
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation>Ajustes de radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished">Hardware</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished">Interno</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished">Preguntar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished">Por modelo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished">Interno + Externo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished">Externo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished">APAGADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished">Activado</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetría</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">Entrenador</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">Entrenador SBUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">Depuración</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished">Normal</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">Modo 1 (RUD ELE THR AIL)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">Modo 3 (AIL ELE THR RUD)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">Modo 4 (AIL THR ELE RUD)</translation>
     </message>
 </context>
 <context>
@@ -5281,201 +5364,199 @@ Estos puede ser relevantes para todos los modelos en el mismo EEPROM.</translati
         <translation>Desactivar sólo lectura</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Zona horaria UTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Lenguaje de las voces</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Código país</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Invertir stick</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>Modo FAI</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Ajustar RTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Tono de vario al máx</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Volumen altavoz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>Interruptor de luz de fondo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Modo sonido</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>Tono altavoz(sólo alt)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Si este valor no es 0, cualquier pulsación encenderá la pantalla y se apagará despues de un número determinado de segundos.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation> seg</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>Color de pantalla</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>Beeper</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Altavoz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>VozBeeper</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>VozAltavoz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Volumen beep</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Volumen wav</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Volumen vario</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Volumen de fondo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>Auto apagado de pantalla después de</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>Pantalla parpadea con alarma</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Tono de vario en cero</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Vario repite en cero</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5485,7 +5566,7 @@ Estos puede ser relevantes para todos los modelos en el mismo EEPROM.</translati
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5500,42 +5581,42 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Los valores pueden ser 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>Brillo pantalla</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Navegación RotEnc</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>Ajusta automáticamente el reloj de la radio si se conecta un GPS a la telemetría.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>América</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Japón</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>Europa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>Brillo luz de fondo OFF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5576,262 +5657,122 @@ Modo 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>Modo 1 (RUD ELE THR AIL)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>Modo 2  (RUD THR ELE AIL)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>Modo 3 (AIL ELE THR RUD)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>Modo 4 (AIL THR ELE RUD)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Orden de los canales&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Define el orden por defecto de las mezclas en un nuevo modelo&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation>Si activas FAI, sólo los sensores RSSI y RxBt seguirán funcionando. Esta función no puede ser deshabilitada en la radio.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation>Aviso RSSI al apagado</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation>Advertencia de poca EEPROM</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation>ID de propietario</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation>Teclas luz de fondo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5842,310 +5783,343 @@ Este es el umbral cuando la batería emite sonidos de aviso.
 Los valores aceptables son 3v..12v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation>Retraso de encendido</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation>Modo jack</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation>Entrenador</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation>Modo USB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation>Retraso de apagado</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation>Preguntar al conectar</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation>Joystick (HID)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation>Almacenamiento USB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation>USB Serial (CDC)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Modo sticks</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Métrico</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Imperial</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Orden prederterminado canales</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>Coordenadas GPS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation>Mín</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation>Máx</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Tiempo de inactividad</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Mostrar pantalla de inicio al encender</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>Contraste</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Medidor de rango de batería</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Fuerza de haptic</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>Tipo de pantalla LCD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Aviso &quot;sin sonido&quot;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Aviso de batería</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Duración haptic</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>Velocidad de transmisión MAVLink</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Silencio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Sólo alarmas</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>No teclas</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>Estándar</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Si no es cero emitirá sonidos si el transmisor se deja sin pulsaciones durante el número específico de minutos.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6170,67 +6144,67 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Aviso de silencio - te alertará si el beeper está en modo silencio (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>X-Corto</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>Largo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>X-Largo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Retardo de reproducción (interruptor en posición media)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Unidades de medida</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Modo haptic</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Duración del beeper</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Modo beeper</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6247,12 +6221,14 @@ p, li { white-space: pre-wrap; }
 4 - Extra Alto.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Sólo alarmas</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6260,157 +6236,157 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation>Teclas</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation>Sticks</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation>Teclas + Sticks</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation>Inglés</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation>Holandés</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation>Francés</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation>Alemán</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation>Checo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation>Español</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation>Polaco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation>Portugués</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation>Ruso</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation>Sueco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation>Húngaro</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6419,22 +6395,22 @@ Esta función no puede ser deshabilitada en la radio.
 ¿ Estás seguro ?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished">Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6442,17 +6418,17 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Sí, controlado por un interruptor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Sí, controlado por un potenciómetro</translation>
     </message>
@@ -6460,118 +6436,128 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished">Nombre dispositivo:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished">Filtro ADC</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished">Offset actual</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Invertir</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6652,22 +6638,22 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>Canal de acelerador:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>Canal de viraje:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>Canal de inclinación:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>Canal de balanceo:</translation>
     </message>
@@ -6675,19 +6661,19 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation>Archivo EEPROM no válido %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>No se puede abrir el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Error escribiendo el archivo %1:
@@ -6697,159 +6683,159 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Limpiar todas las entradas</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation>¡No hay suficientes entradas!</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation>Borrar las líneas de entrada seleccionadas ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation>Cortar las líneas de entrada seleccionadas ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation>Líneas</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;Añadir</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation>Intro</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>C&amp;ortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>&amp;Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;Duplicar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation>Limpiar todas las líneas de entrada ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6890,96 +6876,96 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished">Error cargando modelos</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6987,17 +6973,17 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation></translation>
     </message>
@@ -7005,7 +6991,7 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation></translation>
     </message>
@@ -7013,122 +6999,122 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation>Temporizador</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation>Pegajoso</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation>Borde</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation></translation>
     </message>
@@ -7136,112 +7122,117 @@ Esta función no puede ser deshabilitada en la radio.
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>Duración</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>Retardo</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>Función</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>Interruptor AND</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">Persistente</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation>Menú emergente disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation>(instante)</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation> (infinito)</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation>Borrar interruptor lógico ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation>Cortar interruptor lógico ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation>Limpiar interruptor lógico ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation>Limpiar todos los interruptores lógicos ¿Estás seguro?</translation>
     </message>
@@ -7294,52 +7285,52 @@ Esta función no puede ser deshabilitada en la radio.
         <translation>Sesiones de vuelo</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>Registros de telemetría</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>Cambia título de plot</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>Nuevo título de plot:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>Cambia etiqueta de eje</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>Nueva etiqueta de eje:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>Cambia nombre gráfico</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>Nuevo nombre gráfico:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation>Error: datos de GPS no encontrados</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7348,74 +7339,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 Las columnas para altitud &quot;GAlt&quot; y para velocidad &quot;GSpd&quot; son opcionales</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>No se puede escribir el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>Cursor A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>Cursor B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>Tiempo delta: %1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>Velocidad de ascenso: %1 m/s</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>Selecciona tu archivo de registros</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>Campos disponibles</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>El archivo de registros elegido contiene %1 líneas inválidas de un total de  %2 líneas</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation>lapso de tiempo</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>duración </translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation></translation>
     </message>
@@ -7423,125 +7414,125 @@ Las columnas para altitud &quot;GAlt&quot; y para velocidad &quot;GSpd&quot; son
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Archivo cargado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Archivo guardado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Leer los modelos y ajustes de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>Guardar copia de seguridad de la radio a un archivo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Leer el firmware de la radio a un archivo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>Si has encontrado este programa útl, por favor ayuda con una &lt;a href=&apos;%1&apos;&gt;donación&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Abre archivo de modelos y ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>Abrir...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Guardar como...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Comparar modelos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Sale de la aplicación</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>Muestra la ventana de aplicación Acerca de</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Lenguaje</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>Escribir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>El nuevo tema será cargado la próxima vez que inicies Companion.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>Acerca de Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>Tema de icono monocromo negro</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>Tema de icono monocromo blanco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>Tema de icono monocromo azul</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
@@ -7550,611 +7541,611 @@ Do you wish to continue?</source>
 ¿Quieres continuar?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation>¡No configurada la ruta a la estructura SD local!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation>¡No radio o tarjeta SD detectada!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation>Cierra el archivo de modelos y ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation>Lista de los archivos recientes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation>Perfiles de radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation>Crea o selecciona perfiles de radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation>Notas de la versión...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation>Muestra notas de la versión</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation>Crea un nuevo perfil de ajustes de radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation>Copiar el perfil de radio actual</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation>Duplica el perfil de radio actual</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation>Borrar el perfil de radio actual...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation>Borra los ajustes actuales del perfil de radio actual</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation>Exportar ajustes aplicación...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation>Guarda los ajustes actuales de %1 y del simulador (incluyendo perfiles de radio) a un archivo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation>Importar ajustes de la aplicación...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation>Carga los ajustes de %1 y del simulador desde un fichero de ajustes exportado previamente</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation>Usa las pestañas para organizar las ventanas abiertas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation>Ventanas con pestañas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation>Ventanas en cascada</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation>Organiza las ventanas en todo el espacio disponible</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation>Ventanas en cascada</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation>Organiza todas las ventanas abiertas en una cascada</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation>Cierra todas las ventanas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation>Cierra todos los archivos abiertos (pregunta guardar si es necesario)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation>Ventana</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Pequeño</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>Usa iconos pequeños en la barra de herramientas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>Usa iconos normales en la barra de herramientas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>Usa iconos grandes en la barra de herramientas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Grande</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>Usa iconos extra grandes en la barra de herramientas</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Extra Grande</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation> - Copiar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation>Companion :: advertencia de archivos abiertos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation>Por favor guarda o cierra los archivos modificados antes de borrar el perfil activo.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation>No se puede eliminar el perfil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation>El perfil prederterminado no se puede eliminar.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation>Confirma borrar perfil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation>¿Seguro que quieres borrar el perfil de radio &quot;%1&quot;? ¡Esta acción no se puede deshacer!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation>Por favor guarda o cierra todos los archivos modificados antes de importar ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;p&gt;Los ajustes de %1 y del simulador pueden ser importados (restaurar) desde archvo exportado previamente (copia de seguridad). Esto reemplazará los ajustes actuales con los ajustes del archivo.&lt;/p&gt;&lt;p&gt;Se realizará automáticamente una copia de seguridad de los ajustes actuales. Pero si los ajustes actuales son útiles se recomienda que hagas una copia de seguridad manual primero.&lt;/p&gt;&lt;p&gt;Para los mejores resultados al importar ajustes, &lt;b&gt;cierra otras ventanas de %1 que tengas abiertas, y asegúrate que la aplicación del simulador no se está ejecutando.&lt;/p&gt;&lt;p&gt;¿Quieres continuar?&lt;/p&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation>Confirma importar ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation>Selecciona %1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation>copia de seguridad</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation>Presiona el botón de &apos;Ignorar&apos; para continuar de todos modos.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation>Los ajustes no han podido ser importados.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation>&lt;html&gt;&lt;p&gt;Nuevos ajustes han sido importados desde:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 ahora se reiniciará.&lt;/p&gt;&lt;p&gt;Ten en cuenta que puedes necesitar cerrar y reiniciar %2 antes de que algunos ajustes como el lenguaje y el tema de iconos se hagan efectivos.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation>&lt;p&gt;Los ajustes anteriores fueron guardados en:&lt;br&gt; %1&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation>Algunos textos no serán traducidos hasta que reinicie Companion. Por favor ten en cuenta que algunas traducciones no están completas.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation>Lee modelos y ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation>Carpeta local</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation>Carpeta de radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation>Esta función aún no está implementada</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Crea un nuevo archivo de modelos y ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Guarda el archivo de modelos y ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation>Usa el lenguaje predeterminado del sistema.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation>Usa lenguaje %1 (algunas traducciones pueden no estar completas)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>Clásico</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>Tema de iconos clásicos de companion9x</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation>Yerico</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Tema de iconos amarillo miel redondo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>Monocromo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>MonoBlanco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>MonoAzul</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>Lenguaje del sistema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>Sincronizar SD</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>Ver archivo de registro...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Abre el archivo de registro</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Ajustes...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Edita ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Comparar modelos...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Editar imagen de inicio de la radio...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>Editar la imagen de inicio de tu radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Leer firmware de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>Leer firmware de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Escribir firmware a la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Escribir firmware a la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Añadir perfil de radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Escribir modelos y ajustes a la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Escribir modelos y ajustes a la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Leer los modelos y ajustes de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>Configurar comunicaciones...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>Configura software para la comunicación con la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Escribir copia de seguridad a la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Escribir copia de seguridad desde un archivo a la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Copia de seguridad de la radio a un archivo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>Guardar una copia de seguridad completa de todos los datos de ajustes y modelos en la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>Sincronización de la tarjeta SD</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>Archivos recientes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Tema de iconos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Tamaño de iconos</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Archivo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Leer/Escribir</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Listo</translation>
     </message>
@@ -8162,120 +8153,120 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Editando modelo %1: </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished">Mover arriba</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished">Mover abajo</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation>¿Quieres sobreescribir los ajustes generales de la radio?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&gt;&lt;p&gt;&lt;b&gt;El tipo actualmente seleccionado de radio (%1) no es compatible con el archivo %3 (de %2), los modelos y ajustes necesitan ser convertidos.&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>¡No se puede encontrar el archivo %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Error leyendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8284,7 +8275,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8293,241 +8284,241 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation>Nada seleccionado</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation>Editar modelo</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation>Editar ajustes de radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation>Copiar ajustes de radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation>Pegar ajustes de radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation>Simular radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation>Añadir modelo</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation>Modelo</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation>Restaurar desde copia de seguridad</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation>Asistente modelos</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation>Fijar como predeterminado</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation>Imprimir modelo</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation>Simular modelo</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation>Duplicar modelo</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation>Muestra barra de acciones de radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation>Muestra barra de acciones de modelo</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation>solo lectura</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation>No se puede insertar el modelo, no hay slots de modelo disponibles.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation>No se puede añadir el modelo, no hay slots de modelo disponibles.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation>No se puede pegar el modelo, no hay slots de modelo disponibles.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
             <numerusform>¿Borrar %n modelo seleccionado?</numerusform>
@@ -8535,86 +8526,86 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation>No se puede duplicar el modelo, no hay un slot de modelo disponibles.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation>¿Quieres continuar la conversión?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation>Elige &lt;i&gt;Aplicar&lt;/i&gt; para convertir el archivo, o &lt;i&gt;Cerrar&lt;/i&gt; para cerrar sin conversión.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation>&lt;b&gt;La conversión ha generado mensajes importantes, por favor revísalos.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation>Companion :: Resultado de la conversión para %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation>¡No se puede encontrar la tarjeta SD de la radio!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Error abriendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Guardar como</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>Abre archivo de copia de seguridad de modelos y ajustes</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 ha sido modificado.
 ¿Quieres guardar los cambios?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>Archivo binariode copia de seguridad no válido %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>¡No se puede escribir el archivo temporal!</translation>
     </message>
@@ -8622,143 +8613,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8766,12 +8762,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation></translation>
     </message>
@@ -8784,88 +8780,90 @@ Do you want to save your changes?</source>
         <translation>Mezclas</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>La fuente de la mezcla</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <oldsource>The value of the mixer is multiplied by this value and divided by 100.</oldsource>
-        <translation>Interruptor usado por la mezcla.
-Si está en blanco entonces la mezcla se considera que está activa todo el tiempo.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Offset</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Incluir trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>La curva usada por la mezcla</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Interruptor</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8880,142 +8878,104 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>Aviso del mezclador.
-Selecionar este valor provocará un beep cuando el valor esté activo.</translation>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">Precisión</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>APAGADO</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <oldsource>2 Beeo</oldsource>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Multiplexer
-
-Esto determina cómo los valores de mezcla son añadidos.
-
-&quot;+&quot; significa que el valor de la mezcla actual es añadido a la mezcla previa en el mismo canal.
-&quot;*&quot; significa que el valor de la mezcla actual es multiplicada por la mezcla previa en el mismo canal
-&quot;R&quot; significa que el valor reemplaza el valor previo.  Si el interruptor  esta desactivado el valor será ignorado.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>AÑADIR</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>MULTIPLICAR</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>REEMPLAZAR</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Modos de vuelo</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>IncluirDR/Expo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Retardo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Lento</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation>Pulsa para acceder el menú emergente</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation>Fijar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation>Ivertir todo</translation>
     </message>
@@ -9023,22 +8983,22 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation>Aumentar tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation>Reducir tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation>Tamaño de fuente predeterminado</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation></translation>
     </message>
@@ -9046,136 +9006,136 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Limpiar mezclas</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>¡No hay suficientes mezclas disponibles!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation>Borrar líneas de mixes seleccionadas ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation>Cortar líneas de mixes seleccionadas ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;Añadir</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>Intro</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>&amp;Seleccionar palanca</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>C&amp;ortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>&amp;Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;Duplicar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>¿Limpiar mezclas?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>¿Seguro que quieres limpiar todas las mezclas?</translation>
     </message>
@@ -9183,18 +9143,23 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation>Modelo: </translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation>Fuente del acelerador</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9243,32 +9208,49 @@ Esto determina cómo los valores de mezcla son añadidos.
         <translation type="unfinished">Master/Multi</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
+        <translation type="unfinished">Apagado</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9281,65 +9263,60 @@ Esto determina cómo los valores de mezcla son añadidos.
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>Heli</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Entradas</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Interruptor lógicos</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Mezclas</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>Salidas</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Curvas</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Funciones especiales</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Telemetría</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Fases de vuelo</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.ui" line="51"/>
@@ -9396,8 +9373,8 @@ Esto determina cómo los valores de mezcla son añadidos.
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Fases de vuelo</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9433,585 +9410,595 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation>Exponencial</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>Extra Fino</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>Fino</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>Medio</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>Duro</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation>Desconocido</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation>Activar</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation>Desactivar</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation>Verdadero</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation>Falso</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation>Modo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation>Canales</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation>Longitud frame</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation>Retardo PPM</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation>Polaridad</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation>Protocolo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation>Retardo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation>Receptor</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation>Protocolo radio</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation>Subtipo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation>Valor opción</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation>Sub tipo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation>Potencia de salida RF</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation>Modos de vuelo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation>Modo de vuelo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation>Borde</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation>Pegajoso</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation>Temporizador</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation> falta</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation>Duración</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation>Límites extendidos</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation>Mostrar lista de verificación</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation>Funciones globales</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation>Modo failsafe</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation>Mantener</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation>Sin pulsos</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation>No fijado</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation>Sin pulsos</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation>Paso</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation>Extendido</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation>Nunca</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation>Al cambiar</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation>Siempre</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation>Trim sólo al ralentí</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation>Invertido</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation>Veloc. vert.</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation>Celdas</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation>Mínimo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation>Máximo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation>Números</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation>Barras</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation>Nombre archivo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation>Error: ¡No se puede abrir o leer el archivo!</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished">Opciones</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation>Ninguno</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>Desactivado en todos los modos de vuelo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation>instante</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>Personalizado</translation>
     </message>
@@ -10019,27 +10006,27 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Avión</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Helicóptero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Nombre modelo:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Tipo modelo:</translation>
     </message>
@@ -10047,27 +10034,27 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished">Índice</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Nombre</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished">Modelo %1</translation>
@@ -10323,285 +10310,290 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation>Positivo</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation>Negativo</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation>Puerto entrenador</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation>Sistema de radio interno</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation>Módulo externo de radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation>Sistema de radio extra</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation>Sistema de radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished">APAGADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation>200mW - 16CH (sin telemetría)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation>500mW - 16CH (sin telemetría)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation>100mW - 16CH (sin telemetría)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation></translation>
     </message>
@@ -10609,57 +10601,57 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished">perfil</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation>Valor</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>Mantener</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>Sin pulsos</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation>Bind con canal</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished">Opciones</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
@@ -10667,456 +10659,456 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>Entrada</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation>Cíc. long.</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation>Cíc. lateral</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>Colectivo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>Modos de vuelo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>Modo de vuelo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>Interruptores</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation>Imagen del modelo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation>Acelerador</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation>Beep en centro</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation>Avisos interruptores</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation>Avisos potenciómetros</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation>Otro</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation>Temporizadores</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation>Cuenta atrás</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">Modo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation>Módulos</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation>Puerto entrenador</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation>Helicóptero</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Función</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished">Activado</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation>Protocolo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation>Bajo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation>Crítico</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation>Audio telemetría</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation>Altímetro</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation>Fuente variómetro</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation>Límites variómetro</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation>Descenso máx</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation>Descenso mín</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation>Ascenso mín</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation>Ascenso máx</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation>Centro silencio</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation>Barra superior</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation>Fuente de voltage</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation>Fuente de altitud</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation>Parámetros</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation>Sensores de telemetría</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation>Pantallas de telemetría</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation>Funciones globales</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation>Lista de verificación</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>Canal</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation>Emergente</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation>Salidas</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation>Directo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation>Lineal</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation>Telemetría</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation>Mín</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation>Cada min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation>Persistente</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation>Atn. entr.</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation>Atn.sal.</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation>Vars globales</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation>Máx</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>Variables globales</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>Entradas</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>Mezclas</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>Curvas</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>Interruptores lógicos</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>Funciones especiales</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>Unidad</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>Alarmas RSSI</translation>
     </message>
@@ -11124,7 +11116,7 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,22 +11124,22 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Canal de acelerador:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Canal de viraje:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Canal de inclinación:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Canal de balanceo:</translation>
     </message>
@@ -11155,22 +11147,22 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation>Error desconocido</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation> ... más %1 errores</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation>No se pueden escribir los ajustes de la radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation>No se puede escribir el modelo %1</translation>
     </message>
@@ -11178,17 +11170,17 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Corte de gas</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Temporizador de gas</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Temporizador de vuelo</translation>
     </message>
@@ -11196,40 +11188,40 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Error abriendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Error escribiendo el archivo %1:
@@ -11259,17 +11251,17 @@ Esto determina cómo los valores de mezcla son añadidos.
         <translation>Imprimir a archivo</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Imprimir documento</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11296,12 +11288,12 @@ Esto determina cómo los valores de mezcla son añadidos.
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -11317,22 +11309,22 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation>AVISO</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation>&lt;p&gt; Importar datos de JumperTX a OpenTX 2.3 &lt;b&gt; no es compatible y es peligroso. &lt;/b&gt; &lt;/p&gt; &lt;p&gt; Desafortunadamente, no es posible diferenciar los datos de JumperTX de los datos legítimos de FrSky X10, pero &lt;b&gt; Sólo debes continuar aquí si el archivo que se abrió proviene de un FrSky X10 real. &lt;/b&gt; &lt;/p&gt; &lt;p&gt; ¿Realmente deseas continuar? &lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished">¿Mostrar este mensaje de nuevo en el siguiente inicio?</translation>
     </message>
@@ -11340,24 +11332,24 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11365,97 +11357,107 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation>es inválido</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation>convertido a</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation>verificar si</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation>Evento</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation>Comp</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation>Sub-componente</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation>Campo</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation>Anterior</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation>Acción</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation></translation>
     </message>
@@ -11463,30 +11465,30 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>No se puede escribir el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation>No se puede borrar el archivo temporal: %1</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation>¡No se puede encontrar la tarjeta SD de la radio!</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11494,12 +11496,12 @@ Esto determina cómo los valores de mezcla son añadidos.
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Valor (entrada): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation>Doble click derecho para reiniciar centro.</translation>
     </message>
@@ -11606,12 +11608,17 @@ s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation></translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation></translation>
     </message>
@@ -11627,358 +11634,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation>Batería</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation>Hora</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
-        <translation></translation>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Fuente</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">Ninguno</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation>TrmH izquierda</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation>TrmH derecha</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation>TrmV abajo</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation>TrmV arriba</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation>Uno</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation>Telemetría</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
-        <translation></translation>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">Ninguno</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;Canal del timón (Rudder):</translation>
     </message>
@@ -11986,21 +12093,21 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Error abriendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation>Error abriendo archivo %1 en modo de escritura:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12008,319 +12115,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished">Instancia</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished">Fuentes</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished">Unidad</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished">Precisión</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished">Ratio</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished">Offset</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished">Palas</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished">Filtro</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished">Persistente</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished">Positivo</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished">Reporte</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizado</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished">Calculado</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished">Media</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished">Multiplicar</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished">Total</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished">Celda</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished">Consumo</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished">Distancia</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished">Menor</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished">Celda %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished">Mayor</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation>horas</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation>minutos</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation>ml/minuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation></translation>
     </message>
@@ -12542,87 +12664,87 @@ Si está marcado el acelerador será invertido.  El ralentí será delante, el t
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation>Menú emergente disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>Temporizador %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation>Ajustes de perfil</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation>Ruta de la SD no especificada o no válida</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation>Limpiar timer ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation>Limpiar todos los timers ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation>Cortar timer ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation>Borrar timer ¿Estás seguro?</translation>
     </message>
@@ -12630,7 +12752,7 @@ Si está marcado el acelerador será invertido.  El ralentí será delante, el t
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Canal de profundidad:</translation>
     </message>
@@ -12638,204 +12760,204 @@ Si está marcado el acelerador será invertido.  El ralentí será delante, el t
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation>captura</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation>INTRO</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation>RE PÁG</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation>AV PÁG</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation>SUPR</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation>RETR</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation></translation>
     </message>
@@ -12843,115 +12965,115 @@ Si está marcado el acelerador será invertido.  El ralentí será delante, el t
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation>Perfiles disponibles:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation>Nombre: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation>Radios disponibles:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation>Perfil ID de radio o nombre a usar para simulador.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation>perfil</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation>Tipo de radio a simular (normalmente definido en el perfil).</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation>radio</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation>Directorio conteniendo la imagen de la tarjeta SD a usar. El predeterminado es configurado en el perfil de radio seleccionado.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation>ruta</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation>tipo</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation>origen-datos</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation>[origen-datos]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation>Error: Perfil ID %1 no encontrado.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation>Tipo de origen de datos de arranque desconocido: %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation>WARNING: No se puede inicializar SDL:
 %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation>ERROR: No hay librerías de simulador disponibles.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
@@ -12960,7 +13082,7 @@ Data File: [%3]</source>
 Archivo datos: [%3]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation>ERROR: Perfil de radio o firmware del simulador no encontrado.
@@ -12971,8 +13093,8 @@ Perfil ID: [%1]; Radio ID: [%2]</translation>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
-        <translation>Simulador de OpenTX</translation>
+        <source>EdgeTX Simulator</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
@@ -13120,74 +13242,74 @@ Perfil ID: [%1]; Radio ID: [%2]</translation>
         <translation>Fija el alto de widget de la radio a un tamaño fijo.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation>ERROR: No se puede crear la interfaz de simulador, posiblemente falta o es erronea la librería.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation>Salidas de radio</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation>Simulador de telemetría</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation>Simulador de entrenador</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation>Salida de depuración</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Controles simulador:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation>&lt;tr&gt;&lt;th&gt;Tecla/Ratón&lt;/th&gt;&lt;th&gt;Acción&lt;/th&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation>Ayuda simulador</translation>
     </message>
@@ -13316,32 +13438,32 @@ El predeterminado es configurado en el Perfil de radio seleccionado.</translatio
         <translation>Ruta SD</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation>Todos los ficheros (*.*)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation>Selecciona un archivo de datos</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation>Selecciona directorio de datos</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation>Selecciona carpeta de imágenes de la tarjeta SD</translation>
     </message>
@@ -13354,67 +13476,72 @@ El predeterminado es configurado en el Perfil de radio seleccionado.</translatio
         <translation>Simulador Companion</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation>Simulador radio (%1)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation>No se pueden determinar los datos de arranque.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation>No se puede cargar datos, posiblemente formato erróneo.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation>Error de carga de de datos</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation>Datos de inicio inválidos. Por favor specifica un archivo/ruta válido.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation>Error de arranque del simulador</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation>Error salvando datos: no se puede abrir el archivo como escritura: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation>Error salvando datos: no se puede obtener datos de la interfaz del simulador.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation>Ha ocurrido un error inesperado al intentar guardar los datos de la radio al archivo &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation>Error de guardado de datos</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation>Error del firmware de la radio: %1</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
-        <translation> - Modo de vuelo %1 (#%2)</translation>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation>No se puede abrir el joystick, joystick desactivado</translation>
     </message>
@@ -13441,17 +13568,17 @@ El predeterminado es configurado en el Perfil de radio seleccionado.</translatio
         <translation></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>LIbrería de pantallas de inicio - página %1 de %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>Imagen no válida en la librería %1</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>No se ha encontrado una imagen válida en la librería, comprueba tus ajustes</translation>
     </message>
@@ -13459,7 +13586,7 @@ El predeterminado es configurado en el Perfil de radio seleccionado.</translatio
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>Canal %1</translation>
     </message>
@@ -13467,7 +13594,7 @@ El predeterminado es configurado en el Perfil de radio seleccionado.</translatio
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation>¡No se puede encontrar el archivo %1!</translation>
     </message>
@@ -13476,9 +13603,9 @@ El predeterminado es configurado en el Perfil de radio seleccionado.</translatio
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation>Editor de hoja de estilo</translation>
     </message>
@@ -13503,21 +13630,21 @@ El predeterminado es configurado en el Perfil de radio seleccionado.</translatio
         <translation>Esta propiedad no valida tus cambios y asume que eres familiar con la sintaxis CSS para QT.</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation>No se puede obtener el estilo %1
 Error: %2</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation>No se puede obtener el estilo predeterminado %1
 Error: %2</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation>No se puede actualizar el estilo personalizado %1
@@ -13527,47 +13654,47 @@ Error: %2</translation>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation>Hoja de estilo leída desde &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation>No se puede leer hoja de estilo desde &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation>No se puede crear el directorio &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation>No se puede abrir el archivo para escritura &apos;%1&apos;: Error: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation>No se puede escribir en el archivo &apos;%1&apos;: Error: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation>No se puede vaciar buffer para el archivo &apos;%1&apos;: Error: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation>Hoja de estilo escrita a &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation>Hoja de estilo personalizada borrada: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation>No se puede borrar hoja de estilo personalizada: &apos;%1&apos;</translation>
     </message>
@@ -13575,59 +13702,59 @@ Error: %2</translation>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation>[TEST RUN] </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation>Sincronización fallida, no se ha encontrado nada para copiar.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation>Omitiendo archivo largo: %1 (%2KB)</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation>Creando directorio: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation>No se puede crear el directorio: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation>Reuniendo información del archivo para %1...</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation>Ficheros no encontrados en %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation>Sincronización abortada con %1 de %2 ficheros.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation>Sincronización finalizada con %1 ficheros en %2m %3s.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation>Sincronizando: %1
     a: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
@@ -13636,84 +13763,84 @@ Error: %2</translation>
 </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation>
 Demasiados errores, abortando.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation>Omitiendo archivo filtrado: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation>Omitiendo archivo linkado: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation>Sincronizacíon abortada de:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation>Sincronización finalizada:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation>Creado: %1; Actualizado: %2; Omitido: %3; Errores: %4;</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation>Existe el directorio: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation>Al menos una de las fechas de modificación de los ficheros está en el futuro, error en: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation>Omitiendo fichero más antiguo: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation>No se puede abrir el archivo de origen &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation>No se puede abrir el archivo de destino &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation>Omitiendo archivo idéntico: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation>Reemplazando archivo:; %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation>Creando archivo: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation>No se puede borrar el archivo de destino &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation>Copia fallida: &apos;%1&apos; a &apos;%2&apos;: %3</translation>
     </message>
@@ -13721,17 +13848,17 @@ Demasiados errores, abortando.</translation>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>&lt;br&gt;Canal del timón (Rudder):</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Canal de profundidad:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>¡Sólo hay un canal disponible!&lt;br&gt;Deberías configurar el modelo sin el asistente.</translation>
     </message>
@@ -13739,22 +13866,22 @@ Demasiados errores, abortando.</translation>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Profundidad y timón</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Sólo profundidad</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>Cola-V</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Tipo de cola:</translation>
     </message>
@@ -14086,7 +14213,7 @@ Demasiados errores, abortando.</translation>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">Pantalla telemetría %1</translation>
     </message>
@@ -14094,29 +14221,962 @@ Demasiados errores, abortando.</translation>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Alarma baja</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Alarma crítica</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (no soportado)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
         <translation>Borrar sensor ¿Estás seguro?</translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Form</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VelocVertical</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished">Grados</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished">VelocTierra</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Form</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished">Celdas</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished">Cant. combust.</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished">VelocAire</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished">Voltios</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">Temporizador 1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished">Grados</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished">Metros</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">Temporizador 2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VelocVertical</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Combustible</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished">VelocTierra</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Form</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Combustible</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">Temporizador 2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VelocVertical</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished">Fecha</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished">Batería</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">Temporizador 1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished">Grados</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished">VelocTierra</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14232,72 +15292,72 @@ Demasiados errores, abortando.</translation>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation>Menú desplegable disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation>Cortar</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation>Insertar</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation>Borrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation>Mover arriba</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation>Mover abajo</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation>Limpiar todo</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation>Cortar sensor de telemetría ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation>Limpiar el sensor de telemetría ¿Estás seguro?</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation>Limpiar todos los sensores de telemetría ¿Estás seguro?</translation>
     </message>
@@ -14310,356 +15370,125 @@ Demasiados errores, abortando.</translation>
         <translation>Simulador de telemetría</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
         <translation>Simular</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation>Reproducir archivo SD de reporte</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation>Velocidad de reproducción</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation>Cargar</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation>Col # 
 Tiempo</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation>Actualmente no hay cargado archivo de reporte</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation>Temporizador 1</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation>Temporizador 2</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>Combustible</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation>Metros</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation>VelocVertical</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation>Cant. combust.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation>VelocAire</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation>Fecha</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation>Voltios</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation>Celdas</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation>VelocTierra</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation>Grados</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation>Fijando RSSI a cero simula pérdida de telemetría y conexión con la radio.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation>Fijar RSSI a cero en pausa.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation>Para de enviar datos de telemetría cuado el simulador esté oculto.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation>Pausar simulación cuando se oculte.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
@@ -14667,78 +15496,35 @@ hh:mm:ss</source>
         <translation>Cuando está activado, envía valores no vacíos como datos de telemetría simulados.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation>Archivo Log</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation>Ficheros LOG (*.csv)</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
         <translation>ERROR - archivo no válido</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Sí</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;Canal de acelerador:</translation>
     </message>
@@ -14764,138 +15550,138 @@ hh:mm:ss</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation>Temporizador %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished">Silencio</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">Beeps</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">Voz</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">Reproducir haptic</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">No persistente</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">Persistente (vuelo)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished">Vuelo</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">Persistente (reset manual)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished">Reset manual</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished">APAGADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14903,22 +15689,22 @@ hh:mm:ss</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished">APAGADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Suma)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Reemplazar)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14926,27 +15712,27 @@ hh:mm:ss</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">Modo</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Peso</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Fuente</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished">Calibración</translation>
     </message>
@@ -14957,6 +15743,210 @@ hh:mm:ss</source>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
         <translation>Simulador de entrenador</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">desconocido</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14983,47 +15973,47 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15036,22 +16026,42 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15059,285 +16069,317 @@ hh:mm:ss</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished">desconocido</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15353,63 +16395,90 @@ hh:mm:ss</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15502,32 +16571,32 @@ hh:mm:ss</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15540,22 +16609,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15568,22 +16637,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15607,17 +16676,17 @@ hh:mm:ss</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15625,37 +16694,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15771,32 +16840,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15804,32 +16873,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">Información</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished">Barra superior</translation>
     </message>
@@ -15837,12 +16906,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>Primer canal de cola:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>Segundo canal de cola:</translation>
     </message>
@@ -15850,55 +16919,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
-        <translation>Mantener la posición vertical del stick.</translation>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation>Fijar Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation>Evitar el movimiento vertical del stick.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation>Fijar X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation>Evitar el movimiento horizontal del stick.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
         <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
-        <translation>Mantener la posición horizontal del stick.</translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Ala estándar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Ala volante/Ala delta</translation>
     </message>
@@ -15906,22 +16975,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15929,273 +16998,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Asistente Modelos</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Tipo Modelo</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Introduce nombre de modelo y tipo de modelo.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Acelerador</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>¿Tiene tu modelo motor?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Tipo de Ala</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>¿Es tu modelo un ala volante/ala delta o tiene una configuración estándar de ala?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>Alerones</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>¿Tiene tu modelo alerones?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Flaps</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>¿Tiene tu modelo flaps?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Aerofrenos</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>¿Tiene tu modelo aerofrenos?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Ala volante / Ala delta</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Selecciona los canales de los elevones</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Timón</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>¿Tiene tu modelo timón?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Tipo de cola</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Selecciona el tipo de cola que lleva tu modelo.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Cola</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Seleciona los canales para el control de cola.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>Cola-V</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Selecciona el canal de profundidad.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>Cíclico</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>¿Que tipo de plato está instalado en tu helicóptero?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>Giróscopo cola</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>¿Tiene tu helicóptero giróscopo ajustable para la cola?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>Tipo rotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>¿Tiene tu helicóptero flybars?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Helicóptero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>Selecciona los controles de tu helicóptero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>Multirotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Selecciona los canales para tu multirotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Opciones Modelo</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Selecciona opciones adicionales</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>Guardar Cambios</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Comprobar manualmente la dirección de cada control de superficie y los reversos de cualquier canal para que el control de movimiento no sea erróneo. Saca la hélice/hélices antes de intentar controlar tu modelo por primera vez.&lt;br&gt; ¡Por favor ten en cuenta que continuar eliminar los ajustes anteriores del modelo!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Introduce un nombre para tu modelo y selecciona el tipo de modelo.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Selecciona el canal del receptor que está conectado a tu ESC o servo de acelerador.&lt;br&gt;&lt;br&gt;Acelerador - Spektrum: CH1, Futaba: CH3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>La mayoría de los aviones tienen un ala principal y una cola con controles de superficie. Volando alas y alas delta sólo hay un ala simple. El control principal de superficie en un ala estandar controla el alabeo del avión. Esta superficie se llama alerón.&lt;br&gt; El control de superficie de un ala delta controla ambos alabeo y cabeceo. Esta superficie se llama elevon.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>Los modelos usan 1 o 2 canales para controlar los alerones.&lt;br&gt;Un cable en Y se puede usar para conectar un sólo canal del receptor a dos servos separados de los alerones. Si usas servos conectados por un cable Y debes seleccionar la opcion de servo único.&lt;br&gt;&lt;br&gt; Alerón - Spektrum: CH2, Futaba CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>Este asistente asume que tus flaps estan controlados por un interruptor. Si tus flaps están controlados por un potenciómetro lo puedes cambiar manualmente más tarde.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>Los aerofrenos son usados para reducir la velocidad de avance en los veleros.&lt;br&gt;No son muy comunes en otro tipo de aviones.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>Los modelos usan dos canales para controlar los elevones.&lt;br&gt;Selecciona esos dos canales</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Selecciona el canal del receptor que está conectado al timón.&lt;br&gt;&lt;br&gt;Timón - Spektrum: CH4, Futaba: CH4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Selecciona el tipo de cola de tu avión.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Selecciona los canales de timón y de profundidad.&lt;br&gt;&lt;br&gt;Timón - Spektrum: CH4, Futaba: CH4&lt;br&gt;Profundidad - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Selecciona el canal de profundidad&lt;br&gt;&lt;br&gt;Profundidad - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Selecciona el control de canales de tu multirotor.&lt;br&gt;&lt;br&gt;Gas - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>No hay ayuda disponible en la página actual.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Ayuda asistente de modelo</translation>
     </message>
@@ -16203,37 +17272,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>Avión</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>Multicóptero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>Helicóptero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>Nombre modelo: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>Tipo Modelo: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>Opciones: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>Canal %1: </translation>
     </message>
@@ -16241,47 +17310,47 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Error abriendo el archivo %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished">Error abriendo archivo %1 en modo de escritura:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16289,16 +17358,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16307,10 +17379,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16405,18 +17492,18 @@ Por favor solamente usa esto si sabes lo que estás haciendo.  No hay control de
         <translation>Puerto serie sam-ba</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>Configuración DFU-UTIL</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>Configuración SAM-BA</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Seleccionar ubicación</translation>
     </message>
@@ -16468,7 +17555,7 @@ m2560 para las placas v4.1</translation>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>Siguiente</translation>
     </message>
@@ -16478,65 +17565,65 @@ m2560 para las placas v4.1</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation>No asignado</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation>No se han encontrado joysticks</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>No se puede abrir el joystick.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation>Presiona el botón Inicio para empezar el procedimiento de calibración de los stick
 Puedes cambiar la asinación de canales o inversión en cualquier momento.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation>Mueve los sticks y pots hasta el final en todas las direcciones
 Presiona Siguiente al finalizar</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation>Mueve los sticks y pots a la posición central
 Presiona Siguiente al finalizar</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation>Mapea los canales de joystick a los controles usando las listas deplegables
 Presiona Siguiente al finalizar.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation>Revisa la casilla de inversión si es necesario invertir la dirección.
 Presiona Siguiente cuando finalices.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation>Presiona OK oara guardar la configuración
 Presiona Cancelar para abortar la calibración del joystick sin guardar.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation>Calibración incompleta, ¿guardar?</translation>
     </message>

--- a/companion/src/translations/companion_fi.ts
+++ b/companion/src/translations/companion_fi.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>Ei</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Kyllä, ohjataan yhdellä kanavalla</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Kyllä, ohjataan kahdella kanavalla</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;1. siiveke kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>2. siiveke kanava:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>Ei</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Kyllä, ohjataan yhdellä kanavalla</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Kyllä, ohjataan kahdella kanavalla</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;1. lentojarru kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>2. lentojarru kanava:</translation>
     </message>
@@ -60,23 +60,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -169,22 +169,22 @@
         <translation>Radio profiili</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>Kanavien järjestys</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>Perus tikkujen tila</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>Valitse kuva</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -228,662 +228,657 @@ Tila 4:
 </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Mode 1 (PER KOR KAA SII)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Mode 2 (PER KAA KOR SII)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Mode 3 (SII KOR KAA PER)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Mode 4 (SII KAA KOR PER)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>Alkuruutu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>Radio tyyppi</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kanava järjestys&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Määrittelee miksereiden perusasetukset uuteen malliin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>P Ko Ka S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>P Ko S Ka</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>P Ka Ko S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>P Ka S Ko</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>P S Ko Ka</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation>P S Ka Ko</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>Ko P Ka S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>Ko P S Ka</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>Ko Ka P S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>Ko Ka S P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>Ko S P Ka</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>Ko S Ka P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>Ka P Ko S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>Ka P S Ko</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>Ka Ko P S</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>Ka Ko S P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>Ka S P Ko</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>Ka S Ko P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>S P Ko Ka</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>S P Ka Ko</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>S Ko P Ka</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>S Ko Ka P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>S Ka P Ko</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>S Ka Ko P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>Profiilin nimi</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>Tyhjennä kuva</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>Yleiset asetukset</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>SD muistikortin kansio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>Ohjelman asetukset</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>Laita automaatiinen varmuuskopionti päälle ennen firmwaren kirjoitusta</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>Alkuruutu kirjasto</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Google Earth tiedosto</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>Näytä vain käyttäjän oma alkuruutu kuvat</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>Näytä käyttäjän ja Companionin alkuruutu kuvat</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>Käyttäjän oma alkuruudut</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>Automaattisen varmuuskopion kansio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>Simulaattorin asetukset</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>Simulaattorin taustavalo</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>Päälle</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>Sininen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>Vihreä</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>Joystick</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>Kalibroi</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>Kaappaa leikepöydälle</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Minun radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Valitse kansioi kuville</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Joystickia ei löydy</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>TYHJÄ: Ei radion asetuksia tallennettu profiiliin</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>TARJOLLA: Radion asetukset, voi olla vanhoja</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>TARJOLLA: Radion asetukset %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Valitse kansio kirjastolle</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Valitse kansio mallien ja asetusten varmuuskopioille</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Valitse Google Earth tiedosto</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Valitse kansio mihin &quot;monistetaan&quot; SD muistikortin kansio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Avaa kuva latausta varten</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Kuvia (%1)</translation>
     </message>
@@ -891,30 +886,30 @@ Tila 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Virhe kirjottaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,33 +947,33 @@ Tila 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -989,255 +984,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">Vasen vaaka</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished">Vasen pysty</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished">Oikea pysty</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">Oikea vaaka</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished">Kytkin</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Toiminto</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">Vakio</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">Pieni</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">Molemmat</translation>
     </message>
@@ -1245,17 +1250,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished">Negatiivinen liike</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished">Keski alue</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished">Positiivinen liike</translation>
     </message>
@@ -1263,132 +1268,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished">Alitrimmi</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished">Suunta</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">Käyrä</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished">PPM keski</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished">Lineaarinen alitrimmi</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished">KÄÄNT</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished">Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished">Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1431,57 +1436,57 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Ei voi kirjoittaa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1497,12 +1502,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1510,173 +1515,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished">Info</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished">Varoitus</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished">Virhe</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished">Ohjelman asetukset</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished">Tämän firmwaren simulointi ei ole vielä mahdollista</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1714,22 +1729,22 @@ Do you want to import settings from a file?</source>
         <translation>Tulosta tiedostoon</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Tulosta dokumentti</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>Valitse PDF tiedosto</translation>
     </message>
@@ -1755,7 +1770,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>OK, Ymmärrän.</translation>
     </message>
@@ -1763,17 +1778,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation type="unfinished">Kirjoitus virhe</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1781,22 +1796,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished">Vakio</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished">Omat</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished">%1 pisteet</translation>
     </message>
@@ -1879,32 +1894,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">Suora</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">yks expo</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">Symmetrinen f(x)=-f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">Symmetrinen f(x)=f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1912,7 +1927,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1920,22 +1935,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished">Ero</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished">Expo</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished">Toiminto</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished">Omat</translation>
     </message>
@@ -1943,113 +1958,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">Muuta</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished">Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished">Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2057,343 +2072,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished">SF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished">Ohitus %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished">Trainerin PER</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished">Trainerin KOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished">Trainerin KAA</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished">Trainerin SII</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished">Välitön trimmi</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished">Toista ääni</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished">Toista värinä</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished">Resetti</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished">Toistettu kerran, ei aloituksessa</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished">Ei toistoa</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished">1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished">%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation type="unfinished">Lähde</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished">Variom</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished">Toista raita</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished">Toista molemmat</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished">Toista arvo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished">Voluumi</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished">Taustavalo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished">Tausta musiikki</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished">Tausta musiikki tauko</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished">s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2401,123 +2436,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Kytkin</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Toiminto</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Parametrit</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished">Päälle</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished">Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished">Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,22 +2560,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">Palkit</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2548,47 +2583,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">Lento tila</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2645,82 +2680,82 @@ Do you want to import settings from a file?</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished">FW: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished">Pict: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished">Profiili kuva</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>Avaa firmware tiedosto</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>Ei voi ladata liitettyä kuvaa firmware tiedostosta %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>Avaa kuva latausta varten</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>Kuvia (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>Ei voi ladata kuvaa tiedostosta %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>Ei voi ladata profiilikuvaa %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>Ei voi ladata kirjasto kuvaa %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>Tiedosto tallennettu</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>Kuva on tallennettu tiedostoksi %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>Kuvan päivitys virhe</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>Ei voi päivitää kuvaa tiedostosta %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>Tiedoston tallennus virhe</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>Virhe kuvan kirjoituksessa tiedostoon %1</translation>
     </message>
@@ -2728,22 +2763,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2751,53 +2786,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished">Kytkin</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished">Lähde</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX vastaanottaa vain %1 pistettä kaikkiin käyriin</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX vastaanottaa vain %1 pistettä kaikkiin käyriin</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished">OpenTX ja tämä funktio ei onnistu tässä radiossa</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished">OpenTX ei hyväksy tätä radio protokollaa</translation>
     </message>
@@ -2805,52 +2840,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished">ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished">Ei</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished">Kyllä</translation>
     </message>
@@ -2929,101 +2964,82 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished">Ladataan:</translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation type="unfinished">Lataus epäonnistui %1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3032,12 +3048,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3045,12 +3061,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3058,12 +3074,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;1. korkeusper kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>2. korkeusper kanava:</translation>
     </message>
@@ -3071,42 +3087,42 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Virhe avattaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Virhe kirjottaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3114,23 +3130,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">ON</translation>
     </message>
@@ -3138,111 +3154,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>Lähde miksereille</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Tulon nimi</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Paino</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Lento tilat</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Kytkin</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Tikun puoli</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation>NEG</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation>POS</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>Kaikki</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>Lähde miksereille.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Käyttökytkin.
-Jos on tyhjä, katsotaan tulon olen ON tilassa kokoajan.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>Skaala</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Myös trimmi</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Käyrä</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>Käyrä lähteen mukaan.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Tasoitus</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>Lähde</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Nimi</translation>
     </message>
@@ -3252,22 +3252,22 @@ Jos on tyhjä, katsotaan tulon olen ON tilassa kokoajan.</translation>
         <translation>Muuta %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3275,22 +3275,22 @@ Jos on tyhjä, katsotaan tulon olen ON tilassa kokoajan.</translation>
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>Kaasun kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>Yaw kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>Pitch kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>Roll kanava:</translation>
     </message>
@@ -3298,262 +3298,262 @@ Jos on tyhjä, katsotaan tulon olen ON tilassa kokoajan.</translation>
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished">Sulje</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished">Aloitus</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3561,367 +3561,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished">Ei ohituskanava funkitoita saatavissa</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">HELI valikko pois ,myös cyclic mix tuki</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">Globaalit muuttujat pois päältä</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished">Käytä vaihtoehtoista SQT5 fonttia</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished">Potikoiden käyttö valikko navigoinnissa</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">Värinä moduli asennettu</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished">HELI valikko päälle ,cyclic mix tuella</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished">Globaalit muuttujat</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished">Mallien asetukset  asetetaan automaattisesti kun ohjaimia käänellään</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished">Mallien asetukset  asetetaan automaattisesti kun nappeja  käänellään</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished">Ei graaffisia valintalaatikoita ja liukuja</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished">Akun grafiikka</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished">Älä käytä lihavointua fonttia korostamaan aktiivisia asioita</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished">Asetuksien poisto: Paina ylös ja alas samanaikaisesti</translation>
     </message>
@@ -3929,27 +3973,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>Ei</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Kyllä, ohjataan yhdellä kanavalla</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Kyllä, ohjataan kahdella kanavalla</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;1. laippojen kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>2. laippojen kanava:</translation>
     </message>
@@ -3958,7 +4002,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished">Kirjoita mallit ja asetukset lähettimeen</translation>
     </message>
@@ -4023,51 +4067,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">Kirjoita lähettimeen</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation type="unfinished">Valitse Lähettimen varmuuskopio tiedosto</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation type="unfinished">Väärä radion kalibraatio data profiilissa, asetuksia ei ole korjattu</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation type="unfinished">Väärä radion asetus data profiilissa, asetuksia ei ole korjattu</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Ei voi kirjoittaa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Virhe kirjottaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation type="unfinished">Lähettimen firmware kuuluu toiselle lähettin mallille, tarkista oikea tiedosto ja asetukset!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation type="unfinished">Firware on vanhaa versio, päivitä se uudempaan!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation type="unfinished">Ei voi varmistaa että mallit ja asetukset täsmää laitteistoon. Jatketaanko silti ?</translation>
     </message>
@@ -4145,103 +4189,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">Kirjoita lähettimeen</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation type="unfinished">Avaa firmware tiedosto</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation type="unfinished">%1 ei ehkä ole oikea firmware tiedosto</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation type="unfinished">Tämä ei ole oikea firmware tiedosto.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation type="unfinished">Tälle firmwarelle ei ole alku ruutu kuvaa.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation type="unfinished">Profiilin kuva %1 on väärä.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation type="unfinished">Avaa kuva ja käytä sitä alku ruutu kuvana</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation type="unfinished">Kuvia (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation type="unfinished">Kuvaa ei voi ladata %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation type="unfinished">Kuvaa ei voi ladata</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation type="unfinished">Muutettua firmwarea ei voi tallentaa</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished">Kirjoita firmware lähettimeen</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation type="unfinished">Muutos virheellinen</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation type="unfinished">Ei voida muuttaa malli ja asetus tietoja käymään uuteen firmwareen, alkuperäiset tiedot otetaan käyttöön</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation type="unfinished">Palautus epäonnistui</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation type="unfinished">Ei voi palauttaa malli ja asetus tietoja lähettimestä. Mallit ja asetukset löytyy tiedostosta: %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4249,47 +4293,47 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation type="unfinished">ie: OpenTX 9X tai OpenTX 9XR</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation type="unfinished">ie: OpenTX M128 / 9X tai OpenTX 9XR M128 sirulla</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation type="unfinished">ie: OpenTX Gruvin9X</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4298,7 +4342,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 Tarkasta asetuksista CPU:n oikea tyyppi.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4307,7 +4351,7 @@ Please select an appropriate firmware type to program it.</source>
 Valitse oikea firmware jonka ohjelmoit.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4316,22 +4360,22 @@ Käytät nyt:
 %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation type="unfinished">SULAKKEET: Ala=%1 Kork=%2 Lis=%3</translation>
     </message>
@@ -4339,7 +4383,7 @@ Käytät nyt:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
@@ -4390,225 +4434,240 @@ Käytät nyt:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>??Rotary Encoder?? %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>GVAR%1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Popupit sallittu</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished">Trimmi pois</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished">Oma trimmi</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished">Käytä trimmiä lentotilaan %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished">Käytä trimmiä lentotilaan %1 + Oma trimmi asetuksena</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished">Yksikkö</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">GV%1</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Oma arvo</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished">Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished">Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4616,17 +4675,17 @@ Käytät nyt:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>Lentotila %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation> (%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (oletus)</translation>
     </message>
@@ -4634,17 +4693,17 @@ Käytät nyt:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>ON flybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>EI flybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>Flybar:</translation>
     </message>
@@ -4652,17 +4711,17 @@ Käytät nyt:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished">Kelt</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished">Orans</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4670,13 +4729,13 @@ Käytät nyt:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished">V</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
@@ -4694,17 +4753,18 @@ Käytät nyt:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished">Aloitus</translation>
     </message>
@@ -4714,7 +4774,12 @@ Käytät nyt:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4722,8 +4787,13 @@ Käytät nyt:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4868,13 +4938,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Proceed only if you know what you are doing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4882,44 +4952,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished">Oma arvo</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation type="unfinished">Lento tila %1 arvo</translation>
     </message>
 </context>
 <context>
@@ -4947,57 +5007,57 @@ These will be relevant for all models in the same EEPROM.</source>
 Nämä vaikuttaa kaikkiin malleihin jotka on EEPROMilla.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Traineri</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>Väärää dataa profiilissa, radion kalibraatio tietoja ei noudettu</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>Väärää dataa profiilissa, HW parametreja ei noudettu</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>Haluatko tallentaa kalibraation %1 profiiliin&lt;br&gt;Vanha kalibraatio poistetaan ?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>Kalibraatio ja HW parametrit tallennettu.</translation>
     </message>
@@ -5036,8 +5096,8 @@ Nämä vaikuttaa kaikkiin malleihin jotka on EEPROMilla.</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Lento tilat</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5073,185 +5133,208 @@ Nämä vaikuttaa kaikkiin malleihin jotka on EEPROMilla.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished">Kytkin</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">Traineri</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">Korjaus</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished">Normaali</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">Mode 1 (PER KOR KAA SII)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished">Mode 2 (PER KAA KOR SII)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">Mode 3 (SII KOR KAA PER)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">Mode 4 (SII KAA KOR PER)</translation>
     </message>
 </context>
 <context>
@@ -5267,201 +5350,199 @@ Nämä vaikuttaa kaikkiin malleihin jotka on EEPROMilla.</translation>
         <translation type="unfinished">Vainlue tilan avaus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation type="unfinished">SC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation type="unfinished">SE</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation type="unfinished">SA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation type="unfinished">SF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation type="unfinished">SH</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation type="unfinished">SD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation type="unfinished">SB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation type="unfinished">SG</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation type="unfinished">Ajansiirto UTC:stä</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation type="unfinished">Äänen kieli</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation type="unfinished">Maa koodi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation type="unfinished">FAI tila</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation type="unfinished">Vario ääni kun max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation type="unfinished">Hz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation type="unfinished">Äänen voimakkuus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation type="unfinished">Taustavalon kytkin</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation type="unfinished">Ääni tila</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation type="unfinished">Väri 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation type="unfinished">Väri 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation type="unfinished">Äänen korkeus (vain kaj.)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation type="unfinished">Jos tämä arvo ei ole 0, jokainen painallus sytyttää taustavalon, sammuu valitun ajan jälkeen ( SEK).</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation type="unfinished">sec</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation type="unfinished">Taustavalon väri</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation type="unfinished">Piipperi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation type="unfinished">Kaiutin</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation type="unfinished">Piippausääni</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation type="unfinished">Kaiutinääni</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation type="unfinished">Piippaus voluumi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation type="unfinished">Wav voluumi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation type="unfinished">Vario voluumi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation type="unfinished">Taustan voluumi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation type="unfinished">ms</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation type="unfinished">Taustavalo pois automaattisesti</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation type="unfinished">Taustavalo vilkkuu hälytyksenä</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation type="unfinished">Vario ääni kun nolla</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation type="unfinished">Varion toisto nollassa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5471,7 +5552,7 @@ Nämä vaikuttaa kaikkiin malleihin jotka on EEPROMilla.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5486,42 +5567,42 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Values can be 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation type="unfinished">Taustavalon kirkkaus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation type="unfinished">RotEnc navigaatio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation type="unfinished">Amerikka</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation type="unfinished">Japani</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation type="unfinished">Eurooppa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5565,252 +5646,112 @@ Tila 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished">Mode 1 (PER KOR KAA SII)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished">Mode 2 (PER KAA KOR SII)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished">Mode 3 (SII KOR KAA PER)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished">Mode 4 (SII KAA KOR PER)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kanava järjestys&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Määrittelee miksereiden perusasetukset uuteen malliin.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation type="unfinished">P Ko Ka S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation type="unfinished">P Ko S Ka</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation type="unfinished">P Ka Ko S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation type="unfinished">P Ka S Ko</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation type="unfinished">P S Ko Ka</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation type="unfinished">P S Ka Ko</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation type="unfinished">Ko P Ka S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation type="unfinished">Ko P S Ka</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation type="unfinished">Ko Ka P S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation type="unfinished">Ko Ka S P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation type="unfinished">Ko S P Ka</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation type="unfinished">Ko S Ka P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation type="unfinished">Ka P Ko S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation type="unfinished">Ka P S Ko</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation type="unfinished">Ka Ko P S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation type="unfinished">Ka Ko S P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation type="unfinished">Ka S P Ko</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation type="unfinished">Ka S Ko P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation type="unfinished">S P Ko Ka</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation type="unfinished">S P Ka Ko</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation type="unfinished">S Ko P Ka</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation type="unfinished">S Ko Ka P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation type="unfinished">S Ka P Ko</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation type="unfinished">S Ka Ko P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5821,320 +5762,353 @@ Tämä on jännitealue jolloin akun varoitus ääni annetaan.
 Hyväksytty arvo: 3v - 12v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished">Traineri</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation type="unfinished">Tikku tila</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation type="unfinished">Metrit</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation type="unfinished">Imperiaali</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation type="unfinished">Kanavien järjestys</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation type="unfinished">GPS koordinaatit</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation type="unfinished">v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation type="unfinished">Käyttämättömyys ajastin</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation type="unfinished">Näytä alkuruutu käynnistyksessä</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation type="unfinished">Kontrasti</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation type="unfinished">Värinän voimakkuus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation type="unfinished">LCD näytön tyyppi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation type="unfinished">&quot;Ei ääniä&quot; hälytys</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation type="unfinished">Akun varoitin</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation type="unfinished">Värinän pituus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation type="unfinished">MAV linkki baudit</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation type="unfinished">Äänetön</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation type="unfinished">Vain hälyt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation type="unfinished">Ei nap</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation type="unfinished">Kaikki</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation type="unfinished">Vakio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation type="unfinished">Optrex</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation type="unfinished">Jos tämä arvo ei ole 0, piipataan valitun ajan jos mitään käskyjä ei tule ( MIN ).</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">0s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">0.5s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation type="unfinished">2s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation type="unfinished">3s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation type="unfinished">4s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation type="unfinished">6s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation type="unfinished">8s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation type="unfinished">10s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation type="unfinished">15s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation type="unfinished">4800 Baudia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation type="unfinished">9600 Baudia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation type="unfinished">14400 Baudia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation type="unfinished">19200 Baudia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation type="unfinished">38400 Baudia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation type="unfinished">57600 Baudia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation type="unfinished">76800 Baudia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation type="unfinished">115200 Baudia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6159,67 +6133,67 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation type="unfinished">X-lyhyt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation type="unfinished">Lyhyt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation type="unfinished">Normaali</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation type="unfinished">Pitkä</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation type="unfinished">X-Pitkä</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation type="unfinished">NMEA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation type="unfinished">Toista viive (kytkin keskiasennossa)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation type="unfinished">Mittayksiköt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation type="unfinished">Värinä tila</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation type="unfinished">Piippaus pituus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation type="unfinished">Piipperin moodi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6236,12 +6210,14 @@ p, li { white-space: pre-wrap; }
 4 -Erittäin voimakas.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation type="unfinished">Vain hälyt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished">1s</translation>
     </message>
@@ -6249,179 +6225,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished">Napit</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished">Tikut</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished">Napit + Tikut</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished">ON</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished">Englanti</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished">Ranska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished">Italia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished">Saksa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished">Tsekki</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished">Slovakia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished">Espanja</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished">Puola</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished">Portugali</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished">Ruotsi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished">Ei</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished">RotEnc A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">RotEnc B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">RotEnc C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">RotEnc D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">RotEnc E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished">Normaali</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6429,17 +6405,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>Ei</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Kyllä, ohjataan kytkimellä</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Kyllä, ohjataan potikalla</translation>
     </message>
@@ -6447,118 +6423,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Käänteinen</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6639,22 +6625,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>Kaasu kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>Yaw kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>Pitch kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>Roll kanava:</translation>
     </message>
@@ -6662,18 +6648,18 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished">Väärä EEPROM tiedosto %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Virhe kirjottaessa tiedostoa %1:
@@ -6683,159 +6669,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Tyhjennä kaikki tulot</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished">Viivat</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;Lisää</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;Muuta</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation>Entteri</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>&amp;Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopio</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>&amp;Leikkaa</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>&amp;Liitä</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>Jäl&amp;jennä</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished">Tulo</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6876,96 +6862,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6973,17 +6959,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished">KÄÄNT</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished">NOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6991,7 +6977,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
     </message>
@@ -6999,122 +6985,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished">a&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished">a&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished">|a|&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished">|a|&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished">JA</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished">TAI</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished">KÄÄNT TAI</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished">a=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished">a!=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished">a&gt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished">a&lt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished">a&gt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished">a&lt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished">d&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished">|d|&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished">a=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished">a~x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished">Ajastin</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished">Lukko</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished">Reuna</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished">Tuntematon</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7122,112 +7108,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation>V1</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation>V2</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>Kesto</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>Viive</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>Toiminto</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>JA kytkin</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">Yhtämittainen</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished">Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished">Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7280,126 +7271,126 @@ Are you sure ?</source>
         <translation type="unfinished">Lento jakso</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation type="unfinished">Telemetria logit</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Ei voi kirjoittaa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation type="unfinished">Valitse logi tiedosto</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation type="unfinished">Valittavana olevat kentät</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation type="unfinished">Valittu logi sisältää: %1 virhe riviä, kokomäärästä  %2 riviä</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7407,736 +7398,736 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Tiedosto ladattu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>Uusi teema  otetaan käyttöön Companionissa kun se käynnistettään seuraavan kerran.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Tiedosto tallennettu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>Jos meinaat että tämä ohjelma on hyvä. Teeppä hyvä teko ja: &lt;a href=&apos;%1&apos;&gt;Lahjoita&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>Tietoja Companionista</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Uusi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>Avaa...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Tallenna nimellä...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Poistu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Poistu ohjelmasta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>Klassinen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Avaa mallit ja asetukset </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Lue mallit ja asetukset lähettimestä</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>Tallenna lähettimen varmuuskopio tiedostoon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Lue firmware tiedostosta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Luo uusi mallit ja asetukset tiedosto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Tallenna mallit ja asetukset tiedostoon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>Klassiset Companion iconit teema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation>Yerico</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Hunajan keltaiset ikonit teema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>Yksivärinen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>Yksivärisen teeman musta ikoni tyyli</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>Simppeli valkoinen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>Yksivärisen teeman valkoinen ikoni tyyli</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>Simppeli sininen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation type="unfinished">Sulje</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>Yksivärisen teeman sininen ikoni tyyli</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Pieni</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>Käytä pieniä ikoneita työkalupalkissa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Normaali</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>Käytä normaaleita ikoneita työkalupalkissa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Iso</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>Käytä isoja ikoneita työkalupalkissa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Valtava</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>Käytä valtavia ikoneita työkalupalkissa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>Järjestelmän kieli</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished">Profiilia ei voida poistaa</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished">Nykyistä profiilia ei voida poistaa.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>Näytä logi tiedosto...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Avaa ja näytä logi tiedosto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Asetukset...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Vertaa malleja...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Muuta lähettimen  alkuruutu kuvaa...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>Muuta alkuruutua omaan lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Lue firmware lähettimestä</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>Lue firmware lähettimestä</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Kirjoita firmware lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Kirjoita firmware lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Kirjoita mallit ja asetukset lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Kirjoita mallit ja asetukset lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Lue mallit ja asetukset lähettimestä</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>Määrittele yhteydet...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>Asetetaan ohjelma joka lukee ja kirjoittaa tiedot lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Kirjoita varmuuskiop lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Kirjoita varmuuskopio tiedosto lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Varmuuskopio lähetin tiedostoon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>Tallenna täydellinen varmuuskopio kaikista malleista ja asetuksista lähettimeen</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Tallenna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation>%2</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>Näytä sovelluksen tietoja ikkuna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Muuta asetuksia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Vertaa malleja</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Lisää lähettimen profiili</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>Viimeisimmät tiedostot</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Aseta valikon kieli</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Aseta ikonien teema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Aseta ikonien koko</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Tiedosto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Muuta</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Lue/Kirjoita</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Apu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>Kirjoita</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Valmis</translation>
     </message>
@@ -8144,137 +8135,137 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished">Alt+S</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished">Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished">Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished">Haluatko päällekirjoittaa radion yleiset asetukset ?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Muutetaan mallia %1: </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Ei löydy tiedostoa %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Virhe avattaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Virhe luettaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Tallenna nimellä</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation type="unfinished">
@@ -8283,7 +8274,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation type="unfinished">
@@ -8292,241 +8283,241 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Muuta</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation type="unfinished">Malli</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation type="unfinished">Apuri</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -8534,69 +8525,69 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 on modifoitu.
 Haluatko tallentaa muutokset ?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Väliaikaiseen tiedostoon ei voida kirjoittaa!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>Avaa varmuuskopio  mallit ja asetukset </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>Väärää tietoa varmuuskopio tiedostossa %1</translation>
     </message>
@@ -8604,143 +8595,148 @@ Haluatko tallentaa muutokset ?</translation>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8748,12 +8744,12 @@ Haluatko tallentaa muutokset ?</translation>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8766,65 +8762,82 @@ Haluatko tallentaa muutokset ?</translation>
         <translation>Mikserit</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">0.00</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Viive</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Hidas</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Myös trimmi</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Tasoitus</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Paino</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8839,163 +8852,112 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Lähde</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Multiplexi</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Mikserissä käytettävä käyrä</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>Myös DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Lento tilat</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Kytkin</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>Mikserin varoitus.
-Tämän arvon asettaminen aiheuttaa piippauksen aina kun arvo on aktiivinen.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>Pois</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 Piip</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2 Piip</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 Piip</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>Ei</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Kyllä</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>Lähde miksereille</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Multipelxeri
-
-Tämä määrittää kuinka mikserin arvot lisätään.
-
-&quot;+&quot; tarkoittaa että arvo lisätään edellisiin miksereihin samalle kanavalle.
-&quot;*&quot; tarkoittaa että arvo kerrotaan edellisiin miksereihin samalle kanavalle.
-&quot;R&quot; tarkoittaa että arvo korvaa edellisen mikserin arvon . Jos kytkin on OFF arvoa ei huomioida.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>Lisää</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>Kerro</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>Korvaa</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Käyrä</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Mikserissä käytetty kytkin.
-Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9003,22 +8965,22 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9026,136 +8988,136 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Tyhjennä mikserit</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>Ei enempää vapaita miksereitä!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;Lisää</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;Muuta</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>Entteri</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>&amp;valitse korostettu</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopio</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>C&amp;ut</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>&amp;Liitä</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>Jäl&amp;jennä</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>Tyhjennä mikserit?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>Varmasti tyhjennä kaikki mikserit?</translation>
     </message>
@@ -9163,19 +9125,24 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished">Kaasun lähde</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation type="unfinished">KAA</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9223,32 +9190,49 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
+        <translation type="unfinished">Pois</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished">---</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9266,63 +9250,58 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
         <translation>Simuloi</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>Kopteri</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Lento tilat</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Tulot</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Mikserit</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Loogiset kytkimet</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Käyrät</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Spesiaali toiminnot</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Telemetria</translation>
     </message>
@@ -9376,8 +9355,8 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Lento tilat</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9413,585 +9392,595 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation type="unfinished">Expo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation type="unfinished">Eri hieno</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation type="unfinished">Hieno</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation type="unfinished">Keski</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation type="unfinished">Karkea</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation type="unfinished">Tuntematon</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished">Päälle</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished">Kyllä</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished">Ei</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished">ON</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished">Moodi</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished">Kanavat</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished">PPM viive</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished">Napaisuus</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished">Protokolla</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished">Viive</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished">Vastaanotin</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation type="unfinished">90</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation type="unfinished">120</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation type="unfinished">120X</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation type="unfinished">140</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished">Lento tilat</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished">Lento tila</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished">Kaikki</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished">Reuna</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished">Lukko</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished">Ajastin</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished">Kesto</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished">Laajemman rajat</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished">Näytä teht.lista</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished">Käsin</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished">Autom</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished">Turvatila</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished">Pidä</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished">Lähde</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished">Varoitus</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished">FrSky S.PORT</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished">FrSky D</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished">FrSky D (kaapeli)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished">Kork</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished">Kork+</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished">Vnopeus</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished">A1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished">A2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished">A3</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished">A4</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished">FAS</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished">Kennoja</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished">Palkit</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished">Tiedoston nimi</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation type="unfinished">FM%1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation type="unfinished">FM%1%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation type="unfinished">Ei trimmiä</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation type="unfinished">Ei DR / Expoja</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation type="unfinished">Tasoitus(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation type="unfinished">Omat</translation>
     </message>
@@ -9999,27 +9988,27 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Lentokone</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>Moniroottori / autogiro</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Helikopteri</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Mallin nimi:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Mallin tyyppi:</translation>
     </message>
@@ -10027,27 +10016,27 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10303,285 +10292,290 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished">Positiivinen</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished">Negatiivinen</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished">Trainerin portti</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished">Sisäinen radio systeemi</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished">Ulkoinen radio systeemi</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished">Extra Radio järjestelmä</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished">Radio systeemi</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10589,57 +10583,57 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation type="unfinished">Arvo</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation type="unfinished">Pidä</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10647,456 +10641,456 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation type="unfinished">Tulo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation type="unfinished">Paino</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation type="unfinished">Kopt Collective</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation type="unfinished">Lento tilat</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation type="unfinished">Lento tila</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation type="unfinished">Kytkin</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished">Mallin kuva</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished">Kaasu</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished">Kytkin varoitukset</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished">Potikka varoitus</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished">Aika</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished">Laskuri</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">Moodi</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished">Aloitus</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished">Helikopteri</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Toiminto</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished">Protokolla</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished">Korkeusmittaus</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished">Variom lähde</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished">Parametrit</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation type="unfinished">GV%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation type="unfinished">Nimi</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished">Alitrimmi</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished">Käyrä</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished">Suora</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation type="unfinished">Globaalit muuttujat</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation type="unfinished">Tulot</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation type="unfinished">Mikserit</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation type="unfinished">Käyrät</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation type="unfinished">L%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation type="unfinished">Loogiset kytkimet</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation type="unfinished">SF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation type="unfinished">Spesiaali toiminnot</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation type="unfinished">Yksikkö</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11104,7 +11098,7 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11112,22 +11106,22 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Kaasun kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Yaw kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Pitch kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Roll kanava:</translation>
     </message>
@@ -11135,22 +11129,22 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11158,17 +11152,17 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Kaasu pakko pois</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Kaasu ajastin</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Lento ajastin</translation>
     </message>
@@ -11176,40 +11170,40 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Virhe avattaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Virhe kirjottaessa tiedostoa %1:
@@ -11239,17 +11233,17 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
         <translation>Tulosta tiedostoon</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Tulosta dokumentti</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11276,12 +11270,12 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation type="unfinished">Sulje</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished">Peruuta</translation>
     </message>
@@ -11297,22 +11291,22 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11320,24 +11314,24 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11345,97 +11339,107 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished">Toiminto</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished">Uusi</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11443,30 +11447,30 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Ei voi kirjoittaa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11474,12 +11478,12 @@ Jos tyhjä mikserin katsotaan olevan &quot;ON&quot; kokoajan.</translation>
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11575,12 +11579,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation type="unfinished">FM%1</translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished">GV%1</translation>
     </message>
@@ -11596,358 +11605,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished">V</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished">s</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation type="unfinished">tPER</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation type="unfinished">tKOR</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation type="unfinished">tKAA</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation type="unfinished">tSII</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished">Batt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished">Aika</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished">REa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished">REb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished">LUA%1%2</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished">CYC%1</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Lähde</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">Ei mitään</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished">REa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished">REb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished">ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished">THs</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished">TH%</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished">THt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished">Yksi</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished">----</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished">Kytkin</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">Ei mitään</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation>Ei</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>Kyllä</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;Peräsin kanava:</translation>
     </message>
@@ -11955,20 +12064,20 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Virhe avattaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11976,319 +12085,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished">Kork</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished">Yksikkö</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished">Tasoitus</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished">Prop lavat</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished">Filtteri</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished">Positiivinen</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished">Omat</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished">Kenno</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished">Raaka ( - )</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished">V</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished">A</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished">m/s</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished">km/h</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished">mph</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished">metri</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished">°C</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished">mAh</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished">W</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished">g</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished">°</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12509,87 +12633,87 @@ Jos tämä valittuna, kaasu toimii käänteisesti. Tyhjäkäynti on ylhäällä,
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished">Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished">Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12597,7 +12721,7 @@ Jos tämä valittuna, kaasu toimii käänteisesti. Tyhjäkäynti on ylhäällä,
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Korkeusper kanava:</translation>
     </message>
@@ -12605,204 +12729,204 @@ Jos tämä valittuna, kaasu toimii käänteisesti. Tyhjäkäynti on ylhäällä,
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12810,121 +12934,121 @@ Jos tämä valittuna, kaasu toimii käänteisesti. Tyhjäkäynti on ylhäällä,
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
@@ -12934,7 +13058,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13083,74 +13207,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13275,32 +13399,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13313,67 +13437,72 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished">Companion simulaattori</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished">Ei voi avata joystickia, joystick pois käytöstä</translation>
     </message>
@@ -13400,17 +13529,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>Kuvakirjasto - sivu %1 tai %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>Väärä kuva kirjastossa %1</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>Yhtään kuvaa ei löydy kuva kirjastosta, tarkista asetukset</translation>
     </message>
@@ -13418,7 +13547,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>Kanava %1</translation>
     </message>
@@ -13426,7 +13555,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished">Ei löydy tiedostoa %1!</translation>
     </message>
@@ -13435,9 +13564,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13462,19 +13591,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13483,47 +13612,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13531,141 +13660,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13673,17 +13802,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>Peräsin kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Korkeusper kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13691,22 +13820,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Korkeusper ja peräsin</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Vain korkeusper</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>V-Peräsin</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Perän tyyppi:</translation>
     </message>
@@ -14038,7 +14167,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">Telemetria ruutu %1</translation>
     </message>
@@ -14046,28 +14175,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Ala hälytys</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Kriittinen hälytys</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation>erikoistoiminto korkea</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>erikoistoiminto korkea (ei tuettu)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished">metri</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished">km/h</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vspd</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished">mAh</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">Virta</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Kork</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished">A4</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished">°C</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished">km/h</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vspd</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished">A3</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Bensa</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">Virta</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Kork</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Bensa</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vspd</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished">°C</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished">Batt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Kork</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished">metri</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">Virta</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14184,72 +15246,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished">Poista</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished">Siirrä ylös</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished">Siirrä alas</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14262,354 +15324,123 @@ Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation type="unfinished">RSSI</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation type="unfinished">A1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation type="unfinished">A2</translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
         <translation type="unfinished">Simuloi</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished">25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation type="unfinished">&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation type="unfinished">X</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished">1/5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished">5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Ei mitään</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation type="unfinished">A3</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation type="unfinished">A4</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation type="unfinished">Bensa</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation type="unfinished">°C</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation type="unfinished">%</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation type="unfinished">Kork</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation type="unfinished">Vspd</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation type="unfinished">m/s</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation type="unfinished">km/h</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation type="unfinished">AccX</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation type="unfinished">AccZ</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation type="unfinished">Virta</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation type="unfinished">AccY</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14618,78 +15449,35 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Kyllä</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>Ei</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;Kaasu kanava:</translation>
     </message>
@@ -14715,138 +15503,138 @@ hh:mm:ss</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished">Äänetön</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">Piipit</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">Ääni</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">Toista värinä</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished">5s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished">10s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished">20s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished">30s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">Ei yhtämittainen</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">Jatkuva (lento)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">Jatkuva (manuaalinen nollaus)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished">Aloitus</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished">THs</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished">TH%</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished">THt</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14854,22 +15642,22 @@ hh:mm:ss</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Sum)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Korvaa)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
@@ -14877,27 +15665,27 @@ hh:mm:ss</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">Moodi</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Paino</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Lähde</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14907,6 +15695,210 @@ hh:mm:ss</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14934,47 +15926,47 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14987,22 +15979,42 @@ hh:mm:ss</source>
         <translation type="unfinished">Firmware</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15010,285 +16022,317 @@ hh:mm:ss</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15304,63 +16348,90 @@ hh:mm:ss</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15453,32 +16524,32 @@ hh:mm:ss</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15491,22 +16562,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15519,22 +16590,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15558,17 +16629,17 @@ hh:mm:ss</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15576,37 +16647,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15722,32 +16793,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15755,32 +16826,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">Info</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15788,12 +16859,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>1. V-per kanava:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>2. V-per kanava:</translation>
     </message>
@@ -15801,55 +16872,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation type="unfinished">Kesk Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation type="unfinished">Kesk X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Normaali siipi</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Lentävä siipi / Delta siipi</translation>
     </message>
@@ -15857,22 +16928,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15880,273 +16951,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Apuri</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Mallin tyyppi</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Anna mallille nimi ja tyyppi.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Kaasu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>Onko mallissa moottoria ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Siiven tyyppi</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>Onko malli: Lentäväsiipi / Deltasiipi vai ihan perus siipi ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>Siivekkeet</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>Onko mallissa siivekkeet ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Laipat</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>Onko mallissa laipat ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Lentojarrut</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>Onko mallissa lentojarruja ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Lentäväsiipi / Deltasiipi</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Valitse elevonien kanavat</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Sivuperäsin</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>Onko mallissa peräsin ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Perän tyyppi</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Valitse minkä tyyppinen perä mallissa on.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Perä</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Valitse kanava perän ohjaamiseen.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>V-Peräsin</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Korkeusper kanava.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>Sarjoissa</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>Minkä tyypin &quot;Swash&quot; ohjaus kopterissa on ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>Perän gyro</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>Onko kopterissa säädettävä gyro perän ohjaamiseen ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>Roottorin tyyppi</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>Onko kopterissa flybar ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Helikopteri</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>Valitse kopterin ojaimet</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>Moniroottori</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Valitse moniroottorin ohjain kanavat</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Mallin valinnat</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Vaitse lisävalinnat</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>Talenna muutokset</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Tarkasta kaikki ohjain pinnat että ne toimii oikeaan suuntaa! Muista irroittaa propelli kun testaat asetuksia ensimmäistä kertaa. &lt;br&gt; Muista että jos jatkat kaikki vanhat asetukset kyseiseeen malliin poistetaan !</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Anna mallille nimi sekä tyyppi.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Valitse vastaanottimen kanava joka on kytketti ESCiin / Kaasun servoon.&lt;br&gt;&lt;br&gt;Kaasu - Spektrum: CH1, Futama: CH3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>Yleisesti lentokoneissa on siipi ja peräsimet, joissa on ohjainpinnat. Lentäväsiipi ja deltasiipi koneissa on yksi siipi. Siiven ohjainpintoja kutsutaan siivekkeiksi jolla konetta kallistetaan.&lt;br&gt;Lentävänsiiven ja deltasiiven ohjaus tapahtuu siivenohjainpinnalla jolla kone kallistuu sekä nousee tai laskee.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>Mallit käyttää siivekkeisiin joko yhtä tai kahta kanavaa.&lt;br&gt; Niin kutsuttu Y-kaapeli yhdistää molemmat siiveke servot yhteen kanavaan. Jos yhdistät käyttäen Y-kaapelia niin valitse yhden servon valinta.&lt;br&gt;&lt;br&gt;Siiveke -Spektrum: CH2, Futaba: CH:1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>Malli käyttää kahta kanavaa elevonien käyttämiseen. &lt;br&gt;Valitse nämä kaksi kanavaa</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>Tämä apuri olettaa että laippoja ohjataan kytkimellä. Jos laippoja ohjataan potikalla, voit muuttaa sen myöhemmin valikosta.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>Lentojarruja käytetään vähentämään lentonopeutta isommissa liidokeissa/ Purjekoneissa.&lt;br&gt; Ne ovat aika harvinaisia muun tyyppisissä koneissa.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Valitse vastaanottimen kanava joka kytketty peräsimeen.&lt;br&gt;&lt;br&gt;Peräsin - Spektrum: CH4, Futaba: CH4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Valitse mallin perän tyyppi.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Valitse peräsimen ja korkkarin kanavat.&lt;br&gt;&lt;br&gt;Peräsin - Spektrum:CH4, Futaba: CH4&lt;br&gt;Korkkari -Spektrum:CH3, Futaba:CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Valitse korkkarin kanava.&lt;br&gt;&lt;br&gt;Korkkari -Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation>TBD.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Valitse kanavat monimoottorille.&lt;br&gt;&lt;br&gt;Kaasu -Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>Tähän kohtaan ei ole tarjolla apu sivua.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Malli apurin ohje</translation>
     </message>
@@ -16154,37 +17225,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>Lentokone</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>Multikopteri</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>Helikopteri</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>Mallin nimi:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>Mallin tyyppi: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>Valinnat: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>Kanava %1: </translation>
     </message>
@@ -16192,46 +17263,46 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Virhe avattaessa tiedostoa %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16239,16 +17310,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16257,10 +17331,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16367,18 +17456,18 @@ m2560 joka on v4.1 lähettimessä</translation>
         <translation>Käytä lisä toimintoja</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>DFU-UTIL määrittely</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>SAM-BA määrittely</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Valitse kohde</translation>
     </message>
@@ -16416,7 +17505,7 @@ m2560 joka on v4.1 lähettimessä</translation>
         <translation type="unfinished">Aloitus</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>Seuraava</translation>
     </message>
@@ -16426,59 +17515,59 @@ m2560 joka on v4.1 lähettimessä</translation>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished">Joystickia ei löydy</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>Ei voi avata joystickia.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_fr.ts
+++ b/companion/src/translations/companion_fr.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Oui, contrôlés par 1 voie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Oui, contrôlés par 2 voies</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;Première voie ailerons:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>Deuxième voie aileron:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Oui, contrôlés par une seule voie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Oui, contrôlés par 2 voies</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;Première voie de volets:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>Deuxième voie de volets:</translation>
     </message>
@@ -60,24 +60,24 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation>Les paramètres de l&apos;application ont été enregistrés dans
  %1</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation>Impossible d&apos;enregistrer les paramètres de l&apos;application dans le fichier &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation>car le fichier n&apos;a pas pu être enregistré (vérifiez les autorisations d&apos;accès).</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation>pour raisons inconnues.</translation>
     </message>
@@ -170,22 +170,22 @@
         <translation>Profil de radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>Ordre des voies par défaut</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>Mode Manches par défaut</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>Sélectionner une image</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -226,662 +226,657 @@ Manche Droit:  Profondeur, Direction
 </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Mode 1 (DIR PROF GAZ AIL)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Mode 2 (DIR GAZ PROF AIL)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Mode 3 (AIL PROF GAZ DIR)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Mode 4 (AIL GAZ PROF DIR)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>Ecran d&apos;accueil</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>Dossier de sauvegarde spécifique au profil courant, si défini remplace le paramètre de l&apos;application</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>Dossier de sauvegarde</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>Si défini, remplace le paramètre de l&apos;application pour ce profil</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>Si défini, remplace le paramètre de l&apos;application pour ce profil</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordre des voies&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Détermine l&apos;ordre des mixages par défaut sur un nouveau modèle.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation>Langage</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation>Invite à écrire le firmware sur la radio après la mise à jour</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>D P G A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>D P A G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>D G P A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>D G A P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>D A P G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation>D A G P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>P D G A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>P D A G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>P G D A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>P G A D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>P A D G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>P A G D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>G D P A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>G D A P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>G P D A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>G P A D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>G A D P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>G A P D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>A D P G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>A D G P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>A P D G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>A P G D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>A G D P</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>A G P D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>Sélectionner dossier</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation>Module Int. par Défaut</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation>Ajouter le numéro de version au nom du firmware</translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation>Invite à exécuter SD Sync après mise à jour</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>Conservez un journal de tous les messages de débogage générés par  Companion/Simulateur. Un développeur EdgeTX peut demander cela pour aider à diagnostiquer un problème</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation>Afficher l&apos;écran de démarrage</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation>Supprimez les emplacements vides lors de la suppression de modèles (s&apos;applique uniquement aux radios sans étiquettes)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished">Profil radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation>Mettre à jour paramètres</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation>Vérifier fréquence</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation>Réinitialiser les paramètres par défaut</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation>Dossiers</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation>Télécharger</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation>Créer des sous-dossiers dans le dossier de téléchargement</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation>Décompresser</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation>Utiliser la structure SD du profil radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation>Composants</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation>Supprimer téléchargements</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation>Supprimer les décompressions</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation>Enregistrement</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>Sélectionner exécutable</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation>Canal de version</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>Gain de volume du simulateur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation>Commandes du simulateur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation>Enregistrer les positions des inters/pots à la sortie du simulateur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation>Effacer les positions enregistrées</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>Nom du profil</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>Effacer l&apos;image</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>Type de radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>Autres paramètres</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>Paramètres Généraux</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>Chemin structure carte SD</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>Paramètres de l&apos;application</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>Activer sauvegarde automatique avant écriture firmware</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>Bibliothèque de l&apos;écran d&apos;accueil</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Exécutable Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>Ne montrer que les images de l&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>Montrer les images de Companion et de l&apos;utilisateur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>Ecrans d&apos;accueil personnalisés</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>Dossier des sauvegardes automatiques</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>Paramètres du simulateur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>Rétroéclairage du simulateur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation>Action lors Ajout Nouveau Modèle</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;b&gt;&lt;u&gt;/!\&lt;/u&gt; Uniquement pour les radios sans catégories &lt;u&gt;/!\&lt;/u&gt;&lt;/b&gt;&lt;/p&gt;&lt;p&gt;Cette option maintient le comportement des anciennes versions d’OpenTx où les emplacements des modèles vides sont conservés lorsqu&apos;un modèle est supprimé ou déplacé.&lt;/p&gt;&lt;p&gt;Lorsque cette option est désélectionnée, les autres modèles peuvent être réarrangés pour combler l&apos;écart laissé par le modèle supprimé.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation>fichiers récemment utilisés</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation>Paramètres de démarrage</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation>Rappel</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation>Dossier des logs sauvegardés</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation>Log les messages de debug</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation>Application (Companion/Simulateur)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Conserver un log de tous les messages générés par le firmware radio lors de l&apos;exécution du Simulateur. C&apos;est la même information visible depuis le Simulateur dans la &lt;span style=&quot; font-style:italic;&quot;&gt;Fenêtre de débogage&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation>Firmware radio (dans Simulateur)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation>Afficher le choix du profil radio&quot; au démarrage</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation>Invite à exécuter le programme d&apos;installation après la mise à jour</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation>Mise à jour</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>Bleu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>Jaune</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation>Dossier des captures d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>Joystick</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>Calibrer</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>Capturer uniquement dans le presse-papier</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Ma radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Vous ne pouvez pas changer de type de radio ou modifier les options de compilation tant que les changements ne sont pas sauvegardés. Que souhaitez-vous faire?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Sauvegarder tout&lt;/i&gt; - Enregistrez le(s) fichier(s) ouvert(s) avant d&apos;enregistrer les paramètres.&lt;li&gt;&lt;li&gt;&lt;i&gt;Réinitialiser&lt;/i&gt; - Revenir aux précédentes options de type et de compilation de la radio avant d&apos;enregistrer les paramètres&lt;/li&gt;&lt;li&gt;&lt;i&gt;Annuler&lt;/i&gt; - Retournez dans la boîte de dialogue de l&apos;éditeur de paramètres.&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Sélectionner le dossier de captures d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation>Paramètres de mise à jour: chemin du dossier de téléchargement manquant !</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation>Paramètres de mise à jour: chemin du dossier de décompression manquant !</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation>Paramètres de mise à jour : chemin du dossier de mise à jour manquant !</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation>Paramètres de mise à jour: le dossier de décompression et de téléchargement ont le même chemin !</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Aucun Joystick trouvé</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>VIDE: Aucune donnée stockée dans le profil</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>DISPONIBLE: Paramètres enregistrés à une date inconnue</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>DISPONIBLE: Paramètres enregistrés le %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation>Réinitialisez tous les paramètres de mise à jour aux valeurs par défaut. Etes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation>Les paramètres de mise à jour ont été réinitialisés. Veuillez fermer et redémarrer Companion pour éviter tout comportement inattendu !</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation>Sélectionnez votre dossier de téléchargement</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation>Sélectionnez votre dossier de décompression</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation>Sélectionnez votre dossier de mise à jour</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation>Vérifier</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Sélectionner le dossier de bibliothèque</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Sélectionner le dossier de sauvegarde des paramètres et modèles</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation>Sélectionner un dossier pour le log des applications</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Sélectionnez l&apos;emplacement de l&apos;exécutable Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Sélectionner le dossier contenant une copie des dossiers carte SD</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Ouvrir l&apos;image à charger</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Images (%1)</translation>
     </message>
@@ -889,31 +884,31 @@ Manche Droit:  Profondeur, Direction
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation>Erreur de lecture %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation>Sauvegarde EEPROM impossible</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Impossible d&apos;ouvrir le fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Erreur d&apos;écriture du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation>Fichier EEPROM invalide %1</translation>
     </message>
@@ -951,33 +946,33 @@ Manche Droit:  Profondeur, Direction
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -988,273 +983,283 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Potentiomètre avec centre</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation>2 Positions momentané</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation>2 Positions</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 Positions</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Fonction</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">Petites</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">Les 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">Vol</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation>Plage négative</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation>Centre</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation>Plage Positive</translation>
     </message>
@@ -1262,132 +1267,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation>Subtrim</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation>Direction</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation>Courbe</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation>Trace</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation>Neutre PPM</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation>Subtrim linéaire</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation>VOIE%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation>Menu contextuel disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation>---</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation>INV</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation>Supprimer Voie. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation>Couper la Voie. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation>Tout Effacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation>Effacer la Voie. Êtes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation>Effacer toutes les Voies. Êtes-vous sûr ?</translation>
     </message>
@@ -1430,57 +1435,57 @@ Error description: %4</source>
         <translation>Fichier: inconnu</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation>Ouvrir Checklist</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation>Fichier Checklist (*.txt)</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation>Checklist Modèle</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished">Impossible d&apos;ouvrir le fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation>Ligne %1, Col %2</translation>
     </message>
@@ -1496,12 +1501,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation>Interface Utilisateur</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation>Vue Principale %1</translation>
     </message>
@@ -1509,174 +1514,184 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation>Paramètres de l&apos;application</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation>fichiers</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation>EdgeTX Companion</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation>Paramètres Radio et Modèles</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt; Le type de radio sélectionnée dans le profil n&apos;existe pas. Utilisez plutôt le type par défaut. &lt;/p&gt; &lt;p&gt;&lt;b&gt;Veuillez mettre à jour les paramètres de votre profil!&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation>Sélectionnez ou créez un fichier pour les paramètres exportés:</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation>Appuyez sur le bouton &apos;Réessayer&apos; pour choisir un autre fichier.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation>Le simulateur n&apos;est pas encore disponible pour ce firmware</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation>Erreur inconnue pendant le démarrage du simulateur.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation>Erreur Simulateur</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation>Erreur de chargement des données</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation>Une erreur s&apos;est produite lors du démarrage du simulateur.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation>Les paramètres enregistrés ne peuvent pas être importés. Veuillez réessayer ou continuer avec les paramètres actuels.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation>Importer depuis le fichier</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation>Ne pas importer</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation>Nous avons trouvé un ou plusieurs fichiers de sauvegarde des paramètres Companion.
 Voulez-vous importer les paramètres depuis un fichier ?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation>Importez les paramètres depuis un fichier ou commencez avec les valeurs actuelles.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation>Sélectionnez %1:</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation>Enregistrer les paramètres de l&apos;application dans un fichier...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation>Charger les paramètres de l&apos;application depuis un fichier ou depuis la version précédente...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation>Réinitialiser TOUS les paramètres de l&apos;application aux valeurs par défaut et supprimer les profils radio...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation>Quitter avant l&apos;initialisation des paramètres et le démarrage de l&apos;application.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation>Afficher le numéro de version et quittez.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation>Afficher ce texte d&apos;aide.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation>Réinitialiser TOUS les paramètres de l&apos;application aux valeurs par défaut et supprimer les profils radio, êtes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation>Voulez-vous d&apos;abord effectuer une sauvegarde?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation>Les paramètres de l&apos;application ont été réinitialisés et sauvegardés.</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation>paramètres</translation>
     </message>
@@ -1714,22 +1729,22 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
         <translation>Imprimer vers un fichier</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation>Modèle sans Nom %1</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation>Cliquer pour supprimer ce modèle.</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Imprimer le document</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>Choisir le fichier PDF de sortie</translation>
     </message>
@@ -1755,7 +1770,7 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>OK, compris.</translation>
     </message>
@@ -1763,17 +1778,17 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>Erreur d&apos;écriture</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>Impossible d&apos;écrire %1 (raison: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation>Impossible d&apos;ouvrir %1 (raison: %2)</translation>
     </message>
@@ -1781,22 +1796,22 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation>CB</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished">Prédéfini</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1879,32 +1894,32 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
         <translation type="unfinished">Taille point</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">Linéaire</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">Expo simple</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">Symétrique f(x)=-f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">Symétrique f(x)=f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation>Pas assez de points libres dans le tableau de points global pour stocker la courbe.</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation>Editer courbe %1: %2</translation>
     </message>
@@ -1912,7 +1927,7 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation>Double-cliquez pour modifier</translation>
     </message>
@@ -1920,22 +1935,22 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation>Diff</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation>Expo</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation>Fonct.</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished">Prédéfini</translation>
     </message>
@@ -1943,113 +1958,113 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation>Menu contextuel disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation>Remarque : pour créer une courbe, cliquez avec le bouton droit sur l&apos;étiquette de la courbe.</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation>Nom:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation>Type:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation>Adoucie:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished">Addition</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">Édition</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished">Effacer la courbe %1 : %2. Etes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation>Effacer toutes les courbes. Etes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2057,343 +2072,363 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation>FG</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation>SF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation>Remplacer %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation>Écolage Direction</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation>Écolage Profondeur</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation>Écolage Gaz</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation>Écolage Ailerons</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation>Canaux d&apos;Écolage</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation>Trims instantanés</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation>Jouer Son</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation>Vibreur</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation>Remise à zéro</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation>Activer %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation>Vario</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation>Jouer fichier</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation>Jouer les deux</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation>Lire valeur</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation>Script Lua</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation>Test Portée Module Int.</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation>Test Portée Module Ext.</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation>Mode Course/Racing</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation>Désactiver Touches</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation>Définir écran principal</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>Désact. Ampli Audio</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished">1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished">%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished">Trims</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation>Alerte 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation>Alerte 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation>Piauler</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation>Ratata</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation>Tic-tac</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation>Sirène</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation>Sonner</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation>Robot</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation>Gazouiller</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation>Tada</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation>Criquet</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation>Réveil</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation>Source</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation>Variable Globale</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation>Inc/Décrémenter</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation>Actif</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation>Logs SD</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation>Volume</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation>Rétroéclairage</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation>Capture d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation>Musique de fond</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation>Pause musique de fond</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation>Ajuster %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation>Définir Failsafe</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation>Bind module interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation>Bind module externe</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation>Lu une fois, mais pas à la mise en route</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation>Lu une fois</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation>Répéter %1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation>Vol</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation>Télémétrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation>DESACTIVE</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation>FPN</translation>
     </message>
@@ -2401,123 +2436,123 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Inter</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Action</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation>Menu contextuel disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation>FS%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation>FG%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation>VG</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation>Une erreur s&apos;est produite lors de la lecture du son, le fichier est peut-être déjà ouvert. (Err: %1 [%2])</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation>Supprimer la Fonction. Êtes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation>Couper la Fonction. Êtes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation>Effacer la Fonction. Êtes-vous sûr ?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation>Effacer toutes les Fonctions. Êtes-vous sûr ?</translation>
     </message>
@@ -2525,22 +2560,22 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished">Chiffres</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">Barres</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation>Script</translation>
     </message>
@@ -2548,47 +2583,47 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation>Widgets:</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">Phase de vol</translation>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
+        <source>%1 mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
         <source>Sliders</source>
         <translation>Curseurs</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
         <source>Trims</source>
         <translation>Trims</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
         <source>Mirror</source>
         <translation>Miroir</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation>Option #%1</translation>
     </message>
@@ -2645,82 +2680,82 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation>FW: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation>Img: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation>Image du profil</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>Sélectionner le firmware</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>Impossible d&apos;enregistrer l&apos;image %1 dans le firmware.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>Ouvrir l&apos;image à charger</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>Images (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>Impossible d&apos;ouvrir l&apos;image %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>Impossible d&apos;ouvrir l&apos;image du profil %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>Impossible d&apos;ouvrir l&apos;image de bibliothèque %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>Fichier sauvegardé</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>L&apos;image a été enregistrée dans le fichier %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>Erreur de rafraîchissement de l&apos;image</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>Impossible de rafraîchir l&apos;image %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>Erreur à la sauvegarde du fichier</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>Erreur à l&apos;écriture du fichier %1</translation>
     </message>
@@ -2728,22 +2763,22 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2751,53 +2786,53 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation>Erreur de conversion du champ %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation>Interrupteur</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation>L&apos;interrupteur </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation> n&apos;est pas supporté sur cette carte !</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation>Source</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation>La source %1 n&apos;est pas supportée sur cette plateforme !</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation>OpenTX n&apos;accepte que %1 points au maximum entre toutes les courbes</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation>OpenTX n&apos;accepte que %1 points au maximum entre toutes les courbes</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation>OpenTX ne supporte pas cette fonction sur cette carte</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation>OpenTX ne supporte pas ce protocole radio</translation>
     </message>
@@ -2805,52 +2840,52 @@ Voulez-vous importer les paramètres depuis un fichier ?</translation>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation>Désactivé</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation>Activé</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation>ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation>Faux</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation>Vrai</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
@@ -2930,95 +2965,76 @@ Pour &lt;b&gt;retirer un filtre de l&apos;historique&lt;/b&gt;, sélectionnez-le
         <translation>Basculer le filtre on/off.</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;Le filtre supporte deux types de syntaxes: la recherche simple utilisant les métacaractères ou la recherche avancée utilisant les expressions régulières (&lt;code&gt;RegEx&lt;/code&gt;) de type Perl.&lt;/p&gt;&lt;p&gt;Par défaut, un filtre ne montre que les lignes qui correspondent (&lt;b&gt;inclusif&lt;/b&gt;). Pour faire un filtre &lt;b&gt;exclusif&lt;/b&gt; qui supprime les lignes de correspondance, préfixez l&apos;expression du filtre avec un &lt;kbd&gt;!&lt;/kbd&gt; (point d&apos;exclamation).&lt;/p&gt;&lt;p&gt;Pour utiliser les &lt;b&gt;Expressions Régulières&lt;/b&gt; (RegEx), préfixez le texte du filtre avec un &lt;kbd&gt;/&lt;/kbd&gt; (slash) ou &lt;kbd&gt;^&lt;/kbd&gt; (accent circonflexe).&lt;ul&gt;&lt;li&gt;Il faut mettre le &lt;kbd&gt;!&lt;/kbd&gt; &lt;u&gt;avant&lt;/u&gt; le &lt;kbd&gt;/&lt;/kbd&gt; ou &lt;kbd&gt;^&lt;/kbd&gt; dans le cas d&apos;un filtre exclusif.&lt;/li&gt;&lt;li&gt;Par défaut, la correspondance est sensible à la casse (ex: a &amp;ne; A). Pour la rendre insensible (ex: a = A), ajoutez l&apos;opérateur typique &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) à la fin de votre RegEx.&lt;/li&gt;&lt;li&gt;Si vous utilisez un &lt;kbd&gt;^&lt;/kbd&gt; pour désigner une RegEx, il deviendra une partie de la RegEx (&lt;kbd&gt;^&lt;/kbd&gt; est le caractère de début de chaîne).&lt;/li&gt;&lt;li&gt;Si la RegEx n&apos;est pas valide, le champ d&apos;édition du filtre affichera une bordure rouge et vous ne pourrez pas activer le filtre.&lt;/li&gt;&lt;li&gt;Une ressource utile pour tester les RegExs (avec une référence complète) peut être trouvée sur le site &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt; (tutoriel en français: &lt;a href=&quot;http://perl.mines-albi.fr/DocFr/perlretut.html&quot;&gt;Expressions rationnelles/régulières en Perl&lt;/a&gt;)&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;Pour utiliser la &lt;b&gt;recherche simple&lt;/b&gt;, tapez simplement le texte recherché.&lt;ul&gt;&lt;li&gt;Métacaractères: le quantificateur &lt;kbd&gt;*&lt;/kbd&gt; (astérisque) correspond à zéro ou plus de n&apos;importe quel caractère, et le quantificateur &lt;kbd&gt;?&lt;/kbd&gt; (point d&apos;interrogation) correspond à un caractère unique.&lt;/li&gt;&lt;li&gt;La correspondance est toujours sensible à la casse.&lt;/li&gt;&lt;li&gt;La correspondance commence toujours au début du Log. Pour ignorer les caractères au début, utilisez le métacaractère &lt;kbd&gt;*&lt;/kbd&gt;.&lt;/li&gt;&lt;li&gt;Un métacaractère &lt;kbd&gt;*&lt;/kbd&gt; est implicitement ajouté à la fin (ainsi, toutes les correspondances valides soient bien affichées jusqu&apos;à la fin du Log). Si vous voulez éviter ce métacaractère implicite, il faut utiliser une RegEx.&lt;/li&gt;&lt;li&gt;Pour rechercher un caractère qui est lui-même un métacaractère, il faut préfixer avec un &lt;kbd&gt;\&lt;/kbd&gt; (backslash) (ex: &quot;&lt;i&gt;toto\*titi&lt;/i&gt;&quot; correspond à &quot;&lt;i&gt;toto*titi&lt;/i&gt;&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;Quand l&apos;&lt;b&gt;édition&lt;/b&gt; est terminée, appuyez sur la touche ENTRER ou TAB (ou cliquez n&apos;importe où à l&apos;extérieur du champ du filtre) afin de mettre à jour le filtre.&lt;/p&gt;&lt;p&gt;Pour &lt;b&gt;retirer un filtre de l&apos;historique&lt;/b&gt;, sélectionnez-le d&apos;abord, puis faite le raccourci clavier &lt;kbd&gt;Shift-Suppr&lt;/kbd&gt; (ou &lt;kbd&gt;Shift-Retour Arrière&lt;/kbd&gt;). Les filtres par défaut ne peuvent pas être effacés. Jusqu&apos;à 50 filtres peuvent être mémorisés.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation>Aide sur les filtres pour la console de débogage</translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation>Téléchargement: </translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation>Le téléchargement a échoué: %1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation>Causes possibles:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation>- L&apos;EEPROM peut avoir été créée avec une version d&apos;OpenTX plus récente</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation>- L&apos;EEPROM peut avoir été créée avec un firmware autre qu&apos;OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation>- L&apos;EEPROM n&apos;est pas une EEPROM ErSky9X</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation>- La taille de l&apos;EEPROM est invalide</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation>- Le système de fichier de l&apos;EEPROM est invalide</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation>- L&apos;EEPROM ne correspond à aucune carte supportée</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation>- L&apos;EEPROM ne correspond pas au type de radio sélectionné</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation>- Sauvegarde d&apos;EEPROM non supportée</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation>- Erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation>Avertissement:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation>- Le firmware de la radio est probablement incorrect,
@@ -3026,7 +3042,7 @@ la taille de l&apos;EEPROM est de 4096 mais seulement 2048 bytes sont utilisés.
 Vérifier la sélection (M64/M128)</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation>- Votre eeprom provient d&apos;une ancienne version d&apos;OpenTX, mettez à niveau!
@@ -3036,12 +3052,12 @@ Vérifier la sélection (M64/M128)</translation>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3049,12 +3065,12 @@ Vérifier la sélection (M64/M128)</translation>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation>Ouverture impossible %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation>Fichier EEPROM invalide %1</translation>
     </message>
@@ -3062,12 +3078,12 @@ Vérifier la sélection (M64/M128)</translation>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;Première voie d&apos;élevons:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>Deuxième voie d&apos;élevons:</translation>
     </message>
@@ -3075,42 +3091,42 @@ Vérifier la sélection (M64/M128)</translation>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Erreur à l&apos;ouverture du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Erreur d&apos;écriture du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3118,23 +3134,23 @@ Vérifier la sélection (M64/M128)</translation>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation>ENT</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished">Eteint</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">ON</translation>
     </message>
@@ -3142,111 +3158,95 @@ Vérifier la sélection (M64/M128)</translation>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Ratio</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Phases de Vol</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Nom de l&apos;entrée</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation>VG</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Interrupteur</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>Courbe appliquée à la source.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Nom de la ligne</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Direction</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>La voie maître du mixage.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Interrupteur utilisé pour activer la ligne.
-Si vide, la ligne est toujours active.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>Echelle</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Inclure Trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Courbe</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Décalage</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>La voie maître du mixage</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation>Négative</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation>Positive</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>Les 2</translation>
     </message>
@@ -3256,22 +3256,22 @@ Si vide, la ligne est toujours active.</translation>
         <translation>Éditer %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation>Menu contextuel disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation>Définir Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation>Inverser Tout</translation>
     </message>
@@ -3279,22 +3279,22 @@ Si vide, la ligne est toujours active.</translation>
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>Voie des gaz:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>Voie du lacet:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>Voie du tangage:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>Voie du roulis:</translation>
     </message>
@@ -3302,109 +3302,109 @@ Si vide, la ligne est toujours active.</translation>
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation>Synchroniser les fichiers</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation>Êtes-vous sûr de vouloir annuler la synchronisation?</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation>Comment gérer l&apos;écrasement des fichiers qui existent déjà dans le dossier de destination.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation>Copiez seulement si &quot;plus récent et différent&quot; (comparez le contenu)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation>Copier uniquement si &quot;plus récent&quot; (ne pas comparer le contenu)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation>Copier uniquement si &quot;différent&quot; (ignorer l&apos;horodatage des fichiers)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation>Toujours copier (écraser tous les fichiers existants)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation>Toutes tailles</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation>Ignorer tous les fichiers plus grands que cette taille. Entrez 0 pour illimité.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation>Niveau de rapport au minimum. Les événements de ce type et d&apos;une plus grande importance sont indiqués.
 ATTENTION: un taux de rapport élevé peut rendre l&apos;interface utilisateur temporairement inutilisable.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation>Sauté</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation>Créé</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation>Mis à jour</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation>Erreur seulement</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation>Essai</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation>Exécutez normalement, mais ne rien copier. Utile pour vérifier les résultats avant la synchronisation réelle.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation>Niveau de rapport:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation>Filtres:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
@@ -3413,156 +3413,156 @@ Le filtre &quot;Exclure&quot; ignorera les fichiers correspondant à la (aux) r�
 Le filtre &quot;Inclure&quot; est évalué en premier.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation>Une ou plusieurs règle(s) de fichier(s) à exclure, séparés par des virgules.
 Blanc signifie &quot;exclure aucun&quot;.Les métacaractères ?, * et [...] sont acceptés.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Une ou plusieurs règle(s) de fichier(s) à inclure, séparés par des virgules.
 Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont acceptés.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation>Inclure:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation>Exclure:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation>Sensible aux majuscules et minuscules</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation>Suivez les liens</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation>Inclure fichier/dossier caché</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation>Récursif</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation>Sauter vide</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation>Appliquer les filtres</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation>Options des Filtres:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation>Options des Dossiers:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation>Afficher les options supplémentaires</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation>Réinitialiser les paramètres par défaut</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation>Direction de la synchro.:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation>Fichiers existants:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation>Taille Max Fichier:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation>Mo</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation>ko</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation>Total: &lt;b&gt;%1&lt;/b&gt;; Créé(s): &lt;b&gt;%2&lt;/b&gt;; Mis à jour: &lt;b&gt;%3&lt;/b&gt;; Sauté(s): &lt;b&gt;%4&lt;/b&gt;; Erreur(s): &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation>Courant: &lt;b&gt;%1&lt;/b&gt; de </translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3570,367 +3570,411 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation>Désactive la fonction spéciale &quot;Remplacer VOIExx&quot;</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation>Possibilité d&apos;activer le mode FAI (télémétrie désactivée) sur le terrain</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation>Mode FAI (télémétrie toujours désactivée)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation>Masque le protocole D8. Légalement obligatoire sur les radios Européennes importées après le 1er janvier 2015</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Supprimer le menu HELICO et les mixages cycliques</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation>Supprimer le support des variables globales</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Activer l&apos;écran des scripts Lua personnalisés</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation>Utiliser la police alternative SQT5</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation>Désactiver le RAS (SWR). Utile uniquement pour les X9D+ avec un RAS/SWR non fonctionnel</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation>Support de la navigation dans les menus avec les POTS</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation>Activer le support du AFHDS3</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation>Module vibreur installé</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Confirmation avant l&apos;arrêt de la radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Manches Horus à effet HALL installés</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>Prise en charge du module de remplacement interne ACCESS</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>Exclusivement pour les Horus DEV</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation>Prise en charge du module MULTI interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation>Prise en charge du module Bluetooth</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation>Autoriser l&apos;appairage avec le bouton&quot;bind&quot;</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation>Prise en charge du GPS interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation>Activer le menu hélico et les mixages CCPM</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation>Variables globales</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation>Activer les firmwares non certifiés</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation>Sélectionner les sources des mixeurs en bougeant le contrôle désiré</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation>Sélectionner les interrupteurs en bougeant le contrôle désiré</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation>Pas de cases à cocher et de curseurs graphiques</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation>Graphique de la batterie</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation>Ne pas mettre les lignes actives en gras</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation>Permet la remise à zéro des valeurs en pressant haut-bas en même temps, valeur min avec gauche/bas, valeur max avec haut/droite, inversion avec gauche/droite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
@@ -3938,27 +3982,27 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Oui, contrôlés par une seule voie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Oui, contrôlés par 2 voies</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;Première voie de volets:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>Deuxième voie de volets:</translation>
     </message>
@@ -3967,7 +4011,7 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Transférer les paramètres et modèles vers la radio</translation>
     </message>
@@ -4032,51 +4076,51 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
         <translation>Transférer</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>Profil courant: %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>Sélectionner le fichier de sauvegarde</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>Données de calibration incorrectes dans le profil, les paramètres ne seront pas transférés</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>Données de configuration incorrectes dans le profil, les paramètres ne seront pas transférés</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Ecriture du fichier %1 impossible:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Erreur d&apos;écriture du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>Ce firmware ne correspond pas à la radio sélectionnée, vérifiez le fichier et les préférences !</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>Le firmware de la radio est obsolète, veuillez mettre à jour !</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>Impossible de vérifier la compatibilité des paramètres et modèles ! Continuer quand même ?</translation>
     </message>
@@ -4154,103 +4198,103 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
         <translation>Transférer</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>Sélectionner le firmware</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 ne semble pas être un firmware valide</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>Le firmware est invalide.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>Aucun écran d&apos;accueil trouvé dans le firmware.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>L&apos;image du profil %1 est invalide.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>Ouvrir l&apos;image à utiliser comme écran d&apos;accueil</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>Images (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>L&apos;image %1 n&apos;a pu être chargée</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>L&apos;image n&apos;a pu être chargée depuis la bibliothèque</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>Ecran d&apos;accueil sélectionné introuvable</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>Impossible d&apos;enregistrer le firmware personnalisé</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>Transférer le firmware à la radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>La vérification a échoué</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>Impossible de vérifier le firmware de la radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>Le nouveau firmware ne correspond pas à la version installée, vérifiez le type de radio !</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>La conversion a échoué</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>Impossible de convertir les paramètres et modèles pour ce firmware, les données originales vont être utilisées</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>Echec de la restauration</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>Impossible de restaurer les paramètres et modèles sur la radio. Le fichier peut être récupéré ici: %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>Programmation terminée</translation>
     </message>
@@ -4258,47 +4302,47 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation>Exécutable %1 introuvable</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation>Ecriture...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation>Lecture...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation>Vérification...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation>inconnu</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>ex: OpenTX pour carte d&apos;origine 9x ou OpenTX pour 9XR</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>ex:. OpenTX pour carte d&apos;origine 9x avec m128 ou OpenTX pour 9XR avec m128</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>ex: OpenTX pour carte gruvin9x</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4307,7 +4351,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 Vérifiez les options de programmateur et choisissez le bon type de processeur.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4316,7 +4360,7 @@ Please select an appropriate firmware type to program it.</source>
 Veuillez choisir le firmware approprié.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4325,22 +4369,22 @@ Vous utilisez actuellement:
 %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>Votre radio ne semble pas être connectée en USB, ou le pilote n&apos;est pas initialisé !!!.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>Terminé (code de sortie = %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>Terminé avec des erreurs</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>Fusibles: Bas=%1 Haut=%2 Ext=%3</translation>
     </message>
@@ -4348,7 +4392,7 @@ Vous utilisez actuellement:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
     </message>
@@ -4399,225 +4443,240 @@ Vous utilisez actuellement:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
         <translation>PV</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>Sélecteur Rotatif %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>Source valeur</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>VG%1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">VG%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
-        <translation>Avertissement: la Variable Globale boucle sur elle-même. La Phase de Vol 0 est utilisée.</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Valeur indépendante</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
-        <translation>Avertissement: le Sélecteur Rotatif boucle sur lui-même. La Phase de Vol 0 est utilisée.</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
-        <translation>Effacer la Phase de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
-        <translation>Effacer toutes les Phases de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
-        <translation>Couper la Phase de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
-        <translation>Supprimer la Phase de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Effacer la Variable Globale pour toutes les Phases de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation>Effacer la Variable Globale. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Couper la Variable Globale pour toutes les Phases de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation>Couper la Variable Globale. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation>Supprimer la Variable Globale. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Coller la Variable Globale pour toutes les Phases de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation>Effacer toutes les Variables Globales pour toutes les Phases de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation>Effacer toutes les Variables Globales pour cette Phase de Vol. Êtes-vous sûr?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Indication activée</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation>Menu contextuel disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation>Trim désactivé</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation>Valeur indépendante</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation>Utiliser le trim de la phase de vol %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation>Utiliser le trim de la phase de vol %1 + une valeur indépendante additionnée</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
@@ -4625,17 +4684,17 @@ Vous utilisez actuellement:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>Phase de vol %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (par défaut)</translation>
     </message>
@@ -4643,17 +4702,17 @@ Vous utilisez actuellement:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>Avec barre de Bell</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>Sans barre de Bell</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>Barre de Bell:</translation>
     </message>
@@ -4661,17 +4720,17 @@ Vous utilisez actuellement:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation>Jaune</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation>Orange</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
@@ -4679,13 +4738,13 @@ Vous utilisez actuellement:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation></translation>
     </message>
@@ -4703,17 +4762,18 @@ Vous utilisez actuellement:
         <translation>Inters paramétrables</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4723,7 +4783,12 @@ Vous utilisez actuellement:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4731,8 +4796,13 @@ Vous utilisez actuellement:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4877,13 +4947,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A n&apos;utiliser que si vous êtes certain de ce que vous faites.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>Réinitialiser les fusibles de la radio</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>Lire les fusibles de la radio</translation>
     </message>
@@ -4891,50 +4961,40 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation>VG</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation>Valeur indépendante</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation>Valeur de la phase de vol %1</translation>
     </message>
 </context>
 <context>
     <name>GeneralEdit</name>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Configuration</translation>
     </message>
@@ -4951,7 +5011,7 @@ These will be relevant for all models in the same EEPROM.</source>
 Communs à tous les modèles d&apos;une même EEPROM.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Écolage</translation>
     </message>
@@ -4966,47 +5026,47 @@ Communs à tous les modèles d&apos;une même EEPROM.</translation>
         <translation>Lire paramètres Radio depuis profil</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>Fonctions globales</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation>Matériel</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>Données du profil erronnées, l&apos;étalonnage n&apos;a pas été lu</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>Données incorecte, Interrupteurs/Pot non trouvés</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>Données du profil erronnées, les paramètres hw n&apos;ont pas été lus</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>Voulez-vous stocker l&apos;étalonnage dans le profil %1&lt;br&gt; et écraser l&apos;étalonnage existant ?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>Etalonnage et paramètres hw enregistrés avec succès.</translation>
     </message>
@@ -5045,8 +5105,8 @@ Communs à tous les modèles d&apos;une même EEPROM.</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Phases de Vol</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5082,185 +5142,208 @@ Communs à tous les modèles d&apos;une même EEPROM.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation>Paramètres de la radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished">Matériel</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished">Interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished">Demander</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished">Par modèle</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished">Interne + Externe</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished">Externe</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished">Eteint</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished">Activé</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">Écolage</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">Écolage SBUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">Débogage</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished">Normales</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished">Trims uniquement</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished">Touches uniquement</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished">Commutable</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished">Global</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5276,201 +5359,199 @@ Communs à tous les modèles d&apos;une même EEPROM.</translation>
         <translation>Débloquage lecture seule</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Décalage horaire (UTC)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Langue des voix</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Zone géographique RF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Inversion des manches</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>Mode FAI</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Ajuster l&apos;heure par GPS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Tonalité du vario au max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Volume haut-parleur</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>Inter de rétroéclairage</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Mode Son</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>Couleur 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>Couleur 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>Tonalité (HP uniquement)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Si cette valeur est différente de 0, l&apos;appui sur une touche de navigation déclenche le rétroéclairage qui s&apos;éteint après la durée spécifiée (en secondes).</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>Couleur du rétroéclairage</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>Bipeur</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Haut-parleur</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>Bipeur/Voix</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>Haut-parleur/Voix</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Volume des bips</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Volume des fichiers audio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Volume du variomètre</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Volume de la musique d&apos;ambiance</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>Arrêt rétroéclairage après</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>Clignotement rétroécl. alarmes</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Tonalité du vario à 0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Répétition du vario à 0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5478,7 +5559,7 @@ Communs à tous les modèles d&apos;une même EEPROM.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5493,42 +5574,42 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Plage de valeurs: 20...45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>Luminosité du rétroéclairage</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Navigation sélecteur rotatif</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>Régle automatique l&apos;heure de la radio si un GPS est présent.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>Amérique</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Japon</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>Luminosité écran éteint</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5569,252 +5650,112 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>Mode 1 (DIR PRF GAZ AIL)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>Mode 2 (DIR GAZ PRF AIL)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>Mode 3 (AIL PRF GAZ DIR)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>Mode 4 (AIL GAZ PRF DIR)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordre des voies&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Détermine l&apos;ordre des mixages par défaut sur un nouveau modèle.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation>Si vous activez l&apos;option FAI, seuls les capteurs RSSI et BtRx vont fonctionner. Cette fonction ne peut pas être désactivée sur la radio.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation>Enregistrement ID du propriétaire</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation>Rétroéclairage des touches</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation>D P G A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation>D P A G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation>D G P A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation>D G A P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation>D A P G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation>D A G P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation>P D G A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation>P D A G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation>P G D A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation>P G A D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation>P A D G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation>P A G D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation>G D P A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation>G D A P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation>G P D A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation>G P A D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation>G A D P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation>G A P D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation>A D P G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation>A D G P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation>A P D G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation>A P G D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation>A G D P</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation>A G P D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5825,316 +5766,349 @@ Seuil auquel se déclenche l&apos;alarme de batterie.
 Plage de valeurs: 3v...12v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation>Délai mise hors tension</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation>Mode USB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation>Mode Jack</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation>Écolage</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation>Demander à la connexion</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation>Stockage USB (SD)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation>Port série USB (Debug)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>Mode joystick</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Mode</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Métrique</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Impérial</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Ordre des voies par défaut</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>Coordonnées GPS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation>Vérifier RSSI à l&apos;extinction</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Alerte d&apos;inactivité</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Afficher l&apos;écran de démarrage</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>Contraste</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Plage de l&apos;indicateur de batterie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Puissance vibreur</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>Type de LCD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Alerte &quot;son coupé&quot;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Alerte batterie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Durée vibreur</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>Baudrate Mavlink</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Mode silencieux</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Seulement les alarmes</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>Touches silencieuses</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>Tous</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Si différent de 0, émission d&apos;un bip sonore régulier si aucune action n&apos;a été effectuée sur l&apos;émetteur depuis le temps spécifié (en minutes).
 Réinitialisation en agissant sur n&apos;importe lequel des manches / touches de navigation.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation>Délai mise sous tension</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">0s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">0.5s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6159,72 +6133,72 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Alerte mode silencieux - Avertissement si les bips sont désactivés&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>Très court</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Court</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>Très long</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation>Avertissement EEPROM faible</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Délai position centrale inters</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Unités de mesure</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Mode du vibreur</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Durée des bips</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Paramètre des bips</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6241,12 +6215,14 @@ Long : bips plus longs.
 Extra long : bips extra longs.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Seulement les Alarmes</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished">1s</translation>
     </message>
@@ -6254,157 +6230,157 @@ Extra long : bips extra longs.</translation>
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation>Touches</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation>Manches</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation>Touches + manches</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation>Anglais</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation>Hollandais</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation>Français</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation>Italien</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation>Allemand</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation>Tchèque</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation>Slovaque</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation>Espagnol</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation>Polonais</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation>Portugais</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation>Suédois</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation>Hongrois</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation>Russe</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation>Sel.Rot. A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation>Sel.Rot. B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation>Sel.Rot. C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation>Sel.Rot. D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation>Sel.Rot. E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6413,22 +6389,22 @@ Cette fonction ne peut pas être désactivée sur la radio.
 Êtes-vous sûr d&apos;activer cette option ?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished">Normales</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6436,17 +6412,17 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Oui, contrôlé par un inter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Oui, contrôlé par un potentiomètre</translation>
     </message>
@@ -6454,118 +6430,128 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished">Nom de l&apos;appareil:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished">Filtre ADC</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>Muet si pas de son</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished">Alimentation S.Port</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished">Correction  courant</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6646,22 +6632,22 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>Voie des gaz:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>Voie du lacet:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>Voie du tangage:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>Voie du roulis:</translation>
     </message>
@@ -6669,19 +6655,19 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation>Fichier EEPROM invalide %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Impossible d&apos;ouvrir le fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Erreur d&apos;écriture du fichier %1:
@@ -6691,159 +6677,159 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Haut</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Bas</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Effacer toutes les entrées</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation>Pas assez d&apos;Entrées disponibles!</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation>Supprimer les lignes Entrée sélectionnées. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation>Couper les lignes Entrée sélectionnées. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation>Linéaire</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;Ajouter</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;Édition</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>&amp;Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>&amp;Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>&amp;Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>Du&amp;pliquer</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation>Effacer toutes les lignes Entrée. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation>Effacer toutes les lignes Entrée sélectionnées. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation>Supprimer toutes les lignes Entrée sélectionnées. Êtes-vous sûr?</translation>
     </message>
@@ -6884,96 +6870,96 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished">Erreur de chargement des modèles</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6981,17 +6967,17 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation>VOIE</translation>
     </message>
@@ -6999,7 +6985,7 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation>VG</translation>
     </message>
@@ -7007,122 +6993,122 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation>ET</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation>OU</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation>OUX</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation>Chrono</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation>Bistable</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation>Flanc</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation>IL</translation>
     </message>
@@ -7130,112 +7116,117 @@ Cette fonction ne peut pas être désactivée sur la radio.
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>Durée</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>Délai</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>Fonction</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>ET supplémentaire</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">Persistant</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation>Menu contextuel disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation> (infini)</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation>Supprimer l&apos;Interrupteur Logique. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation>Couper l&apos;Interrupteur Logique. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation>Effacer l&apos;Interrupteur Logique. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation>Effacer tous les Interrupteurs Logiques. Êtes-vous sûr?</translation>
     </message>
@@ -7288,52 +7279,52 @@ Cette fonction ne peut pas être désactivée sur la radio.
         <translation>Sessions de vol</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>Enregistrements de télémesure</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>Changer le titre du graphique</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>Nouveau nom de graphique:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>Changer le nom de l&apos;axe</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>Nouveau nom d&apos;axe:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>Changer le nom de la série</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>Nouveau nom de série:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation>Erreur: pas de données GPS trouvées</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7342,74 +7333,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 Les colonnes contenant l&apos;altitude &quot;GAlt&quot; et la vitesse &quot;GSpd&quot; sont optionnelles</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Ecriture fichier %1 impossible:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>Curseur A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>Curseur B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>Ecart temps:%1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>Taux monté : %1 m/s</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>Sélectionnez votre fichier log</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>Champs disponibles</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>Le fichier de log sélectionné contient %1 lignes invalides sur %2</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation>plage de temps</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>durée </translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation></translation>
     </message>
@@ -7417,363 +7408,363 @@ Les colonnes contenant l&apos;altitude &quot;GAlt&quot; et la vitesse &quot;GSpd
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Édition</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Fichier</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Comparer les modèles</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>Thème avec icônes monochromes noires</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>Synchroniser la carte SD</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>Ouvrir...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>Thème avec icônes monochromes blanches</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>Thème avec icônes monochromes bleues</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Petites</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>Petites icônes de barre d&apos;outils</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>Icônes de barre d&apos;outils normales</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Normales</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>Grosses icônes de barre d&apos;outils</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Grandes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>Immenses icônes de barre d&apos;outils</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Immenses</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Lire le firmware de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>Lire le firmware de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Transférer le firmware à la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Transférer le firmware à la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Ajouter un profil de radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Transférer les paramètres et modèles vers la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Transférer les paramètres et modèles vers la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Lire les paramètres et modèles depuis la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation>Liste des fichiers récemment utilisés</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation>Profil radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation>Créer ou Sélectionner un profil radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>Configurer les communications...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>Configurer le programme gérant les communications avec la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Transférer une sauvegarde à la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Transférer une sauvegarde à la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Sauvegarder la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>Créer une copie de sauvegarde de tous les paramètres et modèles de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>Synchronisation de la carte SD</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>Fichiers récents</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Choisir le thème d&apos;icônes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Choisir la taille des icônes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>Ecrire</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>Si vous trouvez ce programme utile, merci de le supporter par une &lt;a href=&apos;%1&apos;&gt;donation&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Prêt</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>Afficher la fenêtre &quot;A propos&quot; de l&apos;application</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Fichier chargé</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Ouvrir un fichier de paramètres et modèles</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Fichier sauvegardé</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Lire les paramètres et modèles depuis la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation>Certains textes ne seront pas traduits avant le prochain redémarrage de Companion. Veuillez noter que certaines traductions peuvent ne pas être complètes.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation>Lecture des modèles et paramètres</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation>Dossier &quot;Local&quot;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation>Dossier &quot;Radio&quot;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation>Cette fonction n&apos;est pas implémentée pour l&apos;instant</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>Sauvegarder la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Sauvegarder le firmware de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Créer un nouveau fichier de paramètres et modèles</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Enregistrer le fichier de paramètres et modèles</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Enregistrer sous...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation>Fermer le fichier de paramètres et modèles</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Quitter l&apos;application</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation>Créer un nouveau profil de paramètres et modèles</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation>Copier le profil radio actuel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation>Dupliquer les paramètres radio du profil actuel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation>Supprimer les paramètres radio du profil actuel</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation>Utiliser le langage système par défaut.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation>Utiliser la langue %1 (certaines traductions peuvent être incomplètes).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>Classique</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
@@ -7782,373 +7773,373 @@ Do you wish to continue?</source>
 Êtes-vous sûr de vouloir continuer ?</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation>Aucun chemin de configuré pour la structure SD en local !</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation>Pas de Radio ou carte SD de détectée !</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation>Notes de version...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation>Afficher les notes de version</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation>Supprimer le profil radio actuel...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation>Exporter Préférences Application...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation>Enregistrez tous les paramètres actuels %1 et du simulateur (y compris les profils radio) dans un fichier.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation>Importer les paramètres de l&apos;application...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation>Charger les paramètres %1 et les paramètres de Simulation depuis un fichier précédemment exporté.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation>Fenêtres à onglets</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation>Utilisez les onglets pour organiser les fenêtres ouvertes.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation>Titre de la fenêtre</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation>Disposez les fenêtres ouvertes sur tout l&apos;espace disponible.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation>Fenêtres en cascade</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation>Organisez toutes les fenêtres ouvertes dans une pile.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation>Fermer toutes les fenêtres</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation>Fermer tous les fichiers ouverts (proposer de sauvegarder si nécessaire).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation>Fenêtre</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>Thème d&apos;icônes classique de Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Thème d&apos;icônes rondes jaunes</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>Monochrome Blanc</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation> - Copier</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation>Companion::Ouvrir les fichiers d&apos;avertissement</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation>Veuillez sauvegarder ou fermer le(s) fichier(s) modifié(s) avant de supprimer le profil actif.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation>Impossible de supprimer le profil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation>Le profil par défaut ne peut pas être supprimé.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation>Confirmer la suppression du profil</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation>Etes-vous sûr de vouloir supprimer le profil radio %1? Cette action est irréversible !</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation>Veuillez sauvegarder ou fermer tous les fichiers modifiés avant d&apos;importer les paramètres</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;p&gt;%1 et les paramètres du simulateur peuvent être importés (restaurés) à partir d’un fichier d’exportation (sauvegarde) préalablement sauvegardé. Ceci remplacera les paramètres actuels par tous les paramètres trouvés dans le fichier.&lt;/p&gt;&lt;p&gt;Une sauvegarde automatique des paramètres actuels sera tentée. Mais si les paramètres actuels sont utiles, il est recommandé de commencer par une sauvegarde manuelle.&lt;/p&gt;&lt;p&gt;Pour obtenir de meilleurs résultats lors de l&apos;importation des paramètres,&lt;b&gt; fermez les autres fenêtres %1 que vous avez éventuellement ouvertes et assurez-vous que l&apos;application autonome Simulator n&apos;est pas en cours d&apos;exécution. &lt;/p&gt;&lt;p&gt;Souhaitez-vous continuer ? &lt;/p&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation>Confirmer les paramètres d&apos;importation</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation>Sélectionnez %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation>sauvegarde</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation>Appuyez sur le bouton &apos;Ignorer&apos; pour continuer quand même.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation>Les paramètres n&apos;ont pas pu être importés.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation>&lt;html&gt;&lt;p&gt;Les nouveaux paramètres ont été importés depuis:&lt;br&gt; %1. &lt;/p&gt;&lt;p&gt;%2 sera maintenant réinitialisé.&lt;/p&gt;&lt;p&gt;Notez que vous devrez peut-être fermer et redémarrer %2 avant que certains paramètres tels que la langue et le thème d’icône prennent effet.&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation>&lt;p&gt;Les paramètres précédents ont été sauvegardés sous:&lt;br&gt; %1 &lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>Monochrome Bleu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>Langue du système</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>Ouvrir un Log...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Ouvrir et visualiser un log</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Préférences...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Éditer les préférences</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Comparer 2 modèles...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Éditer l&apos;écran d&apos;accueil de la radio...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>Éditer l&apos;écran d&apos;accueil de la radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>Le nouveau thème sera utilisé lors du prochain lancement de Companion.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>A propos de Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Choisir la langue des menus</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Transfert</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation>%2</translation>
     </message>
@@ -8156,57 +8147,57 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Fichier %1 introuvable !</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Enregister Sous</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8215,7 +8206,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8224,64 +8215,64 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation>Rien n&apos;a été sélectionné</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation>Éditer le modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
@@ -8292,107 +8283,107 @@ Do you wish to continue?</source>
         <translation>Exporter</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation>Éditer Paramètres Radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation>Copier les paramètres radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation>Coller les paramètres radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation>Simuler Radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation>Ajouter modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation>Modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation>Exporter Modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation>Restaurer depuis une sauvegarde</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation>Assistant de configuration modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation>Définir par défaut</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation>Imprimer modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation>Simuler modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation>Dupliquer modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation>Afficher la barre d&apos;outils &quot;Radio&quot;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation>Afficher la barre d&apos;outils &quot;Modèle&quot;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation>lecture seule</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation>Impossible d&apos;insérer le modèle, le dernier modèle dans la liste serait supprimé.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation>Impossible d&apos;ajouter un modèle, aucun emplacement libre n’est disponible.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation>Impossible de coller le modèle, aucun emplacement libre n’est disponible.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
             <numerusform>Supprimer le modèle sélectionné ?</numerusform>
@@ -8400,219 +8391,219 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation>Impossible de dupliquer le modèle, aucun emplacement libre n’est disponible.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation>Extension de fichier invalide</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation>Souhaitez-vous vraiment lancer la conversion ?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation>Choisissez &lt;i&gt;Appliquer&lt;/i&gt; pour convertir le fichier ou &lt;i&gt;Annuler&lt;/i&gt; pour le fermer sans conversion.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation>&lt;b&gt;La conversion a généré des messages importants, veuillez les consulter ci-dessous.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation>Companion :: Résultat de conversion de %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation>Modèles et paramètres écrit vers radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation>Erreur écriture modèles et paramètres vers radio</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Ecriture de fichier temporaire impossible !</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Édition du modèle %1 : </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished">Addition</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation>Renommer</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished">Monter</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished">Descendre</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Fichier %1 corrompu:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Édition</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished">Modèle</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Erreur à l&apos;ouverture du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation>Voulez-vous vraiment écraser les paramètres généraux ?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Le type de radio actuellement sélectionné (%1) n&apos;est pas compatible avec le fichier %3 (à partir de %2), les modèles et les paramètres doivent être convertis.&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation>Impossible de trouver la carte SD de la radio !</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>Ouvrir la sauvegarde de paramètres et modèles</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>Fichier de sauvegarde %1 invalide</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 a été modifié.
@@ -8622,143 +8613,148 @@ Enregistrer les changements ?</translation>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation>taille</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation>Archive existante sera écrasée</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation>Impossible d&apos;ouvrir l&apos;archive existante</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation>L&apos;archive existante a été ouverte</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8766,12 +8762,12 @@ Enregistrer les changements ?</translation>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation></translation>
     </message>
@@ -8779,123 +8775,99 @@ Enregistrer les changements ?</translation>
 <context>
     <name>MixerDialog</name>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Haut</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>+= Ajouter</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">0.00</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Bas</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Ralenti</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Délai</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">Précision</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Courbe</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Multiplexage
-
-Spécifie comment les valeurs de mixage  sont interprétées.
-
-&quot;+=&quot;: la valeur du mixage courant est ajoutée au résultat des mixages précédents dans la même voie.
-&quot;*&quot;=: la valeur du mixage courant est multipliée par le résultat des mixages précédents dans la même voie.
-&quot;:=&quot;: la valeur remplace les valeurs précédentes. Si l&apos;inter est sur OFF, la valeur est ignorée .</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Courbe utilisée par le mixage</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation>VG</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>Alerte de mixage.
-Si activée, signale par des bips que le mixage est actif.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 Bip</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2 Bips</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 Bips</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Multiplexage</translation>
     </message>
@@ -8905,10 +8877,10 @@ Si activée, signale par des bips que le mixage est actif.</translation>
         <translation>Dialogue</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8933,97 +8905,87 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Si le Ralenti est différent de 0, le mixage est ralenti du nombre de seconds spécifiés -&amp;gt;la valeur spécifiée du ralenti correspond à une transition de -100 à +100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Décalage</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Source</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Interrupteur</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Ratio</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>:= Remplacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>La source du mixage</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>*= Multiplier</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Interrupteur utilisé par le mixage.
-Mixage actif par défaut si non-renseigné.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation>Cliquez pour accéder au menu contextuel</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation>Définir Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation>Inverser Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Inclure Trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Phases de Vol</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>Inclure DR/Expo</translation>
     </message>
@@ -9031,22 +8993,22 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation>Augmenter la taille de la police</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation>Diminuer la taille de la police</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation>Taille de la police par défaut</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation></translation>
     </message>
@@ -9054,136 +9016,136 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Haut</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Bas</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Effacer tous les mixages</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>Plus de mixages disponibles !</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation>Supprimer les lignes Mixeur sélectionnées. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation>Couper les lignes Mixeur sélectionnées. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;Ajouter</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;Édition</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>&amp;(Dé)sélectionner</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>&amp;Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>&amp;Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;Dupliquer</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>Effacer tous les mixages ?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>Êtes-vous sûr de vraiment vouloir effacer tous les mixages ?</translation>
     </message>
@@ -9191,19 +9153,24 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation>Modèle: </translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation>Source des gaz</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation>GAZ</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9251,32 +9218,49 @@ Mixage actif par défaut si non-renseigné.</translation>
         <translation type="unfinished">Maître/Multi</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
+        <translation type="unfinished">Aucun</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished">---</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished">Actif</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9289,43 +9273,43 @@ Mixage actif par défaut si non-renseigné.</translation>
         <translation>Simulation</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>Paramètres Hélico</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Entrées</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Mixages</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Inters Logiques</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Configuration</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Courbes</translation>
     </message>
@@ -9335,22 +9319,17 @@ Mixage actif par défaut si non-renseigné.</translation>
         <translation>Dialogue</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Phases de Vol</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>Sorties</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Fonctions Spéciales</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Télémesure</translation>
     </message>
@@ -9404,8 +9383,8 @@ Mixage actif par défaut si non-renseigné.</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Phases de Vol</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9441,585 +9420,595 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation>Exponentiel</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>Extra fin</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>Fin</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>Moyen</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>Grossier</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation>Inconnu</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation>Actif</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation>Désactiver</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation>Vrai</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation>Faux</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation>Nombre de voies</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation>Longueur de Trame PPM</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation>Impulsion</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation>Polarité</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation>Protocole</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation>Délai</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation>Récepteur</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation>Protocole radio</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation>Sous-type</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation>Valeur optionnelle</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation>Sous-Type</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation>Puissance RF</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation>Ratio(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation>Inter(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation>Délai(h%1:b%2)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation>Ralenti(h%1:b%2)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation>Alerte(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation>Phases de Vol</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation>Phase de vol</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation>Tous</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation>Flanc</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation>Bistable</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation>Chrono</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation> absent</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation>Durée</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation>Limites étendues</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation>Afficher la checklist</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation>Fonctions globales</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation>Manuel</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation>Mode Failsafe</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation>Maintien</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation>Pas d&apos;impulsion</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation>Non défini</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation>Pas d&apos;impulsions</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation>Pas</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation>Affichage</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation>Étendu</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished">Mode joystick</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation>Jamais</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation>Sur changement</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation>Toujours</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished">Trims uniquement</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished">Touches uniquement</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished">Commutable</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished">Global</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation>Trim ralenti uniquement</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation>Inversé</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation>FrSky D (câble)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation>Alt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation>Alt+</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation>Vitesse verticale</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation>Velm</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation>Chiffres</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation>Barres</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation>Nom de fichier</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation>Erreur: Impossible d&apos;ouvrir ou de lire le fichier!</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished">Options</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation>PV%1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation>PV%1%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation>PV%1+%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation>Pas de trim</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation>Pas d&apos;expo/DR</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation>Décalage(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation>O</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>Désactivé pour toutes les phases de vol</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation>immédiat</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>Prédéfini</translation>
     </message>
@@ -10027,27 +10016,27 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Avion</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Hélicoptère</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Nom du modèle:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Type de modèle:</translation>
     </message>
@@ -10055,27 +10044,27 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Nom</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished">Modele %1</translation>
@@ -10331,285 +10320,290 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation>Négative</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation>Port écolage</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation>Module HF interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation>Module HF externe</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation>Module HF supplémentaire</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation>Module HF</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished">Eteint</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation>10mW - 16 VOIES</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation>100mW - 16 VOIES</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation>500mW - 16 VOIES</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation>Auto &lt;= 1W - 16 VOIES</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation>25mW - 8 VOIES</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation>25mW - 16 VOIES</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation>200mW - 16 VOIES (pas de télémétrie)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation>500mW - 16 VOIES (pas de télémétrie)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation>100mW - 16 VOIES (pas de télémétrie)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation></translation>
     </message>
@@ -10617,57 +10611,57 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished">profil</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>Maintien</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>Pas d&apos;impulsion</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation>Bind avec VOIE</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished">Options</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10675,456 +10669,456 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>Entrée</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>Ratio</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation>Cyclique longitudinal</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation>Cyclique latéral</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>Source du pas collectif</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>Phases de Vol</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>Phase de vol</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>Inter</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation>VG%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>Voie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation>Courbe</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation>Linéaire</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation>Télémétrie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation>Chronos</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation>Temps</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation>Compte à rebours</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation>Sorties</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation>Subtrim</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation>Image du modèle</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation>Gaz</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation>Bip Centrer</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation>Positions des interrupteurs</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation>Positions des potentiomètres</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation>Autre</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation>Annonces minutes</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation>Persistant</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation>Port écolage</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation>Hélicoptère</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation>Cyclique</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation>Plateau</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation>Fondu en entrée</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation>Fondu en sortie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation>Variables globales</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>Variables globales</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>Entrées</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>Mixages</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>Courbes</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>Inters Logiques</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Fonction</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished">Activé</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation>FS%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>Fonctions Spéciales</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation>Protocole</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation>Faible</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation>Critique</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation>Audio télémétrie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation>Altimétrie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation>Source vario</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation>Limites vario &gt;</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation>Chute max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation>Chute min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation>Pompe min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation>Pompe max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation>Silence centrer</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation>Barre de titre de l&apos;écran d&apos;accueil</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation>Source de la tension</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation>Source de l&apos;altitude</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation>Paramètres</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation>Capteurs Télémétrie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation>Écrans Télémétrie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation>FG%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation>Fonctions globales</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>Inters paramétrables</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>Unité</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>Alarmes RSSI</translation>
     </message>
@@ -11132,7 +11126,7 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11140,22 +11134,22 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Voie des gaz:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Voie du lacet:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Voie du tangage:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Voie du roulis:</translation>
     </message>
@@ -11163,22 +11157,22 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation>Erreur inconnue</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation>... plus %1 erreurs</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation>Impossible d&apos;écrire les paramètres de la radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation>Impossible d&apos;écrire le modèle %1</translation>
     </message>
@@ -11186,17 +11180,17 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Coupure de gaz</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Chrono de gaz</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Chrono de vol</translation>
     </message>
@@ -11204,40 +11198,40 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Erreur à l&apos;ouverture du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Erreur d&apos;écriture du fichier %1:
@@ -11267,17 +11261,17 @@ Mixage actif par défaut si non-renseigné.</translation>
         <translation>Imprimer vers un fichier</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Imprimer le document</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11304,12 +11298,12 @@ Mixage actif par défaut si non-renseigné.</translation>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -11325,22 +11319,22 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation>ATTENTION</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation>&lt;p&gt;L&apos;importation de données JumperTX dans OpenTX 2.3 est &lt;b&gt; non prise en charge et dangereuse.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Il n&apos;est malheureusement pas possible pour nous de différencier les données JumperTX des données légitimes FrSky X10, donc &lt;b&gt;Vous devez continuer uniquement si le fichier que vous avez ouvert provient d’une véritable radio FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Voulez-vous vraiment continuer?&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished">Afficher ce message lors du prochain démarrage ?</translation>
     </message>
@@ -11348,24 +11342,24 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11373,97 +11367,107 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation>est invalide</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation>converti en</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation>vérifier est</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation>Événement</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation>Origine</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation>Sous-composant</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation>Champ</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation>Ancien</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation>Nouveau</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation></translation>
     </message>
@@ -11471,30 +11475,30 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Impossible d&apos;écrire le fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation>Impossible d&apos;effacer le fichier temporaire %1</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation>Impossible de trouver la carte SD de la radio!</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11502,12 +11506,12 @@ Mixage actif par défaut si non-renseigné.</translation>
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Valeur (entrée): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation>Double-clic droit pour recentrer.</translation>
     </message>
@@ -11613,12 +11617,17 @@ G
 E</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation>PV%1</translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished">PV</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation>VG%1</translation>
     </message>
@@ -11634,358 +11643,458 @@ E</translation>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation>TrmD</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation>TrmP</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation>TrmG</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation>TrmA</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation>Temps</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation>E</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
-        <translation></translation>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Source</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">Aucun</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation>TrmH Gauche</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation>TrmH Droite</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation>TrmV Bas</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation>TrmV Haut</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation>GZs</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation>GZ%</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation>GZt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation>Un</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation>Télémétrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
-        <translation></translation>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">Aucun</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;Voie de dérive:</translation>
     </message>
@@ -11993,21 +12102,21 @@ E</translation>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Erreur à l&apos;ouverture du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation>Erreur d&apos;ouverture en mode écriture du fichier %1.
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12015,319 +12124,334 @@ E</translation>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation>Chiffres bruts (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation>heures</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation>secondes</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation>Formule</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation>Capteur</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation>Altitude</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation>Unité</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation>Précision</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation>Décalage</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation>Pales</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation>Multiplicateur</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation>Filtre</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation>Persistant</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation>Prédéfini</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation>Calculé</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation>Addition</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation>Moyenne</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation>Multiplication</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation>Totalisation</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation>Element LiPo</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation>Consommation</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation>Elément %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation>(défaut)</translation>
     </message>
@@ -12549,87 +12673,87 @@ Si cette option est cochée, la voie des gaz est inversée: le ralenti  est &apo
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation>Menu contextuel disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>Chrono %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation>Paramètres du profil</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation>Chemin de la structure SD non spécifié ou invalide</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation>Effacer le Chrono. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation>Effacer tous les Chronos. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation>Couper le Chrono. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation>Supprimer le Chrono. Êtes-vous sûr?</translation>
     </message>
@@ -12637,7 +12761,7 @@ Si cette option est cochée, la voie des gaz est inversée: le ralenti  est &apo
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Voie de profondeur:</translation>
     </message>
@@ -12645,204 +12769,204 @@ Si cette option est cochée, la voie des gaz est inversée: le ralenti  est &apo
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation>capture</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation>Entrer</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation>PgPréc</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation>PgSuiv</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation>Suppr</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation>RetArr</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation>Échap</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation>Inser</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation></translation>
     </message>
@@ -12850,115 +12974,115 @@ Si cette option est cochée, la voie des gaz est inversée: le ralenti  est &apo
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation>Profils disponibles:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation>Nom: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation>Radio disponibles:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation>ID ou nom du profil radio pour le simulateur.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation>profil</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation>Type de radio à simuler (souvent défini dans le profil).</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation>Dossier contenant l&apos;image de la carte SD. La valeur par défaut est configurée dans le profil radio sélectionné.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation>chemin</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation>source-données</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation>[source-données]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation>Erreur: ID Profil %1 non trouvé.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation>Type de données source non reconnue au démarrage: %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation>ATTENTION: erreur initialisation SDL:
 %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation>ERREUR: pas de simulateur disponible.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
@@ -12967,7 +13091,7 @@ Data File: [%3]</source>
 Fichier de Données: [%3]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation>ERREUR: Profil radio ou firmware du simulateur non trouvé
@@ -12978,8 +13102,8 @@ Profil ID: [%1]; Radio ID: [%2]</translation>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
-        <translation>Simulateur OpenTX</translation>
+        <source>EdgeTX Simulator</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
@@ -13127,74 +13251,74 @@ Profil ID: [%1]; Radio ID: [%2]</translation>
         <translation>Défini la hauteur du widget radio comme étant une taille fixe.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation>ERREUR: Impossible de créer l&apos;interface du simulateur, bibliothèque éventuellement manquante ou mauvaise.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation>Sorties de la radio</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation>Simulateur de télémesure</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation>Simulateur d&apos;écolage</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation>Fenêtre de débogage</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Commandes simulateur:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation>&lt;tr&gt;&lt;th&gt;Touche/Souris&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation>Aide du simulateur</translation>
     </message>
@@ -13323,32 +13447,32 @@ La valeur par défaut est configurée dans le profil radio sélectionné.</trans
         <translation>Image SD</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation>Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation>Sélectionnez un fichier</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation>Sélectionnez un dossier</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation>Sélectionnez le dossier image carte SD</translation>
     </message>
@@ -13361,69 +13485,74 @@ La valeur par défaut est configurée dans le profil radio sélectionné.</trans
         <translation>Simulateur Companion</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation>Simulateur Radio (%1)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation>Impossible de déterminer les données source.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation>Impossible de charger les données, mauvais format.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation>Erreur de lecture des données</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation>Données de démarrage fournies non valides. Veuillez spécifier un fichier/chemin approprié.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation>Erreur de démarrage du simulateur</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation>Erreur de sauvegarde des données: impossible d&apos;écrire le fichier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation>Erreur de sauvegarde des données: impossible de récupérer les données depuis l&apos;interface de simulation.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation>Une erreur inattendue s&apos;est produite lors de l&apos;enregistrement des données radio dans le fichier &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation>Erreur de sauvegarde des données</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation>Impossible d&apos;accéder au Joystick, Joystick désactivé</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation>Erreur firmware radio: %1</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
-        <translation> - Phase de Vol %1 (#%2)</translation>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13448,17 +13577,17 @@ La valeur par défaut est configurée dans le profil radio sélectionné.</trans
         <translation></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>Bibliothèque d&apos;écran d&apos;acceuil - page %1 sur %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>Image invalide dans la bibliothèque %1</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>Aucune image valide trouvée dans la bibliothèque, vérifiez vos paramètres</translation>
     </message>
@@ -13466,7 +13595,7 @@ La valeur par défaut est configurée dans le profil radio sélectionné.</trans
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>Voie %1</translation>
     </message>
@@ -13474,7 +13603,7 @@ La valeur par défaut est configurée dans le profil radio sélectionné.</trans
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation>Fichier %1 introuvable !</translation>
     </message>
@@ -13483,9 +13612,9 @@ La valeur par défaut est configurée dans le profil radio sélectionné.</trans
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation>Éditeur de style</translation>
     </message>
@@ -13511,21 +13640,21 @@ La valeur par défaut est configurée dans le profil radio sélectionné.</trans
 Vous devez connaitre la syntaxe CSS pour QT.</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation>Impossible de récupérer le style %1
 Erreur: %2</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation>Impossible de récupérer le style par défaut %1
 Erreur: %2</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation>Impossible de mettre à jour le style personnalisé %1
@@ -13535,47 +13664,47 @@ Erreur: %2</translation>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation>Données de style lues à partir de &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation>Impossible de lire les données de style à partir de &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation>Impossible de créer le dossier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation>Impossible d&apos;ouvrir le fichier en mode écriture &apos;%1&apos;: Erreur: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation>Impossible d&apos;écrire le fichier &apos;%1&apos;: Erreur:%2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation>Impossible de vider le tampon pour le fichier &apos;%1&apos;: Erreur:%2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation>Style sauvegardé dans le fichier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation>Style personnalisé effacé: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation>Impossible d&apos;éffacer le style personnalisé: &apos;%1&apos;</translation>
     </message>
@@ -13583,59 +13712,59 @@ Erreur: %2</translation>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation>[ESSAI]</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation>La synchronisation a échoué, rien trouvé à copier.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation>Ignorer gros fichier: %1 (%2KB)</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation>Création dossier: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation>Impossible de créer le dossier: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation>Collecte des informations depuis le fichier %1...</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation>Aucun fichier trouvé dans %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation>La synchronisation a été annulée à %1 des fichiers %2.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation>La synchronisation s&apos;est terminée avec %1 fichiers en %2m %3s.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation>Synchronisation: %1
     Vers: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
@@ -13644,84 +13773,84 @@ Erreur: %2</translation>
 </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation>
 Trop d&apos;erreurs, abandon.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation>Ignorer le fichier filtré: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation>Ignorer le fichier lié: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation>Synchronisation annulée de:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation>Synchronisation terminée:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation>Créé(s): %1; Mis à jour: %2; Ignoré(s): %3; Erreur(s): %4;</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation>Le dossier existe: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation>Au moins une des dates de modification du fichier est dans le futur, erreur sur: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation>Ignorer ancien fichier: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation>Impossible d&apos;ouvrir le fichier source &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation>Impossible d&apos;ouvrir le fichier de destination &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation>Ignorer fichier identique: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation>Remplacement du fichier: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation>Création du fichier: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation>Impossible de supprimer le fichier de destination &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation>Echec copie: &apos;%1&apos; vers &apos;%2&apos;: %3</translation>
     </message>
@@ -13729,17 +13858,17 @@ Trop d&apos;erreurs, abandon.</translation>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>Voie de dérive:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Voie de profondeur:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>Plus qu&apos;une seule voie de disponible !&lt;br&gt;Vous devriez peut-être configurer ce modèle sans l&apos;assistant.</translation>
     </message>
@@ -13747,22 +13876,22 @@ Trop d&apos;erreurs, abandon.</translation>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Profondeur et Dérive</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Profondeur uniquement</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>Empennage en V</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Type d&apos;empennage:</translation>
     </message>
@@ -14094,7 +14223,7 @@ Trop d&apos;erreurs, abandon.</translation>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">Ecran de télémesure %1</translation>
     </message>
@@ -14102,29 +14231,963 @@ Trop d&apos;erreurs, abandon.</translation>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Alarme basse</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Alarme critique</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (non supporté)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
         <translation>Supprimer le Capteur. Êtes-vous sûr?</translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Formulaire</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vitesse Verticale</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished">PV</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">Courant</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Altitude</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Formulaire</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished">Elément</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished">Qté Carburant</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished">jj-MM-aaaa
+hh:mm:ss</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished">Mètres</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vitesse Verticale</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Carburant</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">Courant</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Altitude</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Formulaire</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Carburant</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Vitesse Verticale</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Altitude</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">Courant</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14240,72 +15303,72 @@ Trop d&apos;erreurs, abandon.</translation>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation>Menu contextuel disponible</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation>Insérer</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation>Monter</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation>Descendre</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation>Effacer Tout</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation>Couper le capteur de télémétrie. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation>Effacer le capteur de télémétrie. Êtes-vous sûr?</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation>Effacez tous les capteurs de télémétrie. Êtes-vous sûr?</translation>
     </message>
@@ -14318,357 +15381,125 @@ Trop d&apos;erreurs, abandon.</translation>
         <translation>Simulateur de télémesure</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation></translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
         <translation>Simuler</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished">25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation>Rejouer le fichier de Log SD</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation>Vitesse</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation>Pas de fichier de Log chargé</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation>Régler le RSSI à zéro simule la perte de liaison radio et de télémétrie.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation>Régler le RSSI à zéro lors d&apos;une pause.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Aucun</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation>Arrêtez d&apos;envoyer des données de télémétrie lorsque la case est cochée.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation>Pause la simulation.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation>Charger</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation>Ligne # 
 Horodatage</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation>Courant</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation>Elément</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation>Mètres</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation>jj-MM-aaaa
-hh:mm:ss</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>Carburant</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation>Qté Carburant</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation>Vitesse Verticale</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation>Altitude</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
@@ -14676,78 +15507,35 @@ hh:mm:ss</translation>
         <translation>Transmet les valeurs non vides au simulateur.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation>Fichier de Log</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation>Fichier LOG (*.csv)</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
         <translation>ERREUR - fichier non valide</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Oui</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;Voie des gaz:</translation>
     </message>
@@ -14773,138 +15561,138 @@ hh:mm:ss</translation>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation>Chrono %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation>Bips</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation>Voix</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation>Vibreur</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation>Non persistant</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation>Persistant (vol)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation>Vol</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation>Persistant (RAZ manuelle)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation>RAZ manuelle</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished">Eteint</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished">GZs</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished">GZ%</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished">GZt</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14912,22 +15700,22 @@ hh:mm:ss</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished">Eteint</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Additionner)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Remplacer)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished">VOIE%1</translation>
     </message>
@@ -14935,27 +15723,27 @@ hh:mm:ss</translation>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Ratio</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Source</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished">Multiplicateur</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14966,6 +15754,210 @@ hh:mm:ss</translation>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
         <translation>Simulateur d&apos;écolage</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">inconnu</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished">Installation</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished">Echec création répertoire %1</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14992,47 +15984,47 @@ hh:mm:ss</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished">Installation</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15045,22 +16037,42 @@ hh:mm:ss</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished">Installation</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15068,285 +16080,317 @@ hh:mm:ss</translation>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished">inconnu</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished">Echec création répertoire %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15362,64 +16406,90 @@ hh:mm:ss</translation>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation>Téléchargement: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation>Téléchargé: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation>Echec création répertoire %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
         <source>Unable to open the download file %1 for writing. Error: %2</source>
         <translation>Impossible d&apos;ouvrir le fichier %1 pour écriture. Erreur: %2</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
         <source>Invalid URL: %1</source>
         <translation>URL invalide: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
         <source>URL: %1</source>
         <translation>URL: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
         <source>Network error has occurred. Error code: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
         <source>Ssl library version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
-%3</source>
-        <translation type="unfinished">Impossible de télécharger %1. Erreur: %2
-%3</translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15512,32 +16582,32 @@ hh:mm:ss</translation>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation>Aucun</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15550,22 +16620,22 @@ hh:mm:ss</translation>
         <translation>Carte SD</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15578,22 +16648,22 @@ hh:mm:ss</translation>
         <translation>Sons</translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation>Pas de pack de langue sélectionné. La mise à jour des sons est abandonnée !</translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15617,17 +16687,17 @@ hh:mm:ss</translation>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation>Pas de mise à jour disponible à ce jour</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation>Vérification de mises à jour</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15635,37 +16705,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation>Mise à jour composants</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation>Démarrage...</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation>Terminé %1</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation>succès</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation>avec des erreurs</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation>Syncroniser SD carte maintenant ?</translation>
     </message>
@@ -15781,32 +16851,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15814,32 +16884,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">Information</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished">Barre de titre de l&apos;écran d&apos;accueil</translation>
     </message>
@@ -15847,12 +16917,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>Première voie d&apos;empennage:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>Deuxième voie d&apos;empennage:</translation>
     </message>
@@ -15860,55 +16930,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation>Maintien Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
-        <translation>Maintien la position verticale du manche.</translation>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation>Bloque Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation>Empêche le mouvement vertical du manche.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation>Bloque X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation>Empêche le mouvement horizontal du manche.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
         <translation>Maintien X</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
-        <translation>Maintien la position horizontale du manche.</translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Aile standard</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Aile delta</translation>
     </message>
@@ -15916,22 +16986,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15939,273 +17009,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Assistant de configuration de modèle</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Type de modèle</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Entrer le nom et le type de modèle.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Gaz</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>Le modèle a-t-il un moteur ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Type d&apos;aile</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>Le modèle a-t-il une aile standard ou une aile delta ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>Le modèle a-t-il des ailerons ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Volets</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>Le modèle a-t-il des volets ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Aérofreins</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>Le modèle a-t-il des aérofreins ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Aile delta</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Sélectionner les voies d&apos;élevons</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Dérive</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>Le modèle a-t-il une dérive ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Type d&apos;empennage</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Choisissez le type d&apos;empennage de votre modèle.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Empennage</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Sélectionner les voies à utiliser pour l&apos;empennage.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>Empennage en V</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Sélectionner la voie de profondeur.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>Cyclique</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>Quel est le type de plateau cyclique installé dans l&apos;hélico ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>Gyro</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>L&apos;hélico a-t-il un gyro à gain ajustable par la radio ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>Type de rotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>L&apos;hélicoptère a-t-il une barre de Bell ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Hélicoptère</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>Sélectionner les commandes de votre hélicoptère</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Sélectionner les commandes de votre multirotor</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Options de modèle</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Sélectionner les options additionnelles</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>Sauvegarder les changements</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Vérifiez manuellement le sens de chaque commande, et inversez les voies de celles qui répondent dans le mauvais sens. Attention à bien enlever les hélices du modèle avant de l&apos;alimenter la première fois !&lt;br&gt;Veuillez noter que tous les paramètres existants du modèle courant seront écrasés !</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Entrer un nom pour le modèle et sélectionnez son type.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Sélectionnez la voie du récepteur auquel le contrôleur/servo de gaz est connecté.&lt;br&gt;&lt;br&gt;Gaz - Spektrum : VOIE1, Futaba : VOIE3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>La plupart des aéronefs possèdent une aile principale et un empennage avec des surfaces de contrôle. Les ailes volantes et delta ne possèdent qu&apos;une aile. Les surfaces de contrôle sur une aile standard qui contrôlent le roulis de l&apos;aéronef sont appelées ailerons.&lt;br&gt;Les surfaces de contrôle d&apos;une aile delta contrôlent le roulis ET le tangage, et sont appelées élevons.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>On utilise en général soit 1, soit 2 voies pour contrôler les ailerons. Un câble en Y peut être utilisé pour connecter 2 servos à une seule voie, auquel cas il convient de choisir l&apos;option &quot;une seule voie&quot;.&lt;br&gt;&lt;br&gt;Aileron - Spektrum : VOIE2, Futaba : VOIE1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>Cet assistant considère que les volets sont commandés par un interrupteur. Si vous souhaitez les commander par un potentiomètre il est possible de le paramétrer manuellement plus tard.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>Les aérofreins sont utilisés pour augmenter le taux de descente des planeurs performants.&lt;br&gt;Ils ne sont pas courants sur les autres types d&apos;aéronefs.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>Un modéle utilise 2 voies pour commanderles élevons.&lt;br&gt;Sélectionnez-les ici</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Sélectionnez la voie du récepteur auquel le servo de dérive est connecté.&lt;br&gt;&lt;br&gt;Dérive - Spektrum : VOIE4, Futaba : VOIE4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Sélectionnez le type d&apos;empennage de votre avion.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Sélectionnez les voies du récepteur auquel les servos de profondeur et dérive sont connectés.&lt;br&gt;&lt;br&gt;Dérive - Spektrum : VOIE4, Futaba : VOIE4&lt;br&gt;Profondeur - Spektrum : VOIE3, Futaba : VOIE2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Sélectionnez la voie du récepteur auquel le servo de profondeur est connecté.&lt;br&gt;&lt;br&gt;Profondeur - Spektrum : VOIE3, Futaba : VOIE2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Sélectionnez les voies de votre multirotor.&lt;br&gt;&lt;br&gt;Gaz - Spektrum: VOIE1, Futaba: VOIE3&lt;br&gt;Lacet - Spektrum: VOIE4, Futaba : VOIE4&lt;br&gt;Tangage - Spektrum : VOIE3, Futaba: VOIE2&lt;br&gt;Roulis - Spektrum : VOIE2, Futaba: VOIE1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>Aide non disponible pour la page actuelle.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Aide de l&apos;assistant de configuration</translation>
     </message>
@@ -16213,37 +17283,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>Avion</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>Multicoptère</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>Hélicoptère</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>Nom du modèle:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>Type de modèle:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>Voie %1: </translation>
     </message>
@@ -16251,47 +17321,47 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Erreur à l&apos;ouverture du fichier %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished">Erreur d&apos;ouverture en mode écriture du fichier %1.
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16299,16 +17369,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16317,10 +17390,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16372,18 +17460,18 @@ Do you wish to continue?</source>
         <translation>Parcourir...</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>Configuration de DFU-UTIL</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>Configuration de SAM-BA</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Choisir l&apos;emplacement</translation>
     </message>
@@ -16476,7 +17564,7 @@ m2560 for v4.1 boards</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>Suivant</translation>
     </message>
@@ -16486,65 +17574,65 @@ m2560 for v4.1 boards</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation>Non assigné</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation>Aucun Joystick trouvé</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>Impossible d&apos;accéder au Joystick.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation>Appuyer sur le bouton Démarrer afin de lancer la procédure de calibration.
 Vous pouvez changer l&apos;ordre et la direction des VOIES à n&apos;importe quel moment.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation>Bouger les manches à fond dans toutes les directions.
 Cliquer sur Suivant lorsque vous avez terminé</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation>Positionner les manches et pots en positon milieu.
 Cliquer sur Suivant lorsque vous êtes prêts</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation>Assigner les voies du Joystick en utilisant les boutons.
 Cliquer sur Suivant lorsque vous êtes prêts.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation>Inverser la direction des VOIES si nécessaire.
 Cliquer sur Suivant lorsque vous êtes prêts.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation>Cliquer sur OK pour sauvegarder.
 Cliquer sur Annuler pour interrompre la calibration sans sauvegarder.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation>Calibration incomplète, sauvegarder tout de même ?</translation>
     </message>

--- a/companion/src/translations/companion_fr.ts
+++ b/companion/src/translations/companion_fr.ts
@@ -5328,22 +5328,22 @@ Communs à tous les modèles d&apos;une même EEPROM.</translation>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1003"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mode 1 (DIR PROF GAZ AIL)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1005"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mode 2 (DIR GAZ PROF AIL)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1007"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mode 3 (AIL PROF GAZ DIR)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1009"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mode 4 (AIL GAZ PROF DIR)</translation>
     </message>
 </context>
 <context>

--- a/companion/src/translations/companion_he.ts
+++ b/companion/src/translations/companion_he.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,23 +60,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -169,22 +169,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -207,662 +207,657 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,29 +865,29 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -930,33 +925,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -967,255 +962,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1223,17 +1228,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1241,132 +1246,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1409,56 +1414,56 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1474,12 +1479,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,173 +1492,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1691,22 +1706,22 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1732,7 +1747,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1740,17 +1755,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1758,22 +1773,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1856,32 +1871,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1889,7 +1904,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1897,22 +1912,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1920,113 +1935,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2034,343 +2049,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2378,123 +2413,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2502,22 +2537,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,47 +2560,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2622,82 +2657,82 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2705,22 +2740,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2728,53 +2763,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2782,52 +2817,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2906,101 +2941,82 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3009,12 +3025,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3022,12 +3038,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3035,12 +3051,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3048,40 +3064,40 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,23 +3105,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3113,110 +3129,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3226,22 +3227,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3249,22 +3250,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,262 +3273,262 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3535,367 +3536,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3903,27 +3948,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3932,7 +3977,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3997,49 +4042,49 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4117,103 +4162,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4221,83 +4266,83 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4305,7 +4350,7 @@ You are currently using:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4356,225 +4401,240 @@ You are currently using:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4582,17 +4642,17 @@ You are currently using:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4600,17 +4660,17 @@ You are currently using:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4618,17 +4678,17 @@ You are currently using:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4636,13 +4696,13 @@ You are currently using:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4660,17 +4720,18 @@ You are currently using:
         <translation>מפסקים בהתאמה אישית</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4680,7 +4741,12 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4688,8 +4754,13 @@ You are currently using:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4785,13 +4856,13 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4799,43 +4870,33 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4853,12 +4914,12 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4873,47 +4934,47 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4952,7 +5013,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
+        <source>%1 Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4989,185 +5050,208 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished">קיזוזים בלבד</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished">ניווט בלבד</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished">משולב</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished">גלובאלי</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5183,201 +5267,199 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5385,7 +5467,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5395,72 +5477,72 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5483,222 +5565,82 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5706,295 +5648,328 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6009,92 +5984,92 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>מצב כובעונים</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6105,12 +6080,14 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,179 +6095,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6298,17 +6275,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6316,118 +6293,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>השתקת קול</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6508,22 +6495,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6531,18 +6518,18 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
@@ -6551,159 +6538,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="52"/>
         <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <source>Ctrl+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,96 +6731,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6841,17 +6828,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6859,7 +6846,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6867,122 +6854,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6990,112 +6977,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7148,125 +7140,125 @@ Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7274,736 +7266,736 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8011,83 +8003,83 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation type="unfinished">
@@ -8096,7 +8088,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation type="unfinished">
@@ -8105,195 +8097,195 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -8301,166 +8293,166 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8468,143 +8460,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8612,12 +8609,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8630,87 +8627,90 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <oldsource>The value of the mixer is multiplied by this value and divided by 100.</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8725,135 +8725,104 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <oldsource>2 Beeo</oldsource>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8861,22 +8830,22 @@ This determines how mixer values are added.
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8884,136 +8853,136 @@ This determines how mixer values are added.
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="47"/>
         <location filename="../modeledit/mixes.cpp" line="441"/>
+        <source>Ctrl+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9021,18 +8990,23 @@ This determines how mixer values are added.
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9081,32 +9055,49 @@ This determines how mixer values are added.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9119,64 +9110,59 @@ This determines how mixer values are added.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9234,7 +9220,7 @@ This determines how mixer values are added.
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
+        <source>%1 Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9271,585 +9257,595 @@ This determines how mixer values are added.
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished">מצב כובעונים</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished">קיזוזים בלבד</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished">ניווט בלבד</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished">משולב</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished">גלובאלי</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9857,27 +9853,27 @@ This determines how mixer values are added.
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9885,27 +9881,27 @@ This determines how mixer values are added.
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10161,285 +10157,290 @@ This determines how mixer values are added.
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10447,57 +10448,57 @@ This determines how mixer values are added.
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10505,456 +10506,456 @@ This determines how mixer values are added.
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>מפסקים בהתאמה אישית</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10962,7 +10963,7 @@ This determines how mixer values are added.
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10970,22 +10971,22 @@ This determines how mixer values are added.
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10993,22 +10994,22 @@ This determines how mixer values are added.
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11016,17 +11017,17 @@ This determines how mixer values are added.
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11034,40 +11035,40 @@ This determines how mixer values are added.
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11095,17 +11096,17 @@ This determines how mixer values are added.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,12 +11133,12 @@ This determines how mixer values are added.
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11153,22 +11154,22 @@ This determines how mixer values are added.
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11176,24 +11177,24 @@ This determines how mixer values are added.
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11201,97 +11202,107 @@ This determines how mixer values are added.
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11299,29 +11310,29 @@ This determines how mixer values are added.
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11329,12 +11340,12 @@ This determines how mixer values are added.
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11430,12 +11441,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11451,358 +11467,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11810,19 +11926,19 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11830,319 +11946,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12361,87 +12492,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12449,7 +12580,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12457,204 +12588,204 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12662,121 +12793,121 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
@@ -12786,7 +12917,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12935,74 +13066,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13127,32 +13258,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13165,68 +13296,73 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13252,17 +13388,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13270,7 +13406,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13278,7 +13414,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13287,9 +13423,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13314,19 +13450,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13335,47 +13471,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13383,141 +13519,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13525,17 +13661,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13543,22 +13679,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13890,7 +14026,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13898,28 +14034,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14036,72 +15105,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14114,305 +15183,118 @@ Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14421,127 +15303,40 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
         <source>When enabled, sends any non-blank values as simulated telemetry data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14567,138 +15362,138 @@ Timestamp</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14706,22 +15501,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14729,27 +15524,27 @@ Timestamp</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14759,6 +15554,210 @@ Timestamp</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14786,47 +15785,47 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14839,22 +15838,42 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14862,285 +15881,317 @@ Timestamp</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15156,63 +16207,90 @@ Timestamp</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15305,32 +16383,32 @@ Timestamp</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15343,22 +16421,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15371,22 +16449,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15410,17 +16488,17 @@ Timestamp</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15428,37 +16506,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15574,32 +16652,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15607,32 +16685,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15640,12 +16718,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15653,55 +16731,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15709,22 +16787,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15732,273 +16810,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16006,37 +17084,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -16044,45 +17122,45 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16090,16 +17168,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16108,10 +17189,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16203,18 +17299,18 @@ Please only use this if you know what you are doing.  There are no error checks 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16264,59 +17360,59 @@ m2560 for v4.1 boards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16326,7 +17422,7 @@ Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_it.ts
+++ b/companion/src/translations/companion_it.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Si, controllato da un singolo canale</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Si, controllati da due canali</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;Canale del primo alettone:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>Canale del secondo alettone:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Si, controllato da un singolo canale</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Si, controllati da due canali</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>Canale del primo diruttore:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>Canale del secondo diruttore:</translation>
     </message>
@@ -60,23 +60,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -169,22 +169,22 @@
         <translation>Profilo Radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>Ordine canali predefinito</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>Modalità Stick</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>Seleziona immagine</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -225,662 +225,657 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Modo 1 (DIR ELE MOT ALE)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Modo 2 (DIR MOTO ELE ALE)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Modo 3 (ALE ELE MOT DIR)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Modo 4 (ALE MOT ELE DIR)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>Schermata di avvio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>La cartella qui specificata, prevarrà su quella delle impostazioni generali</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>Cartella per backup</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>Se impostato, prevarrà sulle impostazioni generali</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>Se impostato, prevarrà sulle impostazioni generali</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordine dei canali&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Definisce l&apos;ordine delle miscelazioni predefinite durante la creazione di un modello.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>D E M A  </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>D E A M</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>D M E A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>D M A E</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>D A E M</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation>D A M E</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>E D M A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>E D A M</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>E M D A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>E M A D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>E A D M</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>E A M D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>M D E A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>M D A E</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>M E D A</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>M E A D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>M A D E</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>M A E D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>A D E M</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>A D M E</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>A E D M</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>A E M D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>A M D E</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>A M E D</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>Guadagno Volume Simulatore</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>Descrizione</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>Cancella immagine</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>Tipo di radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>Altre impostazioni</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>Impostazioni generali radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>Cartella Struttura Scheda SD </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>Impostazioni applicazione</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>Abilita il backup automatico prima degli aggiornamenti</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>Libreria sfondi</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Eseguibile Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>Solamente sfondi utente</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>Mostra anche sfondi di Companion</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>Cartella sfondi utente</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>Cartella per backup</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>Impostazioni simulatore</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>Colore Retroilluminazione</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>Abilita</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>Blu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>Verde</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>Rosso</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>Arancione</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>Giallo</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>Joystick</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>Calibrazione</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>Usa solo gli appunti per la cattura degli schermi</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>La mia radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Selezionare la cartella per le schermate del simulatore</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Nessun joystick trovato</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>VUOTO: Nessuna impostazione radio nel profilo</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>DISPONIBILE: Impostazioni di data sconosciuta</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>DISPONIBILE: Impostazioni memorizzate %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Selezionare la cartella degli sfondi</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Selezionare la cartella per i backup</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Trova l&apos;eseguibile di Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Selezionare la cartella contenente la struttura della scheda SD</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Apri l&apos;immagine da caricare</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Immagini (%1)</translation>
     </message>
@@ -888,30 +883,30 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Errore durante la scrittura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -949,33 +944,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -986,255 +981,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">Orizzontale Sinistro</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished">Verticale Sinistro</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished">Verticale Destro</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">Orizzontale Destro</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished">Interruttore</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Pot con fermo centrale</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">Momentaneo 2 posizioni</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 Posizioni</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 Posizioni</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Funzione</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">Piccole</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">Entrambi</translation>
     </message>
@@ -1242,17 +1247,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished">Corsa negativa</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished">Valore intermedio</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished">Corsa positiva</translation>
     </message>
@@ -1260,132 +1265,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished">Subtrim</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished">Direzione</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished">Centro PPM</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished">Subtrim lineare</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished">INV</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1428,57 +1433,57 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Non posso scrivere il file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1494,12 +1499,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1507,173 +1512,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished">Informazione</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished">Avviso</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished">Errore</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished">Impostazioni applicazione</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished">Il simulatore per questo firmware non è ancora disponibile</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1711,22 +1726,22 @@ Do you want to import settings from a file?</source>
         <translation>Stampa su file</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Stampa documento</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>Scegliere il nome del file PDF</translation>
     </message>
@@ -1752,7 +1767,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>Va bene, ho capito.</translation>
     </message>
@@ -1760,17 +1775,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>Errore di scrittura</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>Non posso scrivere %1 (motivo: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation>Non posso aprire %1 (motivo: %2)</translation>
     </message>
@@ -1778,22 +1793,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizzato</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished">punti %1</translation>
     </message>
@@ -1876,32 +1891,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">Lineare</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">Esponenziale singola </translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">Curva simmetrica f(x)=-f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">Curva simmetrica f(x)=f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1909,7 +1924,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1917,22 +1932,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished">Diff</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished">Espo</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished">Funz</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizzato</translation>
     </message>
@@ -1940,113 +1955,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished">Somma</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2054,343 +2069,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished">SF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished">Imposta %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished">Allievo DIR</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished">Allievo ELE</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished">Allievo MOT</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished">Allievo ALE</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished">Trim Istantanei</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished">Suona</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished">Vibrazione</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished">Ripristina</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>Amplificatore audio off</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished">Suona una sola volta, non durante l&apos;avvio</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished">Non ripetere</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished">1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished">%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished">Valore</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation type="unfinished">Sorgente</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished">Variometro</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished">Suona Traccia</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished">Suana Entrambi</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished">Suona valore</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished">Volume</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished">Retroilluminazione</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished">Cattura schermo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished">Musica di sottofondo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished">Pausa musica di sottofondo</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished">DISABILITATO</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2398,123 +2433,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Interruttore</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Azione</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Parametri</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished">Abilita</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation>FS%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished">VG</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2522,22 +2557,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished">Numeri</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">Barre</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished">Script</translation>
     </message>
@@ -2545,47 +2580,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">Fase di volo</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2642,82 +2677,82 @@ Do you want to import settings from a file?</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished">FW: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished">immag: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished">Immagine profilo</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>Apri file Firmware</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>Impossibile caricare immagine dal file di Firmware %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>Apri l&apos;immagine da caricare</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>Immagini (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>Impossibile caricare il file immagine %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>Impossibile caricarel&apos;immagine dal profilo %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>Impossibile caricare l&apos;immagine di libreria %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>File salvato</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>L&apos;immagine è stata salvata nel file %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>Errore aggiornamento immagine </translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>Errore durante l&apos;aggiornamento dell&apos;immagine dal file %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>Errore salvataggio file</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>Errore di scittura dell&apos;mmagine nel file %1</translation>
     </message>
@@ -2725,22 +2760,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2748,53 +2783,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished">Interruttore</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished">Sorgente</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished">La sorgente %1 non può essere esportata su questa radio!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX accetta solamente %1 punti in tutte le curve</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTx accetta solamente %1 punti in tutte le curve</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished">OpenTX in questa piattaforma non accetta la funzione</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished">OpenTX non accetta questo protocollo di trasmissione</translation>
     </message>
@@ -2802,52 +2837,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished">Acceso</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished">Si</translation>
     </message>
@@ -2926,101 +2961,82 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished">Scaricamento in corso:</translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation type="unfinished">Scaricamento fallito: %1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3029,12 +3045,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3042,12 +3058,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3055,12 +3071,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;Canale primo Elevone:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>Canale secondo Elevone:</translation>
     </message>
@@ -3068,42 +3084,42 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Errore durante l&apos;apertura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Errore durante la scrittura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3111,23 +3127,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">Acceso</translation>
     </message>
@@ -3135,111 +3151,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Fasi di volo</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Spostamento</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>Sorgente da miscelare</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Nome Ingresso</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation>VG</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Interruttore</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>Sorgente</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Nome linea</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Lato dello stick</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>Sorgente per la miscelazione.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Interruttore usato per abilitare la linea.
-Se vuoto verrà sempre considerata &quot;Attiva&quot;.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>Campo di misura</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Include i Trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>Curva applicata alla sorgente.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation>NEG</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation>POS</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>TUTTI</translation>
     </message>
@@ -3249,22 +3249,22 @@ Se vuoto verrà sempre considerata &quot;Attiva&quot;.</translation>
         <translation>Modifica %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,24 +3272,24 @@ Se vuoto verrà sempre considerata &quot;Attiva&quot;.</translation>
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>Canale motore:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Canale imbardata:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Canale Beccheggio:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translatorcomment>TODO</translatorcomment>
         <translation>Canale Rollio:</translation>
@@ -3298,262 +3298,262 @@ Se vuoto verrà sempre considerata &quot;Attiva&quot;.</translation>
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished">Chiudi</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished">Inizio</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3561,367 +3561,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished">Nessuna funzione di forzatura CH disponibile</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished">Impostazione della modalità FAI (no telemetria) da radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished">Modalità FAI (no telemetria) sempre attiva</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Disabilita il menù HELI e le funzioni del piatto ciclico</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">Disabilita variabili globali</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished">Usa font alternativo SQT5 (Leggermente quadrato)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished">Utilizzo dei potenziometri per la navigazione nei menù</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">Modulo vibrazione installato </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Abilita il menù HELI e le funzioni del piatto ciclico</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished">Variabili Globali</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished">Nel menu settaggio modelli selezionare automaticamente la sorgente muovendo il controllo</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished">Nel menu settaggio modelli selezionare automaticamente l&apos;interruttore muovendo il controllo</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished">Disabilita grafica per caselle di spunta e cursori </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished">Grafico della batteria</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished">Non utilizzare font in grassetto per evidenziare le voci attive</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished">Abilita l&apos;azzeramento di un valore mediante pressione contemporanea di tasti</translation>
     </message>
@@ -3929,27 +3973,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Si, controllato da un singolo canale</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Si, controllati da due canali</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;Canale primo Flap:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>Canale secondo Flap:</translation>
     </message>
@@ -3958,7 +4002,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Scrivi Modelli e Impostazioni sulla Radio</translation>
     </message>
@@ -4023,51 +4067,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Scrivi sulla radio</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>Profilo attuale: %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>Scegli il file di salvataggio della radio</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>Dati errati nel profilo, la calibrazione della radio non è stata sostituita</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>Dati errati nel profilo, i settaggi HW della radio non sono stati sostituiti</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Non posso scrivere il file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Errore durante la scrittura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>Il Firmware appartiene ad un&apos;altra famiglia di prodotti, controllare il file e le preferenze!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>Il firmware della radio è obsoleto, per favore aggiornare!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>Non posso controllare la compatibilità delle impostazioni! Continuare ugualmente ?</translation>
     </message>
@@ -4145,103 +4189,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Scrivi sulla radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>Apri file del Firmware</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 potrebbe non essere un file di firmware valido </translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>Il file del firmware non è valido.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>Non c&apos;è nessuna immagine di avvio nel firmware selezionato.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>L&apos;immagine del profilo %1 non è valida.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>Apri immagine da utilizzare come sfondo di avvio della radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>Immagini (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>Impossibile caricare l&apos;immagine da %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>L&apos;immagine della libreria non può essere caricata</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>Immagine di avvio non trovata</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>Errore durante la scrittura del firmware personalizzato</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>Scrivi Firmware sulla Radio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>Controllo firmware fallito</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>Non posso controllare il firmware dallaradio</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>Il nuovo firmware non è compatibile con quello attualmente installato!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>Conversione fallita</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>Non posso convertire le impostazioni per questo firmware, verranno usate le impostazioni originali</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>Ripristino fallito</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>Non è possibile ripristinare Modelli e impostazioni sulla radio. Il file di Modelli e impostazioni può essere trovato in: %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>Scrittura effettuata</translation>
     </message>
@@ -4249,47 +4293,47 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation>Eseguibile %1 non trovato</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation>Scrittura in corso...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation>Lettura in corso...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation>Verifica in corso...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation>Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>ad esempio: OpenTX per 9X o OpenTX per 9XR </translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>ad esempio: OpenTX per M128 9X o OpenTX per 9XR con M128</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>ad esempio: OpenTX per piastra Gruivin9X</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4298,7 +4342,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 Per cortesia controllate le opzioni avanzate e impostate il tipo corretto.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4307,7 +4351,7 @@ Please select an appropriate firmware type to program it.</source>
 Per cortesia selezionate un firmware corretto per programmarla.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4316,22 +4360,22 @@ state attualmente utilizzando:
  %1 </translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>La vostra radio non sembra connessa alla USB o il driver non è inizializzato!!!.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>Scrittura effettuata (codice di uscita = %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>Scrittura effettuata con errori</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation></translation>
     </message>
@@ -4339,7 +4383,7 @@ state attualmente utilizzando:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
@@ -4390,225 +4434,240 @@ state attualmente utilizzando:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>Encoder rotativo %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation type="unfinished">Valore</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>VAR.GLOB%1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Popup abilitato</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished">Trim disabilitato</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished">Trim proprio</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished">Usa Trim della Fase di volo %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished">Usa Trim della Fase di volo %1 + Trim proprio come offset</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished">Unità</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">VG%1</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Legato alla fase</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation type="unfinished">Cancella</translation>
     </message>
@@ -4616,17 +4675,17 @@ state attualmente utilizzando:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>Fase di volo %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation> (%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (Predefinita)</translation>
     </message>
@@ -4634,17 +4693,17 @@ state attualmente utilizzando:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>Con Flybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>Senza Flybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>Flybar:</translation>
     </message>
@@ -4652,17 +4711,17 @@ state attualmente utilizzando:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished">Giallo</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished">Arancione</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished">Rosso</translation>
     </message>
@@ -4670,13 +4729,13 @@ state attualmente utilizzando:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
@@ -4694,17 +4753,18 @@ state attualmente utilizzando:
         <translation>Interruttori personalizzabili</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished">Inizio</translation>
     </message>
@@ -4714,7 +4774,12 @@ state attualmente utilizzando:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4722,8 +4787,13 @@ state attualmente utilizzando:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4868,13 +4938,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Proseguire solo se si sa cosa si sta facendo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>Reimposta FUSES della radio</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>Leggi impostazioni FUSES dalla Radio</translation>
     </message>
@@ -4882,44 +4952,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">VG</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished">Legato alla fase</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation type="unfinished">Valore Fase di Volo %1</translation>
     </message>
 </context>
 <context>
@@ -4937,12 +4997,12 @@ These will be relevant for all models in the same EEPROM.</source>
 Queste impostazioni sono comuni a tutti i modelli nella stessa EEPROM.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Maestro/Allievo</translation>
     </message>
@@ -4957,47 +5017,47 @@ Queste impostazioni sono comuni a tutti i modelli nella stessa EEPROM.</translat
         <translation>Recupera calib. e settaggi HW dal profilo scelto</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>Funzioni Globali</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>Dati errati nel profilo, la calibrazione della radio non è stata ripristinata</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>Dati errati nel profilo, i settaggi HW della radio non sono stati ripristinati</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>Volete salvare la calibrazione e i settaggi nel profilo %1&lt;br&gt;sovrascrivendo i settaggi esistenti ?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>Dati di calibrazione e settaggi HW salvati.</translation>
     </message>
@@ -5036,8 +5096,8 @@ Queste impostazioni sono comuni a tutti i modelli nella stessa EEPROM.</translat
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Fasi di volo</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5073,185 +5133,208 @@ Queste impostazioni sono comuni a tutti i modelli nella stessa EEPROM.</translat
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished">Interruttore</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">Maestro/Allievo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">Maestro/Allievo SBUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">Debug</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished">Solo trims</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished">Solo keys</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished">Commutabile</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished">Globale</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">Modo 1 (DIR ELE MOT ALE)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished">Modo 2 (DIR MOTO ELE ALE)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">Modo 3 (ALE ELE MOT DIR)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">Modo 4 (ALE MOT ELE DIR)</translation>
     </message>
 </context>
 <context>
@@ -5267,201 +5350,199 @@ Queste impostazioni sono comuni a tutti i modelli nella stessa EEPROM.</translat
         <translation>Sblocco modalità sola lettura</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation>SC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation>SE</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation>SA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation>SF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation>SH</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation>SD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation>SB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation>SG</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Differenza in ore da GMT</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Lingua per le voci</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Codice paese</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Inverti Stick</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>Modalità FAI</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Aggiusta Orologio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Tono del vario al massimo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Volume altoparlante</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>Interruttore retroilluminazione</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Modalità audio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>Colore 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>Colore 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>Tonalità suono (modifica HW)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Se questo valore non è 0, ogni pressione di tasto provocherà l&apos;accensione della luce e questa verrà spenta dopo il numero di secondi specificato.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation>sec</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>Colore retroilluminazione</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>Cicalino</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Altoparlante</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>Cicalino e voce</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>Altoparlante e Voce</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Volume cicalino</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Volume file Wav</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Volume per vario</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Volume sottofondo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation> ms</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>Auto spegnimento luce dopo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>Retroilluminazione su allarme</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Tono del vario a zero</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Ripetizione vario a zero</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5469,7 +5550,7 @@ Queste impostazioni sono comuni a tutti i modelli nella stessa EEPROM.</translat
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5484,257 +5565,137 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;I valori possono andare da 20 a 45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>Luminosità retroilluminazione</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Navigazione con Encoder </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>America</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Giappone</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>Europa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ordine dei canali&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Definisce l&apos;ordine delle miscelazioni predefinite durante la creazione di un modello.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation>D E M A  </translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation>D E A M</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation>D M E A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation>D M A E</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation>D A E M</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation>D A M E</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation>E D M A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation>E D A M</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation>E M D A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation>E M A D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation>E A D M</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation>E A M D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation>M D E A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation>M D A E</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation>M E D A</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation>M E A D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation>M A D E</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation>M A E D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation>A D E M</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation>A D M E</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation>A E D M</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation>A E M D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation>A M D E</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation>A M E D</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5745,38 +5706,38 @@ Al di sotto di questo valore verrà generato un seganle di allarme.
 Valori accettabili da 3v a 12v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5817,169 +5778,149 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>Modo 1 (DIR ELE MOT ALE)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>Modo 2 (DIR MOTO ELE ALE)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>Modo 3 (ALE ELE MOT DIR)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>Modo 4 (ALE MOT ELE DIR)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>Modo joystick</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Modo Stick</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Sistema Metrico</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Imperiale</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Ordine canali predefinito</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>Coordinate GPS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation>v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Modalità suono beeper</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Temporizzatore di inattività</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Lunghezza suono</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Mostra schermata all&apos;avvio</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>Contrasto</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Campo misuratore batteria</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Intensità vibrazione (mod. HW)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>Tipo display LCD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Avviso &quot;nessun suono&quot;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Allarme batteria scarica</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Lunghezza vibrazione</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>Baud rate MAVLink</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Modalità vibrazione</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -5996,177 +5937,210 @@ Mode 4:
 4 - Fortissimo.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Silenzioso</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Solo allarmi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>No Tasti</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>Tutti</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Solo allarmi</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation>Optrex</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Se non è zero, verrà fatto suonare l&apos;allarme se la radio non è utilizzata per il numero di minuti specificato.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation>min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation>---</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">0s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">0.5s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation>2s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation>3s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation>4s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation>6s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation>8s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation>10s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation>15s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished">Maestro/Allievo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation>4800 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation>9600 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation>14400 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation>19200 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation>38400 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation>57600 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation>76800 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation>115200 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6191,52 +6165,54 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Suoni disabilitati - avvisa se i suoni sono disabilitati (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>Extra Corto</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>Normale</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>Extra Lungo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation>NMEA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Ritardo esecuzione(posizione intermedia)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Unità di misura</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished">1s</translation>
     </message>
@@ -6244,179 +6220,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished">Tasti</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished">Leve</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished">Tasti + Leve</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished">Acceso</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished">Inglese</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished">Francese</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished">Italiano</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished">Tedesco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished">Ceco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished">Slovacco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished">Spagnolo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished">Polacco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished">Portoghese</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished">Svedese</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished">EncRot A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">EncRot B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">EncRot C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">EncRot D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">EncRot E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6424,17 +6400,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Si, controllato da un interruttore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Si, controllato da un potenziometro</translation>
     </message>
@@ -6442,118 +6418,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>Muto senza suono</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6634,22 +6620,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>Canale motore:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>Canale imbardata:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>Canale Beccheggio:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>Canale Rollio:</translation>
     </message>
@@ -6657,18 +6643,18 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished">File impostazioni non valido %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Errore durante la scrittura del file %1:
@@ -6678,159 +6664,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>Muovi Su</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>Muovi Giù</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Cancella tutti gli ingressi</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished">Linee</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;Aggiungi</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;Modifica</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation>Invio</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>&amp;Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>&amp;Taglia</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>&amp;Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>Dup&amp;lica</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished">Ingresso</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6871,96 +6857,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6968,17 +6954,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished">INV</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished">NOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6986,7 +6972,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">VG</translation>
     </message>
@@ -6994,122 +6980,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished">AND</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished">Bloccato</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished">Soglia</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7117,112 +7103,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation>V1</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation>V2</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>Durata</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>Ritardo</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>Funzione</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>Interruttore AND</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">Persistente</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7275,126 +7266,126 @@ Are you sure ?</source>
         <translation type="unfinished">Sessioni di volo</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation type="unfinished">Log telemetrici</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation type="unfinished">Cambia titolo del grafico</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation type="unfinished">Nuovo titolo del grafico:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation type="unfinished">Cambia etichetta asse</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation type="unfinished">Nuova etichetta:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation type="unfinished">Cambia nome del grafico</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation type="unfinished">Nuovo nome del grafico:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Non posso scrivere il file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation type="unfinished">Selezionare il file di log</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation type="unfinished">Campi disponibili</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation type="unfinished">Il file di log selezionato contiene %1 righe errate su un totale di %2 righe</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation type="unfinished">durata</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7402,736 +7393,736 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Documento caricato</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Documento salvato</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Apri modelli e file impostazioni</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>Il nuovo tema sarà caricato al prossimo riavvio di Companion.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Nuovo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>Apri...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Salva come...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>Tema icone monocromatico nero</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>Tema icone monocromatico bianco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>tema icone monocromatico blu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation type="unfinished">Chiudi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Piccole</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>Usa icone piccole barra strumenti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>Usa icone normali nell barra strumenti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Normali</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>Usa icone grandi barra strumenti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Grandi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>Usa icone giganti barra strumenti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Giganti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished">Non è possibile rimuover il profilo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished">Il profilo predefinito non può essere rimosso.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Crea nuovo modello e file di impostazioni</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Salva Modello e file impostazioni</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>Classica</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>Tema classico icone Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation>Yerico</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Tema di icone giallo dolce miele rotondo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>Monocromatico</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>Monocolore Bianco</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>Monocolore Blu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>Lingua di sistema</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>Visualizza file di Log...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Apri e visualizza file di log</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Impostazioni...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Edita Impostazioni</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Confronta due modelli...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Edita immagine Splah della radio...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>Edita immagine splash della tua radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Leggi il Firmware dalla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>Leggi firmware dalla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Scrivi Firmware sulla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Scrivi firmware sulla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Aggiungi profilo Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Scrivi modello e impostazioni sulla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Scrivi Modeli e Impostazioni sulla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Leggi Modelli e Impostazioni dalla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>Configura Comunicazioni...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>Configura il software per comunicare con la Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Scrivi salvataggio sulla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Scrivi salvataggio dal file sulla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Salvataggio Radio su File</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>Salvataggio completo di Impostazioni e Modelli nella Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>File recenti</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Menù Impostazione Lingua</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Leggi Modelli e impostazioni dalla Radio</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>Salvataggio Radio su file</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Leggi firmware radio su File</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>Se avete trovato utile questo programma prego supportatelo con &lt;a href=&apos;%1&apos;&gt;una donazione&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Confronta due modelli</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Esci dall&apos;applicazione</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>Scrivi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>Informazioni su Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>Mostra la finestra Informazioni Su</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>Sincronizza SD</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>Sincronizzazione scheda SD </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Scegliere il tema di icone</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Scegliere il dimensione di icone</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Documento</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Modifica</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Leggi/Scrivi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Pronto</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation>%2</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8139,81 +8130,81 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Modifica modello %1:</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Impossibile trovare il file %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Errore durante l&apos;apertura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Error durante la lettura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Salva Come</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation type="unfinished">
@@ -8222,7 +8213,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation type="unfinished">
@@ -8231,241 +8222,241 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Modifica</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation type="unfinished">Modello</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation type="unfinished">Assistente di configurazione</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -8473,125 +8464,125 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>Apri salvataggio modelli e impostazioni</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>File di backup binario non valido %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 è stato modificato.
 Salvare le modifiche ?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished">Alt+S</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished">Somma</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished">Vuoi sovrascrivere le impostazioni generali della radio?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Errore durante la scittura del file temporaneo!</translation>
     </message>
@@ -8599,143 +8590,148 @@ Salvare le modifiche ?</translation>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8743,12 +8739,12 @@ Salvare le modifiche ?</translation>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8761,82 +8757,90 @@ Salvare le modifiche ?</translation>
         <translation>Dialogo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Sorgente</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>Sorgente da miscelare</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Spostamento</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">Precisione</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Include i Trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Curva utilizzata dalla miscelazione</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Interruttore</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation>VG</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Interruttore che controlla la miscelazione.
-Se vuoto la miscelazione è sempre attiva.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Avviso</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8861,146 +8865,104 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Se il rallentamento non è zero allora la velocità verrà impostata al valore selezionato -&amp;gt; il valore indica il numero di secondi per passare da -100 a 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>Allarme miscelazione.
-Impostare questo valore causa un&apos;allarme in corrispondenza del valore.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>Spento</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 Beep</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2 Beep</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 Beep</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Miscelatore</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Fasi di volo</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Miscelazionir
-
-Determina come il valore viene aggiunto alla miscelazione.
-
-&quot;+&quot; significa che il valore viene aggiunto ai valori preesitenti sul canale.
-&quot;*&quot; significa che il valore viene utilizzato come moltiplicatore.
-&quot;R&quot; significa che il valore rimpiazza il valore attuale del canale. Se l&apos;interruttore è spento questo valore verrà ignorato.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>AGGIUNGI</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>MOLTIPLICA</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>SOSTITUISCI</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>Include DR/Espo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">0.00</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Ritardo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Rallentamento</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Su</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Giù</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9008,22 +8970,22 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9031,136 +8993,136 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>Muovi in Su</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>Muovi in Giù</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Cancella Miscelazioni</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>Non ci sono più miscelazioni disponibili!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;Aggiungi</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;Modifica</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>Invio</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>Al&amp;terna evidenziazione</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>Ta&amp;glia</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>&amp;Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>Du&amp;plica</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>Cancellare le miscelazioni ?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>Sicuri di voler cancellare le miscelazioni ?</translation>
     </message>
@@ -9168,19 +9130,24 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished">Sorgente motore</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation type="unfinished">MOT</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9228,32 +9195,49 @@ Determina come il valore viene aggiunto alla miscelazione.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
+        <translation type="unfinished">NO</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished">---</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9271,63 +9255,58 @@ Determina come il valore viene aggiunto alla miscelazione.
         <translation>Simula Modello</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>Heli</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Ingressi</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Interruttori logici</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Miscelazioni</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Curve</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Fasi di volo</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation type="unfinished">Uscite</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Funzioni speciali</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Telemetria</translation>
     </message>
@@ -9381,8 +9360,8 @@ Determina come il valore viene aggiunto alla miscelazione.
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Fasi di volo</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9418,585 +9397,595 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation type="unfinished">Esponenziale</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation type="unfinished">Extra Fine</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation type="unfinished">Fine</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation type="unfinished">Medio</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation type="unfinished">Ampio</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished">Abilita</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished">Si</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished">Acceso</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished">Modo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished">Canali</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished">Pausa PPM</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished">Polarità</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished">Protocollo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished">Ritardo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished">Ricevitore</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation type="unfinished">90</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation type="unfinished">120</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation type="unfinished">120X</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation type="unfinished">140</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished">Fasi di volo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished">Fase di volo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished">Tutti</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished">Soglia</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished">Bloccato</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished">Durata</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished">Limiti estesi</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished">Mostra Note</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished">Funzioni Globali</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished">Manuale</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished">Auto</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished">Modalità FailSafe</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished">Mantieni</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished">No impulsi</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished">Non impostato</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished">Modo joystick</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished">Mai</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished">Sempre</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished">Solo trims</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished">Solo keys</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished">Commutabile</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished">Globale</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished">Sorgente</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished">Avviso</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished">FrSky S.PORT</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished">FrSky D</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished">FrSky D (su cavo)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished">A1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished">A2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished">A3</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished">A4</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished">FAS</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished">Celle</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished">Numeri</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished">Barre</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished">Script</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished">Nome file</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation type="unfinished">NO</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation type="unfinished">FV %1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation type="unfinished">FV %1%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation type="unfinished">NoTrim</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation type="unfinished">No DR/Espo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation type="unfinished">Spostamento(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizzato</translation>
     </message>
@@ -10004,27 +9993,27 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Aereo</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>Multirotore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Elicottero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Nome Modello:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Tipo di modello:</translation>
     </message>
@@ -10032,27 +10021,27 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10308,285 +10297,290 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished">Positivo</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished">Negativo</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished">Porta Allievo</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished">Sistema Radio interno</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished">Modulo radio Esterno</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished">Sistema radio esteso</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished">Sistema Radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10594,57 +10588,57 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation>Valore</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>Mantieni</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>No impulsi</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10652,456 +10646,456 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation type="unfinished">Ingresso</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation type="unfinished">Peso</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation type="unfinished">Collettivo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation type="unfinished">Fasi di volo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation type="unfinished">Fase di volo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation type="unfinished">Interruttore</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished">Immagine modello</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished">Motore</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished">Avviso interruttore </translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished">Avviso Pot</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished">Conto alla rovescia</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">Modo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished">Inizio</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished">Elicottero</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Funzione</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished">Protocollo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished">Altimetro</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished">Sorgente per il Vario</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished">Barra superiore</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished">Misura della tensione</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished">Misura dell&apos;altitudine</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>Interruttori personalizzabili</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished">Parametri</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished">GF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished">Funzioni Globali</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation type="unfinished">VG%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished">Uscite</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished">Subtrim</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished">Lineare</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation type="unfinished">Variabili Globali</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation type="unfinished">Ingressi</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation type="unfinished">Miscelazioni</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation type="unfinished">Curve</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation type="unfinished">L%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation type="unfinished">Interruttori logici</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation type="unfinished">FS%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation type="unfinished">Funzioni speciali</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation type="unfinished">Unità</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11109,7 +11103,7 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11117,22 +11111,22 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Canale Motore:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Canale Imbardata:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Canale Beccheggio:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Canale Rollio:</translation>
     </message>
@@ -11140,22 +11134,22 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11163,17 +11157,17 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Blocco motore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Temporizzatore motore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Temporizzatore volo</translation>
     </message>
@@ -11181,40 +11175,40 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Errore durante l&apos;apertura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Errore durante la scrittura del file %1:
@@ -11244,17 +11238,17 @@ Determina come il valore viene aggiunto alla miscelazione.
         <translation>Stampa su file</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Stampa documento</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11281,12 +11275,12 @@ Determina come il valore viene aggiunto alla miscelazione.
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
@@ -11302,22 +11296,22 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11325,24 +11319,24 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11350,97 +11344,107 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished">Azione</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished">Nuovo</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11448,30 +11452,30 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Non posso scrivere il file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished">Non posso cancellare il file temporaneo: %1</translation>
     </message>
@@ -11479,12 +11483,12 @@ Determina come il valore viene aggiunto alla miscelazione.
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11580,12 +11584,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation type="unfinished">FV %1</translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished">VG%1</translation>
     </message>
@@ -11601,358 +11610,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished">Batt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished">REa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished">REb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Sorgente</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">Nessuno</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished">REa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished">REb</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished">Acceso</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished">MOs</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished">MO%</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished">MOt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished">Uno</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished">----</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished">Interruttore</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">Nessuno</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;Canale Direzionale:</translation>
     </message>
@@ -11960,20 +12069,20 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Errore durante l&apos;apertura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11981,319 +12090,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished">Istanza</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished">Alt</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished">Unità</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished">Precisione</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished">Spostamento</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished">Pale dell&apos;elica</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished">Moltiplicatore</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished">Filtra</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished">Positivo</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished">Personalizzato</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished">Calcolato</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished">Somma</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished">Media</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished">Moltiplica</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished">Totalizza</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished">Cella</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished">Consumo</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished">Minore</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished">Cella %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished">Maggiore</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished">Diff</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished">Grezza (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12515,87 +12639,87 @@ Se l&apos;opzione selezionata lo stick motore verrà rovesciato. Il minimo sarà
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12603,7 +12727,7 @@ Se l&apos;opzione selezionata lo stick motore verrà rovesciato. Il minimo sarà
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Canale dell&apos;Elevatore:</translation>
     </message>
@@ -12611,204 +12735,204 @@ Se l&apos;opzione selezionata lo stick motore verrà rovesciato. Il minimo sarà
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12816,121 +12940,121 @@ Se l&apos;opzione selezionata lo stick motore verrà rovesciato. Il minimo sarà
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
@@ -12940,7 +13064,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13089,74 +13213,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished">Simulatore Telemetria</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished">Uscita diagnostica</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13281,32 +13405,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13319,67 +13443,72 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished">Simulatore di Companion</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished">Non riesco ad aprire il joystick, supporto joystick disabilitato</translation>
     </message>
@@ -13406,17 +13535,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>Libreria sfondi - pagina %1 di %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>Immagine corrotta nella libreria %1</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>Nessuna immagine trovata nella libreria, controllate le impostazioni</translation>
     </message>
@@ -13424,7 +13553,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>Canale %1</translation>
     </message>
@@ -13432,7 +13561,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished">Impossibile trovare il file %1!</translation>
     </message>
@@ -13441,9 +13570,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13468,19 +13597,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13489,47 +13618,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13537,141 +13666,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13679,17 +13808,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>Canale Direzionale:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Canale Elevatore:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13697,22 +13826,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Elevatore e Deriva</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Solo Elevatore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>Coda a V</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Tipo di coda:</translation>
     </message>
@@ -14044,7 +14173,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">Schermo telemetria %1</translation>
     </message>
@@ -14052,28 +14181,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Allarme basso</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Allarme critico</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation>Winged Shadow How High</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (non supportato)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished">A4</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished">A3</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished">Batt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14190,72 +15252,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished">Copia</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished">Incolla</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished">Elimina</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14268,355 +15330,124 @@ Too many errors, giving up.</source>
         <translation>Simulatore Telemetria</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation>RSSI</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation>A1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation>A2</translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
         <translation type="unfinished">Simula Modello</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished">25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation type="unfinished">&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation type="unfinished">X</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished">1/5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished">5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Nessuno</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation>A3</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation>A4</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation type="unfinished">Alt</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
@@ -14624,78 +15455,35 @@ hh:mm:ss</source>
         <translation>Quando abilitato invia i valori non nulli come dati telemetrici simulati.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;Canale Motore:</translation>
     </message>
@@ -14721,138 +15509,138 @@ hh:mm:ss</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished">Silenzioso</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">Suoni</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">Voce</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">Vibrazione</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished">5s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished">10s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished">20s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished">30s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">Non persistente</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">Persistente (volo)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">Persistente (reset manuale)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">Acceso</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished">Inizio</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished">MOs</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished">MO%</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished">MOt</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14860,22 +15648,22 @@ hh:mm:ss</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Somma)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Sostituisci)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
@@ -14883,27 +15671,27 @@ hh:mm:ss</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">Modo</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Peso</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Sorgente</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished">Moltiplicatore</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14914,6 +15702,210 @@ hh:mm:ss</source>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
         <translation>Simulatore allievo</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14940,47 +15932,47 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14993,22 +15985,42 @@ hh:mm:ss</source>
         <translation type="unfinished">Firmware</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15016,285 +16028,317 @@ hh:mm:ss</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished">Sconosciuto</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15310,63 +16354,90 @@ hh:mm:ss</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15459,32 +16530,32 @@ hh:mm:ss</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15497,22 +16568,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15525,22 +16596,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15564,17 +16635,17 @@ hh:mm:ss</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15582,37 +16653,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15728,32 +16799,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15761,32 +16832,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">Informazione</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished">Barra superiore</translation>
     </message>
@@ -15794,12 +16865,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>Canale primo servo di coda:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>Canale secondo servo di coda:</translation>
     </message>
@@ -15807,55 +16878,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation type="unfinished">Blocca Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation type="unfinished">Blocca X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Ali normali</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Tuttala / Ala a Delta</translation>
     </message>
@@ -15863,22 +16934,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15886,273 +16957,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Assistente di configurazione</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Tipologia modello</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Inserire nome e tipo di modello.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Motore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>Il modello ha un motore a scoppio o elettrico?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Tipo di ala</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>Il modello è un tuttala / ala a delta o ha una configurazione standard?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>Alettoni</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>Il modello ha gli alettoni?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Flap</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>Il modello ha i flap?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Diruttori</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>Il modello ha i diruttori?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Tuttala / Ala a delta</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Selezionare in canali degli elevoni</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Direzionale</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>Il modello ha un direzionale?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Tipo di coda</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Selezionare quale tipo di coda ha il modello.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Coda</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Selezionare i canali che controllano la coda.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>Coda a V</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Selezionare il canale dell&apos;elevatore.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>Ciclico</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>Quale tipo di anello è installato sul vostro elicottero?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>Giroscopio di coda</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>L&apos; elicottero ha un giroscopio per la coda?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>Tipo di rotore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>L&apos;elicottero ha una Flybar ?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Elicottero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>Selezionare i controlli per l&apos;elicottero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>Multirotore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Selezionare i canali di controllo per il multirotore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Opzioni del modello</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Selezionarefunzionalità aggiuntive </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>Salva cambiamenti</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Controllare manualmente la direzione di ogni superfice di controllo e invertire ogni canale che si sposta nella direzione errata. Rimuovere l&apos;elica/eliche prima di controllare per la prima volta il modello.&lt;br&gt;Attenzione: continuando verranno rimosse tutte le impostazioni dei vecchi modelli!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Inserire il nome per il vostro modello e selezionare il tipo di modello.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Selezionare il canale della ricevente al quale è connesso l&apos;ESC o il servo del gas.&lt;br&gt;&lt;br&gt;Es. Spectrum: CH1, Futaba:.CH3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>Molti aeromobili hanno l&apos;ala principale e la coda con superfici di controllo. I veivoli tuttala e le ali a delta ne hanno una sola. In un ala tradizionale le superfici di controllo principali provocano il rollio del veivolo e si chiamano Alettoni.&lt;br&gt;In un&apos;ala a delta le superfici di controllo provocano contemporaneamente rollio e beccheggio e si chiamano Elevoni.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>Questo assistente configura l&apos;azionamento dei flap tramite switch. Potete associare un potenziometro in seguito.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>I diruttori sono utilizzati per rdurre la velocità degli alianti.&lt;br&gt;Non sono molto comuni in altri tipi di modelli.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>I modelli usano due canali per il controllo degli elevoni.&lt;br&gt;Selezionare i canali appropriati</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Selezionare il canale della ricevente al quale è connesso il direzionale.&lt;br&gt;&lt;br&gt;Es. Spectrum: CH4, Futaba:.CH4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Slezionare il tipo di coda dell&apos;aereo.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Selezionare il canale del direzionale e dell&apos;elevatore.&lt;br&gt;&lt;br&gt;Direzionale - Spectrum: CH4, Futaba:.CH4&lt;br&gt;Elevatore - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Selezionare il canale della ricevente al quale è connesso l&apos;elevatore.&lt;br&gt;&lt;br&gt;Es. Spectrum: CH3, Futaba:.CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Selezionare i canali per il vostro multirotore.&lt;br&gt;&lt;br&gt;Motore - Spektrum: CH1, Futaba: CH3&lt;br&gt;Imbardata - Spektrum: CH4, Futaba: CH4&lt;br&gt;Beccheggio - Spektrum: CH3, Futaba: CH2&lt;br&gt;Rollio - Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>Nessun aiuto disponibile per questa pagina.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Aiuto dell&apos;assistente di configurazione</translation>
     </message>
@@ -16160,37 +17231,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>Aereo</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>Multirotore</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>Elicottero</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>Nome Modello: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>Tipo Modello: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>Opzioni: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>Canale %1: </translation>
     </message>
@@ -16198,46 +17269,46 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Errore durante l&apos;apertura del file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16245,16 +17316,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16263,10 +17337,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16360,20 +17449,20 @@ utilizzatelo solo se sapete cosa state facendo.  Non viene fatto alcun controllo
         <translation>Porta seriale per sam-ba</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <oldsource>DFU-UTIL Cconfiguration</oldsource>
         <translation>Configurazione DFU-UTIL</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <oldsource>SAM-BA Cconfiguration</oldsource>
         <translation>Configurazione SAM-BA</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Seleziona eseguibile</translation>
     </message>
@@ -16425,7 +17514,7 @@ m2560 per le schede v4.1</translation>
         <translation type="unfinished">Inizio</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>Successivo</translation>
     </message>
@@ -16435,59 +17524,59 @@ m2560 per le schede v4.1</translation>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished">Nessun joystick trovato</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>Non riesco ad aprire il joystick.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_ja.ts
+++ b/companion/src/translations/companion_ja.ts
@@ -4,30 +4,30 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translatorcomment>モデルウィザード: エルロン(補助翼)設定</translatorcomment>
         <translation>補助翼なし</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translatorcomment>モデルウィザード: エルロン(補助翼)設定</translatorcomment>
         <translation>補助翼あり、1つの受信機チャンネルを使用</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translatorcomment>モデルウィザード: エルロン(補助翼)設定</translatorcomment>
         <translation>補助翼あり、2つの受信機チャンネルを使用</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;第1補助翼チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>第2補助翼チャンネル:</translation>
     </message>
@@ -35,27 +35,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>エアブレーキなし</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>エアブレーキあり、1つの受信機チャンネルを使用</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>エアブレーキあり、2つの受信機チャンネルを使用</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;第1エアブレーキチャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>第2エアブレーキチャンネル:</translation>
     </message>
@@ -63,24 +63,24 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation>アプリケーション設定が保存されました
  %1</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation>アプリケーション設定をファイル『%1』に保存できませんでした</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation>ファイルを保存できませんでした。(アクセス権を確認してください).</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation>理由は不明です。</translation>
     </message>
@@ -173,69 +173,69 @@
         <translation>送信機プロファイル</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>プロファイル名</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>送信機タイプ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>起動イメージ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>その他の設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>SDカード保存先パス</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>プロファイル固有のフォルダが設定されている場合、通常のバックアップフォルダよりも優先されます</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>バックアップフォルダ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>設定されている場合はアプリケーション設定を上書き保存します</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>設定されている場合は有効なバックアップを上書き保存します</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>設定した場合は自動バックアップを有効にする</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>全般設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>初期スティックモード</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -258,615 +258,610 @@ Mode 4:
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>モード1&#x3000;(左:エレベーター・ラダー&#x3000;右:スロットル・エルロン)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>モード2&#x3000;(左:スロットル・ラダー&#x3000;右:エレベーター・エルロン)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>モード3&#x3000;(左:エレベーター・エルロン&#x3000;右:スロットル・ラダー)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>モード4&#x3000;(左:スロットル・エルロン&#x3000;右:エレベーター・ラダー)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>初期チャンネルマップ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;チャンネルマップ&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;機体モデルを作成した際の初期チャンネルマップを定義します&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation>アップデート後、送信機にファームウェアの書き込みを促すメッセージを表示</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>↔RUD ↕ELE ↕THR ↔AIL&#x3000;[R E T A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>↔RUD ↕ELE ↔AIL ↕THR&#x3000;[R E A T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>↔RUD ↕THR ↕ELE ↔AIL&#x3000;[R T E A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>↔RUD ↕THR ↔AIL ↕ELE&#x3000;[R T A E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>↔RUD ↔AIL ↕ELE ↕THR&#x3000;[R A E T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation>↔RUD ↔AIL ↕THR ↕ELE&#x3000;[R A T E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>↕ELE ↔RUD ↕THR ↔AIL&#x3000;[E R T A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>↕ELE ↔RUD ↔AIL ↕THR&#x3000;[E R A T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>↕ELE ↕THR ↔RUD ↔AIL&#x3000;[E T R A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>↕ELE ↕THR ↔AIL ↔RUD&#x3000;[E T A R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>↕ELE ↔AIL ↔RUD ↕THR&#x3000;[E A R T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>↕ELE ↔AIL ↕THR ↔RUD&#x3000;[E A T R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>↕THR ↔RUD ↕ELE ↔AIL&#x3000;[T R E A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>↕THR ↔RUD ↔AIL ↕ELE&#x3000;[T R A E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>↕THR ↕ELE ↔RUD ↔AIL&#x3000;[T E R A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>↕THR ↕ELE ↔AIL ↔RUD&#x3000;[T E A R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>↕THR ↔AIL ↔RUD ↕ELE&#x3000;[T A R E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>↕THR ↔AIL ↕ELE ↔RUD&#x3000;[T A E R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>↔AIL ↔RUD ↕ELE ↕THR&#x3000;[A R E T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>↔AIL ↔RUD ↕THR ↕ELE&#x3000;[A R T E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>↔AIL ↕ELE ↔RUD ↕THR&#x3000;[A E R T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>↔AIL ↕ELE ↕THR ↔RUD&#x3000;[A E T R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>↔AIL ↕THR ↔RUD ↕ELE&#x3000;[A T R E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>↔AIL ↕THR ↕ELE ↔RUD&#x3000;[A T E R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation>外部モジュール</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation>機体モデルの削除時に空のモデルスロットを削除 (ラベルのない送信機にのみ適用)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation>送信機プロファイル</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation>選択した送信機プロファイルをリストの一番上に移動させる</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation>シミュレータ 制御</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation>シミュレータの終了時にスイッチ / ダイヤル位置を保存する</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation>保存した位置を消去</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation>『ジョイスティックを開けません。ジョイスティックは無効です。』警告の無効</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation>アップデート設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation>周波数チェック</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation>デフォルトに戻す</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation>フォルダ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation>ダウンロード</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation>ダウンロードフォルダにサブフォルダを作成する</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation>展開先</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation>送信機プロファイル SDディレクトリ構造を使用します</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation>コンポーネント</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation>ダウンロードファイルの削除</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation>展開先ファイルの削除</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation>ログ記録</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation>機体モデル新規作成</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation>画面キャプチャフォルダ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>画像消去</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>画像選択</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>フォルダの選択</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>アプリケーション設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation>最近使用したファイル</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation>起動時の設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation>ファイル履歴</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation>ログ出力フォルダ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;このオプションは、機体モデルが削除または移動した際、そのモデルスロットが保持される旧版のOpenTxバージョンの挙動を維持します。&lt;/p&gt;&lt;p&gt;このオプションが選択されない場合は、他の機体モデルは削除により残された差異を埋めるために並べ替えるかもしれません。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation>出力したログのデバッグ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation>アプリケーション (Companion / シミュレータ)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;シミュレータで実行しているときは、送信機ファームウェアによって生成されたすべてのメッセージのログを保存してください。これはシミュレータの&lt;span style = &quot;font-style:italic;&quot;&gt;デバッグ出力&lt;/span&gt;ウィンドウにも同じ情報が表示されます。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation>送信機ファームウェア (シミュレータ内)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>起動イメージライブラリ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Google Earth 実行ファイル</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>オリジナル起動イメージ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>ユーザ設定の起動イメージのみ表示する</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>ユーザ設定とCompanion標準の起動イメージを表示する</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>実行ファイルを選択</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation>チャンネルのリリース</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>シミュレータ設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>キャリブレート</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>青色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation>内部モジュール 初期値</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation>ファームウェア・ファイル名にバージョン番号を付加する</translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation>アップデート後、SD Syncの実行を促すメッセージを表示</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;デスクトップ Companion / シミュレータ アプリケーションによって生成されたすべてのデバッグ メッセージのログを保存します。EdgeTX開発者は、問題を診断するためにこれを要求する場合があります。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation>起動イメージを表示</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation>送信機プロファイルのメッセージを表示</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation>アップデート後、インストーラの実行を促すメッセージを表示</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation>アップデート</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>緑色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>赤色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>オレンジ</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>黄色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>キャプチャをクリップボードのみにコピー</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>スティック</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>バックライト</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>シミュレータ 音量幅</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>マイ送信機</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;ファイル変更後で保存されていない間は、送信機タイプの切り替えやビルドオプションの変更はできません。保存しますか？&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;すべて保存&lt;/i&gt; - 設定を保存する前に、開いているファイルをすべて保存します &#x3000;&lt;li&gt;&lt;li&gt;&lt;i&gt;リセット&lt;/i&gt; - 設定を保存する前に、以前の送信機タイプとビルドオプションに戻します &lt;/li&gt;&lt;li&gt;&lt;i&gt;キャンセル&lt;/i&gt; - 設定エディタダイアログに戻ります &lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>画面キャプチャフォルダを選択してください</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation>アップデート設定:  ダウンロードフォルダのパスが設定されていません！</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation>アップデート設定: 展開先フォルダのパスが設定されていません！</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation>アップデート設定: 更新フォルダのパスが設定されていません！</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation>アップデート設定: 展開先フォルダとダウンロードフォルダが同じパスに設定されています！</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>スティックが認識できません</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>空: プロファイルに送信機設定が保存されていません</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>利用可能: 詳細不明の送信機設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>利用可能: 送信機設定は %1 に保存されています</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation>すべてのアップデート設定をデフォルト値にリセットします。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation>アップデート設定がリセットされました。予期せぬ動作を避けるため、EdgeTX Companionを終了して再起動してください！</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation>ダウンロードフォルダの選択</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation>展開先フォルダの選択</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation>アップデート先フォルダの選択</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation>チェック</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>ライブラリフォルダを選択してください</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>機体モデルの選択とバックアップフォルダの設定をしてください</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation>アプリケーションログフォルダを選択してください</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Google Earth実行有無を選択してください</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>SDカード保存先フォルダを選択してください</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>イメージを開いてロードします</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>イメージ (%1)</translation>
     </message>
@@ -874,31 +869,31 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation>読み取りエラー %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation>EEPROMへ保存できません</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>ファイルを開けません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>ファイルに書き込めません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation>無効なバイナリEEPROMファイルです %1</translation>
     </message>
@@ -936,33 +931,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -973,255 +968,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation>左・横</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation>左・縦</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation>右・縦</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation>右・横</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation>AUX. 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation>AUX. 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished">スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">フライト</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation>ダイヤル (ノッチあり)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation>2 ポジション トグル</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation>2 ポジション</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation>3 ポジション</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">機能</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation>小サイズ</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation>両方</translation>
     </message>
@@ -1229,17 +1234,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation>マイナス長</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation>中央値</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation>プラス長</translation>
     </message>
@@ -1247,132 +1252,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation>サブトリム</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation>最小</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation>方向</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation>カーブ</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation>プロット</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation>PPM センター</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation>線形サブトリム</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation>CH%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation>利用可能なポップアップメニュー</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation>---</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation>リバース</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation>チャンネルを削除します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation>チャンネルを切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation>消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation>チャンネルを消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation>チャンネルをすべて消去します。よろしいですか？</translation>
     </message>
@@ -1415,60 +1420,60 @@ Error description: %4</source>
         <translation>ファイル: 不明</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation>チェックリストを開く</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation>チェックリストファイル (*.txt)</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation>機体モデル チェックリスト</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation>書き込むためにファイルを開けません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation>ファイルに書き込めません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>ファイルを書き込めません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>ファイルを開けません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>ファイルを読み込めません %1:%2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation>行 %1, カラー %2</translation>
     </message>
@@ -1484,12 +1489,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation>ユーザ インターフェイス</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation>メインビュー %1</translation>
     </message>
@@ -1497,174 +1502,184 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation>インフォメーション</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation>アプリケーション設定</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation>ファイル</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation>EdgeTX シミュレータ</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation>送信機と機体モデルの設定</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation>エクスポートした設定ファイルを選択または作成します:</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation>別のファイルを選択するには『再試行』ボタンを押してください。</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation>このファームウェアのシミュレータはまだ利用できません</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation>シミュレータ起動中に不明なエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation>シミュレータ エラー</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation>データロード エラー</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation>シミュレータ起動中にエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation>&lt;p&gt;&lt;b&gt;EdgeTX %1へようこそ。&lt;/b&gt;&lt;/p&gt;&lt;p&gt;最初のステップとして、送信機タイプ、メニュー言語、ビルドオプションを選択して、初期送信機プロファイルを設定してください。&lt;/p&gt;&lt;p&gt;また、表示される設定ダイアログで他の利用可能なオプションを確認することもできます。&lt;/p&gt;&lt;p&gt;設定を保存した後、&lt;i&gt;File -&amp;gt; Download&lt;/i&gt;メニューオプションを使用して送信機の最新ファームウェアをダウンロードすることをお勧めします。&lt;/p&gt;&lt;p&gt;最新のニュース、アップデート、ドキュメントは&lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt;をご覧ください。EdgeTXをご利用いただきありがとうございます！&lt;/p&gt;- EdgeTXチーム.</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation>&lt;p&gt;&lt;b&gt;EdgeTX %1 にアップグレードしていただき、ありがとうございます。&lt;/b&gt;&lt;/p&gt;&lt;p&gt;今回のメジャーアップグレードでは、多くのことが追加・変更されますので、リリースノートをよく読んで変更点を理解し、設定した各機体モデルが正しく機能することを十分に確認してください。&lt;/p&gt;&lt;p&gt;リリースノートやその他のドキュメントについては、&lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt;をご覧ください。&lt;/p&gt;- EdgeTXチーム.</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;選択したプロファイルに送信機タイプが存在しません。そのためデフォルトタイプを使用します。&lt;/p&gt; &lt;p&gt;&lt;b&gt;プロファイル設定を更新してください！&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation>保存した設定をインポートできませんでした。もう一度やり直すか、現在の設定を続行してください。</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation>ファイルからインポート</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation>インポートできません</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation>利用可能なCompanion設定バックアップファイルが見つかりました。
 ファイルから設定をインポートしますか？</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation>ファイルから設定をインポートするか、現在値から設定を始めます。</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation>%1 を選択:</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation>アプリケーション設定をファイルに保存しています...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation>ファイルまたは以前のバージョンからアプリケーション設定をロードしています...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation>すべてのアプリケーション設定をデフォルト値にリセットし、送信機プロファイルを削除します...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation>設定の初期化およびアプリケーションの起動前に終了してください。</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation>バージョン番号を表示して終了します。</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation>このヘルプテキストを出力してください。</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation>すべてのアプリケーション設定をデフォルト値にリセットし、送信機プロファイルを削除します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation>最初にバックアップを実行しますか？</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation>アプリケーション設定がリセットされ、保存されました。</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation>設定</translation>
     </message>
@@ -1702,22 +1717,22 @@ Do you want to import settings from a file?</source>
         <translation>ファイルへ出力</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation>モデル名なし %1</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation>この機体モデルをクリックして削除します。</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>ドキュメントを出力</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>PDF出力ファイルを選択</translation>
     </message>
@@ -1743,7 +1758,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>OK、承知しました。</translation>
     </message>
@@ -1751,17 +1766,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>書き込みエラー</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>%1 へ書き込めません (理由: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation>%1 が開けません (理由: %2)</translation>
     </message>
@@ -1769,22 +1784,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation>CV</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation>カスタム</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation>%1 点</translation>
     </message>
@@ -1869,32 +1884,32 @@ Do you want to import settings from a file?</source>
         <translation>点のサイズ</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation>線形</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation>シングルExpo</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation>対称 f(x)=-f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation>対称 f(x)=f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation>すべての点配列に、曲線を記載するのに十分な空間がありません。</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation>カーブ %1: %2 を編集しています</translation>
     </message>
@@ -1902,7 +1917,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation>ダブルクリックして編集</translation>
     </message>
@@ -1910,22 +1925,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation>差分</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation>エクスポ</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation>機能</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation>カスタム</translation>
     </message>
@@ -1933,113 +1948,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation>注意: カーブを作成するには、カーブの行のラベルを右クリックします</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation>利用可能なポップアップメニュー</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation>名称:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation>タイプ:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation>点(ポイント):</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation>スムーズ:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation>消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation>カーブ設定 %1:%2 を消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation>すべてのカーブ設定を消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation>カーブ設定 %1:%2 を切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation>カーブ設定 %1:%2 を削除します。よろしいですか？</translation>
     </message>
@@ -2047,343 +2062,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation>GF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation>SF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation>上書き %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation>トレーナー RUD</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation>トレーナー ELE</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation>トレーナー THR</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation>トレーナー AIL</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation>トレーナー チャンネル</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation>トリム</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation>音源 再生</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation>バイブレーション</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation>リセット</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation>設定 %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation>Luaスクリプト</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation>フェイルセーフ設定</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation>内部モジュール レンジチェック</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation>外部モジュール レンジチェック</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation>レーシングモード</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation>タッチディスプレイ無効</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation>メイン画面設定</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>オーディオアンプ OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation>RGB LEDs</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation>一度だけ再生され、起動時は非再生</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation>リピートなし</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation>1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation>リピート %1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation>%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished">トリム</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation>ビープ 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation>ビープ 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation>ビープ 3</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation>警告 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation>警告 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation>チープ</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation>ラッタッタ</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation>ティック</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation>サイレン</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation>リング</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation>Sci Fi</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation>ロボット</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation>Tada</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation>クリケット</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation>アラームクロック</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation>値</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation>選択元</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation>グローバル変数</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation>増/減</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation>ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation>バリオ</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation>トラック 再生</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation>両方 実行</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation>値 実行</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation>SDログ</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation>音量</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation>バックライト</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation>画面キャプチャ</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation>BGM</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation>BGM一時停止</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation>調整 %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation>バインド 内部モジュール</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation>バインド 外部モジュール</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation>フライト</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation>テレメトリー</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation>無効</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation>CFN</translation>
     </message>
@@ -2391,124 +2426,124 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>実行</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>パラメータ</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation>リピート</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation>利用可能なポップアップメニュー</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation>GV</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation>音源再生中にエラーが発生しました。おそらくファイルは既に開かれています (Err: %1 [%2])</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation>音源ファイルが見つからない、または開けません
 %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation>ファンクションを削除します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation>ファンクションを切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation>消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation>ファンクションを消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation>すべてのファンクションを消去します。よろしいですか？</translation>
     </message>
@@ -2516,22 +2551,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation>ナンバー</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation>バー</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation>スクリプト</translation>
     </message>
@@ -2539,47 +2574,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation>レイアウト:</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation>ウィジェット:</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation>トップバー</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation>フライトモード</translation>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
+        <source>%1 mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
         <source>Sliders</source>
         <translation>スライダー</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
         <source>Trims</source>
         <translation>トリム</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
         <source>Mirror</source>
         <translation>ミラー</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation>オプション #%1</translation>
     </message>
@@ -2636,82 +2671,82 @@ Do you want to import settings from a file?</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>ファームウェアファイルを開く</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation>FW: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation>画像: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation>プロファイル イメージ</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>ファームウェアファイル %1 から組込イメージを読み込めません。</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>画像をロードして開きます</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>イメージ (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>イメージファイル %1 をロードできません。</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>プロファイルイメージ %1 をロードできません。</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>ライブラリイメージ %1 をロードできません。</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>ファイル 保存</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>イメージはファイル %1 に保存しました</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>画像更新エラー</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>ファイル %1 から画像を更新できませんでした</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>ファイル保存エラー</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>%1 へのイメージ書き込みに失敗しました</translation>
     </message>
@@ -2719,22 +2754,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2742,53 +2777,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation>フィールド %1 変換エラー</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation>スイッチ </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation> このボードにエクスポートできません！</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation>選択元</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation>このボードでは選択元 %1 をエクスポートできません！</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation>OpenTXはすべてのカーブで %1 点のみを許容します</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation>OpenTxはすべてのカーブで %1 点のみを許容します</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation>このボード上のOpenTXはこの機能を受け付けません</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation>OpenTXはこの送信機プロトコルを受け付けません</translation>
     </message>
@@ -2796,52 +2831,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation>無効</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation>ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation>False</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation>True</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation>はい</translation>
     </message>
@@ -2921,103 +2956,83 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation>フィルターをON / OFFします。</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;フィルターは2つのシンタックスタイプをサポートしています: 一般的なワイルドカードを用いた完全一致、そして完全なPerlスタイル (&lt;code&gt;pcre&lt;/code&gt;) 正規表現です。初期値ではフィルターは一致する (&lt;b&gt;包括的&lt;/b&gt;) な行のみを表示します。一致する行を削除する&lt;b&gt;排他的&lt;/b&gt;フィルターを作成するには、フィルター式の先頭に&lt;kbd&gt;!&lt;/kbd&gt;(Exclamationマーク)を付けます。&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;b&gt;正規表現&lt;/b&gt; (RegEx)を使用するには、フィルターテキストの先頭に&lt;kbd&gt;/&lt;/kbd&gt; (スラッシュ) または&lt;kbd&gt;^&lt;/kbd&gt;(アップキャレット)を付けます。&lt;ul&gt;&lt;li&gt;既に &lt;kbd&gt;/&lt;/kbd&gt; または &lt;kbd&gt;^&lt;/kbd&gt; を使用している場合は、 &lt;kbd&gt;!&lt;/kbd&gt; の後ろに置きます。&lt;/li&gt;&lt;li&gt;初期値では大文字と小文字が区別されます。それを鈍感にするには、正規表現の最後に典型的な &lt;kbd&gt;/i&lt;/kbd&gt; (スラッシュ＋i)演算子を追加します。&lt;/li&gt; &lt;li&gt; 正規表現を表すためにキャレット『^』を使用すると、それは正規表現の一部になります。例(つまり、行頭から一致します。)&lt;/li&gt; &lt;li&gt; 正規表現が無効な場合、フィルター編集フィールドには赤い枠が表示されフィルターを有効にすることはできません。&lt;/li&gt; &lt;li&gt; 正規表現のテストに役立つリソース(参考文献)は、&lt;a href=&quot;http://www.regexr.com/&quot;&gt; http://www.regexr.com/にあります。&lt;/a&gt;&lt;/li&gt; &lt;/ul&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;標準一致 basic matching&lt;/b&gt; を使用するには、テキストを入力するだけです。&lt;ul&gt;&lt;li&gt;ワイルドカード: &lt;kbd&gt;*&lt;/kbd&gt; (アスタリスク)は0個以上の任意の文字に一致し、 &lt;kbd&gt;?&lt;/kbd&gt; (クエスチョンマーク) は任意の1文字に一致します。&lt;/li&gt;&lt;li&gt;この一致では常に大文字と小文字が区別されません。&lt;/li&gt;&lt;li&gt;一致は常にログの先頭行から始まります。 先頭の文字を無視するには、先頭に&lt;kbd&gt;*&lt;/kbd&gt;ワイルドカードを使用します。&lt;/li&gt;&lt;li&gt;末尾の &lt;kbd&gt;*&lt;/kbd&gt; は常に暗黙的に指定されます。(つまり、ログ末尾行までが対象) これを回避するには、正規表現を使用します。&lt;/li&gt;&lt;li&gt;リテラルワイルドカード文字の前に &lt;kbd&gt;\&lt;/kbd&gt; (バックスラッシュ) 文字を付けることで一致させることができます。(例: &quot;foo\*bar&quot;は&quot;foo*bar&quot;と一致)&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;テキスト編集&lt;/b&gt;後、EnterまたはTabキーを押して (またはボックスの外側をクリックし) フィルターを更新します。&lt;/p&gt;&lt;p&gt;フィルターセレクタリストから&lt;b&gt;エントリー削除&lt;/b&gt;をするには、まずエントリーを選択しエディタで&lt;kbd&gt;Shift＋Delete&lt;/kbd&gt; (または&lt;kbd&gt;Shift＋Backspace&lt;/kbd&gt;) を押します。デフォルトのフィルターは削除できません。また最大50個のフィルターが保存されています。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation>デバッグコンソールフィルター ヘルプ</translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation>ダウンロード中: </translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation>書き込むためのダウンロードファイル %1 を開けません。
-エラー: %2</translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation>ダウンロードに失敗しました: %1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation>考えられる要因は次のとおりです:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation>- EEPROMはOpenTXの新しいバージョンからのものです</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation>- EEPROMはOpenTXからのものではありません</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation>- EEPROMはErSky9Xからのものではありません</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation>- EEPROMサイズが無効です</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation>- EEPROMファイルシステムが無効です</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation>- EEPROMは不明なボードからのものです</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation>- EEPROMは間違ったボードからのものです</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation>- EEPROMバックアップはサポートされていません</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation>- 推測できない問題が起きています。申し訳ありません</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation>警告:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation>- この送信機は、おそらく間違ったファームウェアを適用しています。
  EEPROMサイズは4096ですが、最初の2048しか使用されません</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation>- このEEPROMは古いバージョンのOpenTXでアップグレードしています。
@@ -3027,12 +3042,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation>送信機設定ファイルのチェックサムエラーです。設定を見直してください</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation>EdgeTX Companionは設定バージョン %1 をサポートしていません！</translation>
     </message>
@@ -3040,12 +3055,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation>%1を開けません: %2</translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation>無効なEEPROMファイルです %1</translation>
     </message>
@@ -3053,12 +3068,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;第1エレボンチャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>第2エレボンチャンネル:</translation>
     </message>
@@ -3066,43 +3081,43 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>ファイルを開くときにエラーが発生しました %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation>EdgeTXアーカイブ %1 を開く際にエラーが発生しました</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation>EdgeTXアーカイブライターの初期化エラー</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>ファイル書き込みエラーです %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation>EdgeTXファイルの作成エラー %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation>EdgeTXアーカイブの作成エラー</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation>EdgeTXアーカイブへの %1 追加エラー</translation>
     </message>
@@ -3110,23 +3125,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation>INP</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation> (@%1)</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation></translation>
     </message>
@@ -3134,111 +3149,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>フライトモード</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>入力名</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>ミキサー選択元.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>ウェイト</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>この設定を有効にするために使用されるスイッチです。
-空白の場合、入力は常に『オン』と見なします。</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>スティック端</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation>リバース</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>すべて</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation>ユニット</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>スケール</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation>イメージ</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>トリム含</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>カーブ</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>選択元に適用されたカーブ.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>選択元</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Expoライン名</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>オフセット</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>ミキサー選択元</translation>
     </message>
@@ -3248,22 +3247,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation>編集 %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation>利用可能なポップアップメニュー</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation>すべて設定</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation>すべてリバース</translation>
     </message>
@@ -3271,22 +3270,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>スロットル チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>ヨー チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>ピッチ チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>ロール チャンネル:</translation>
     </message>
@@ -3294,109 +3293,109 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation>ファイルを同期</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation>同期を中止してよろしいですか？</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation>フォルダ A</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation>フォルダ B</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation>コピー先フォルダに既に存在するファイルを上書きする方法となります。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation>新しい場合、または異なる場合のみコピー (内容を比較して)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation>新しい場合のみコピー (内容を比較しない)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation>異なる場合のみコピー (ファイルのタイムスタンプを無視)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation>常にコピー (既存のファイルを強制上書き)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation>任意のサイズ</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation>このサイズより大きいファイルをスキップします。無制限の場合はゼロを入力してください。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation>最小レポートレベル このような種類の重要度の高いイベントが表示されます。
 警告: ログレベルが高いと、ユーザ インターフェースが一時的に応答しなくなる場合があります。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation>スキップ</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation>作成</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation>更新</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation>エラーのみ</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation>テスト稼働のみ</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation>通常通りに実行しますが、実際には何もコピーしません。実際の同期前に結果を検証するのに役立ちます。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation>ログレベル:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation>フィルター:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
@@ -3405,156 +3404,156 @@ The Include filter is evaluated first.</source>
 Includeフィルターが最初に設定されます。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation>除外する1つ以上のファイルパターンでカンマで区切ります。
 空白は何も除外しないことを意味します。 ?, *, および [...] ワイルドカードを使用できます。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>含める1つまたは複数のファイルパターン。カンマで区切ります。
 空白は何も除外しないことを意味します。 ?, *, および [...] ワイルドカードを使用できます。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation>敏感なケース</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation>フォローリンク</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation>非表示にする</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation>回帰的</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation>空をスキップ</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation>フィルター実行</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation>フィルターオプション:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation>フォルダーオプション:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation>追加オプションを表示</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation>デフォルト値へリセット</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation>方向の同期:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation>既存のファイル:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation>最大ファイルサイズ:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation>バージョン情報</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation>スタート</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation>Total: &lt;b&gt;%1&lt;/b&gt;; 作成: &lt;b&gt;%2&lt;/b&gt;; アップデート: &lt;b&gt;%3&lt;/b&gt;; スキップ: &lt;b&gt;%4&lt;/b&gt;; エラー: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation>現在: &lt;b&gt;%1&lt;/b&gt; </translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation>%1 が見つかりません。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation>フォルダも同一です。</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation>%1%2 両方向、最初に %3 へ</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation> %1  %2 から %3 までのみ</translation>
     </message>
@@ -3562,367 +3561,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation>使用可能な上書きチャンネル機能はありません</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation>フィールドでFAIモード (テレメトリーなし) を有効にする可能性</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation>FAIモード (テレメトリーなし) を常に有効</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation>2015/01/01以降に販売された送信機に対し、EUでの使用に適さないD8 FrSkyプロトコルサポートを削除</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>HELIメニューとサイクリックミックスサポートを無効にする</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation>グローバル変数を無効にする</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Luaカスタムスクリプト画面を有効にする</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation>SQT5 代替フォントを使用する</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation>メニューナビゲーションでダイヤルを使用</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation>FrSky Taranis X9D+</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation>非認証ファームウェアを有効にします</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation>AFHDS3サポート 有効</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation>RAS (SWR)を無効にする</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation>FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation>バイブレーション対応モジュールをインストール</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation>FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation>送信機シャットダウン前の確認</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Horusジンバル (ホールセンサー) をインストール</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation>FrSky Taranis X9-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation>FrSky Taranis X7 / X7S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation>FrSky Taranis X-Lite S/PRO</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation>FrSky Taranis X-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation>FrSky Horus X10 / X10S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation>FrSky Horus X12S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>初期DEV pcbバージョンでのみ使用</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation>MULTI内部モジュールのサポート</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation>Jumper T-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation>Bluetoothモジュールのサポート</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation>Radiomaster TX12</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation>内蔵ELRSモジュールが搭載されているか否かを選択</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished">Jumper T14</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished">Jumper T15</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation>Jumper T20</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation>Radiomaster T8</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation>バインドキーを使用したバインドを許可</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation>Radiomaster TX16S / SE / Hall / Masterfire</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation>内部GPS サポート</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation>ハードウェアMODサポート: FlySky Paladin EV Gimbals</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation>Jumper T18</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation>HELIメニューとサイクリックミックスのサポートを有効にする</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation>AFHDS2Aサポート 有効</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation>グローバル変数</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation>モデル設定メニューでは、コントローラーを動かし自動的に選択元を設定します</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation>モデル設定メニューでは、コントローラーを動かし自動的にスイッチを設定します</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation>グラフィカルなチェックボックスとスライダーはありません</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation>バッテリーグラフ</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation>有効なアイテムを強調表示するために太字フォントを使用しない</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation>FrSky Taranis X7 / X7S ACCESS</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>ACCESS内部モジュール変更のサポート</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation>上下に同時に押し、値のリセットを有効にする</translation>
     </message>
@@ -3930,27 +3973,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>はい、1つのチャンネルで制御します</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>はい、2つのチャンネルで制御します</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;第1フラップチャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>第2フラップチャンネル:</translation>
     </message>
@@ -3959,7 +4002,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>機体モデル・設定を書き込み</translation>
     </message>
@@ -4024,51 +4067,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>書き込み</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>現在のプロファイル: %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>送信機バックアップファイルを選択してください</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>プロファイル内の送信機キャリブレート情報が正しくなく、パッチが適用されません</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>プロファイル内の送信機設定データが正しくなく、パッチが適用されません</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>ファイルを書き込めません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>ファイル書き込みエラーです %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>送信機ファームウェアは他の製品ファミリーに属しています。ファイルと設定を確認してください！</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>送信機ファームウェアは古いままとなっています。アップグレードしてください！</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>機体モデルと設定の互換性を確認できません。そのまま続けますか？</translation>
     </message>
@@ -4146,103 +4189,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>書き込み</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>ファームウェアファイルを開く</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 は有効なファームウェアファイルでない可能性があります</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>ファームウェアファイルが無効です。</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>ファームウェアファイルに起動画面イメージがありません。</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>プロファイルイメージ %1 が無効です。</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>送信機の起動画面として使用する起動イメージファイルを開く</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>イメージ (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>イメージを %1からロードできませんでした</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>ライブラリイメージを読み込めませんでした</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>起動イメージが見つかりません</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>カスタマイズされたファームウェアを保存できません</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>ファームウェアを無線機へ書き込み</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>ファームウェアチェックに失敗しました</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>送信機でファームウェアを確認できませんでした</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>新しいファームウェアは現在インストールされているものと互換性がありません!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>変換に失敗しました</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>このファームウェアで使用するために機体モデルと設定を変換することはできません。元のデータが使用されます</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>復元に失敗しました</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>機体モデルと設定を送信機に復元できませんでした。機体モデルと設定データファイルは %1 にあります</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>書き込み完了</translation>
     </message>
@@ -4250,47 +4293,47 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation>実行可能ファイル %1 が見つかりません</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation>書き込み中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation>読み込み中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation>確認中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation>不明</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>例: 9Xボード用のOpenTXまたは9XRボード用のOpenTX</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>例: M128 / 9Xボード用のOpenTXまたはM128チップ搭載 9XRボード用のOpenTX</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>例: Gruvin9Xボード用OpenTX</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4299,7 +4342,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 正しいCPUタイプを設定するには、詳細書き込みオプションを確認してください。</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4308,7 +4351,7 @@ Please select an appropriate firmware type to program it.</source>
 適切なファームウェアタイプを選択してください。</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4317,22 +4360,22 @@ You are currently using:
  %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>お使いの送信機がUSBに接続されていないか、ドライバが初期化されていません。</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>書き込み完了 (終了コード= %1 )</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>エラーを含んだ書き込み完了</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>FUSES: Low=%1 High=%2 Ext=%3</translation>
     </message>
@@ -4340,7 +4383,7 @@ You are currently using:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">なし</translation>
     </message>
@@ -4391,225 +4434,240 @@ You are currently using:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
         <translation>FM</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>ロータリー エンコーダー %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>元値</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>値</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>ポップアップ有効</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation>利用可能なポップアップメニュー</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation>トリム 無効</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation>独自トリム</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation>フライトモードからトリムを使用してください %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation>フライトモードからトリムを使用してください %1＋オフセット独自トリム</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation>ユニット</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation>最小</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
-        <translation>警告: フライトモード0の値を使用するとグローバル変数としてリンクされます。</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
-        <translation>警告: フライトモード0の値を使用するとロータリーエンコーダとしてリンクされます。</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">GV%1</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">独自トリム</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
-        <translation>フライトモードを消去します。よろしいですか？</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
-        <translation>フライトモードをすべて消去します。よろしいですか？</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
-        <translation>フライトモードを切り取ります。よろしいですか？</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
-        <translation>フライトモードを削除します。よろしいですか？</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>すべてのフライトモードのグローバル変数を消去します。よろしいですか？</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation>グローバル変数を消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation>すべてのフライトモードのすべてのグローバル変数を消去します。よろしいですか？</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation>このフライトモードのすべてのグローバル変数を消去します。よろしいですか？</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>すべてのフライトモードのグローバル変数を切り取ります。よろしいですか？</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation>グローバル変数を切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation>グローバル変数を削除します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>すべてのフライトモードで選択したグローバル変数を貼り付けます。よろしいですか？</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>消去</translation>
     </message>
@@ -4617,17 +4675,17 @@ You are currently using:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>フライトモード %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation> (%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (デフォルト)</translation>
     </message>
@@ -4635,17 +4693,17 @@ You are currently using:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>フライバーあり</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>フライバーなし</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>フライバー:</translation>
     </message>
@@ -4653,17 +4711,17 @@ You are currently using:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation>黄色</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation>オレンジ</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation>赤色</translation>
     </message>
@@ -4671,13 +4729,13 @@ You are currently using:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation>---</translation>
     </message>
@@ -4695,17 +4753,18 @@ You are currently using:
         <translation>カスタマイズスイッチ</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation>スタート</translation>
     </message>
@@ -4715,7 +4774,12 @@ You are currently using:
         <translation>グループ</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation>常時</translation>
     </message>
@@ -4723,9 +4787,14 @@ You are currently using:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
         <translation></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4869,13 +4938,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;あります。自己責任で操作を行ってください。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>送信機ヒューズをリセット</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>送信機からヒューズを読み込み</translation>
     </message>
@@ -4883,44 +4952,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation>独自トリム</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation>フライトモード %1 値</translation>
     </message>
 </context>
 <context>
@@ -4948,57 +5007,57 @@ These will be relevant for all models in the same EEPROM.</source>
 これらは同じEEPROM内のすべてのモデルに関連します。</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>セットアップ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>グローバルファンクション</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>トレーナー</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation>ハードウェア</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation>キャリブレーション</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation>利用可能な機能</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>プロファイルデータが正しくなく、送信機キャリブレート情報が取得できませんでした</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>プロファイルデータが正しくなく、スイッチ/ダイヤル構成が取得できませんでした</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>プロファイルデータが正しくなく、HW関連パラメーターが取得できませんでした</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>既存のキャリブレート情報を上書きして %1 プロファイルにキャリブレート情報を保存しますか？</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>キャリブレート情報とHWパラメータが保存されました。</translation>
     </message>
@@ -5037,8 +5096,8 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation>フライトモード</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5074,185 +5133,208 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation>送信機設定</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished">ハードウェア</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished">スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished">スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation>内部</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation>Per モデル</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation>内部 + 外部</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation>外部</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation>テレメトリー</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation>トレーナー</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation>テレメトリーミラー</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation>テレメトリー IN</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation>SBUS トレーナー</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation>デバッグ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation>外部モジュール</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation>トリムのみ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation>キーのみ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation>すべて</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">モード1&#x3000;(左:エレベーター・ラダー&#x3000;右:スロットル・エルロン)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished">モード2&#x3000;(左:スロットル・ラダー&#x3000;右:エレベーター・エルロン)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">モード3&#x3000;(左:エレベーター・エルロン&#x3000;右:スロットル・ラダー)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">モード4&#x3000;(左:スロットル・エルロン&#x3000;右:エレベーター・ラダー)</translation>
     </message>
 </context>
 <context>
@@ -5268,196 +5350,194 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation>読み取り専用 解除</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>スティック リバース</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>カントリーコード (地域)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>FAIモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>GPSがテレメトリーに接続されている場合、自動的に送信機側の内蔵時計を調整します。</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>内蔵時計調整</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>スピーカー音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>バリオ 最大ピッチ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>バックライトスイッチ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>カラー 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>カラー 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>音源モード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>この値が0以外の場合、キーを押すとバックライトが点灯し、指定秒数を経過すると消灯します。</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation> 秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>バックライトカラー</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>再生ピッチ (対応機のみ)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>ビープ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>スピーカー</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>ビープ音声</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>スピーカー音声</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>ビープ音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>WAV音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>バリオ音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>BGM音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>アラーム時ライト点滅</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>バリオ ゼロピッチ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>バリオ ゼロリピート</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>バックライト 自動消灯</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5467,7 +5547,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5482,57 +5562,57 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;値は20～45です&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Rot Enc ナビゲーション</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>バックライト 明るさ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>アメリカ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>日本</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>ヨーロッパ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>音声言語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>UTC 時差</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>バックライトOFF 明るさ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation>RSSI 信号切断 警告</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation>EEPROM 残量警告</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5573,273 +5653,133 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>モード1&#x3000;(左:エレベーター・ラダー&#x3000;右:スロットル・エルロン)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>モード2&#x3000;(左:スロットル・ラダー&#x3000;右:エレベーター・エルロン)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>モード3&#x3000;(左:エレベーター・エルロン&#x3000;右:スロットル・ラダー)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>モード4&#x3000;(左:スロットル・エルロン&#x3000;右:エレベーター・ラダー)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation>USBモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation>接続時に確認</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation>ジョイスティック (HID)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation>USBストレージ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation>USBシリアル (CDC)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>アナログスティックモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;チャンネルマップ&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;機体モデルを作成した際の初期チャンネルマッピングを定義します&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation>FAIを有効にした場合、RSSIとRxBtセンサーのみ動作し続けます。この機能は送信機側で無効にすることはできません。</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation>オーナー登録ID</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation>モデル クイックセレクト</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation>これを有効にすると、機体モデル選択ページで素早くモデルを変更できます(長押しで機体モデル編集メニューが開きます)。</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation>↔RUD ↕ELE ↕THR ↔AIL&#x3000;[R E T A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation>↔RUD ↕ELE ↔AIL ↕THR&#x3000;[R E A T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation>↔RUD ↕THR ↕ELE ↔AIL&#x3000;[R T E A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation>↔RUD ↕THR ↔AIL ↕ELE&#x3000;[R T A E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation>↔RUD ↔AIL ↕ELE ↕THR&#x3000;[R A E T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation>↔RUD ↔AIL ↕THR ↕ELE&#x3000;[R A T E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation>↕ELE ↔RUD ↕THR ↔AIL&#x3000;[E R T A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation>↕ELE ↔RUD ↔AIL ↕THR&#x3000;[E R A T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation>↕ELE ↕THR ↔RUD ↔AIL&#x3000;[E T R A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation>↕ELE ↕THR ↔AIL ↔RUD&#x3000;[E T A R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation>↕ELE ↔AIL ↔RUD ↕THR&#x3000;[E A R T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation>↕ELE ↔AIL ↕THR ↔RUD&#x3000;[E A T R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation>↕THR ↔RUD ↕ELE ↔AIL&#x3000;[T R E A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation>↕THR ↔RUD ↔AIL ↕ELE&#x3000;[T R A E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation>↕THR ↕ELE ↔RUD ↔AIL&#x3000;[T E R A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation>↕THR ↕ELE ↔AIL ↔RUD&#x3000;[T E A R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation>↕THR ↔AIL ↔RUD ↕ELE&#x3000;[T A R E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation>↕THR ↔AIL ↕ELE ↔RUD&#x3000;[T A E R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation>↔AIL ↔RUD ↕ELE ↕THR&#x3000;[A R E T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation>↔AIL ↔RUD ↕THR ↕ELE&#x3000;[A R T E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation>↔AIL ↕ELE ↔RUD ↕THR&#x3000;[A E R T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation>↔AIL ↕ELE ↕THR ↔RUD&#x3000;[A E T R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation>↔AIL ↕THR ↔RUD ↕ELE&#x3000;[A T R E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation>↔AIL ↕THR ↕ELE ↔RUD&#x3000;[A T E R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5850,289 +5790,322 @@ Acceptable values are 3v..12v</source>
 許容値は3～12vです</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation>電源ON遅延</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation>ジャックモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation>起動時音源</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation>PPMユニット</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation>オーディオ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation>トレーナー</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>スティックモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation>電源OFF遅延</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>メートル法</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>ヤードポンド法</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>チャンネルマップ初期値</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>GPS座標</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation>最小</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>活動限界タイマー</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>起動イメージ 表示時間</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>コントラスト</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>バッテリーメーター範囲</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>バイブレーション 強度</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>LCD ディスプレイタイプ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>音源なし 警告</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>バッテリー警告</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>バイブレーション 長さ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>MAVLink ボーレート</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>消音</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>アラームのみ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>キーなし</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>すべて</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>この値が0以外の場合、送信機で指定した分数だけ入力がなく放置されるとビープ音が鳴ります。</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation>キークリックでバックライト</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation>ロータリー エンコーダーモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation> 最小</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">30秒 {0s?}</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">30秒 {0.5s?}</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation>2秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation>3秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation>4秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation>6秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation>8秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation>10秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation>15秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6157,67 +6130,67 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;サイレントモード警告 - ビープ音が消音(0)に設定されている場合に警告を発します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>より短い</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>短い</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>長い</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>より長い</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>反応遅延 (スイッチ中間位置)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>計測単位</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>バイブレーションモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>ビープ音 長さ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>ビープモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6234,12 +6207,14 @@ p, li { white-space: pre-wrap; }
 4 - かなり大きな音.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>アラームのみ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation>1秒</translation>
     </message>
@@ -6247,157 +6222,157 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation>キー</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation>スティック</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation>キー＋スティック</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation>ON</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation>標準, リバース編集</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation>デンマーク語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation>中国語(簡体)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation>日本語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation>Rot Enc A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6406,22 +6381,22 @@ Are you sure ?</source>
 よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation>リバース</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation>垂直 リバース, 水平 標準</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation>垂直 リバース, 水平 交互</translation>
     </message>
@@ -6429,17 +6404,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>はい、スイッチで制御します</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>はい、ダイヤルで制御します</translation>
     </message>
@@ -6447,118 +6422,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation>デッドゾーン</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation>ダイヤル</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation>内蔵バッテリーチェック</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation>デバイス名:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation>サンプルモード</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation>シリアルポート</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation>電源</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation>ADCフィルター</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>音源なしでミュート</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation>内部RFモジュール</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation>ボーレート:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation>アンテナ:</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation>外部RFモジュール</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation>S.Port 出力</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation>現在のオフセット</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation>警告: 内部モジュールを変更すると、機体モデルの内部モジュールのプロトコル設定が無効になる可能性があります！</translation>
     </message>
@@ -6639,22 +6624,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>スロットル チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>ヨー チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>ピッチ チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>ロール チャンネル:</translation>
     </message>
@@ -6662,19 +6647,19 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation>無効なEEPROMファイル %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>ファイルを開けません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>ファイルに書き込めません %1:
@@ -6684,159 +6669,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>すべての入力項目を消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation>入力項目が不足しています！</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation>選択したInput行を削除します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation>選択したInput行を切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation>直線</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;追加</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;編集</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation>Enter</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>&amp;削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>&amp;切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>&amp;貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation>入力</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation>消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation>すべてのInput行を消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation>選択したすべてのInput行を消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation>選択したすべてのInput行を削除します。よろしいですか？</translation>
     </message>
@@ -6877,96 +6862,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation>RADIO/radio.binを展開できません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation>RADIO/models.txtを展開できません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation>%1 を展開できません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation>機体モデル読み込みエラー</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation>%1/RADIO/radio.ymlが見つかりません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation>%1/RADIO/radio.ymlが見つかりました</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation>%1/MODELS/models.ymlが見つかりません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation>%1/MODELS/models.ymlが見つかりました</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation>%1 が見つかりません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation>%1 が見つかりました</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation>RADIO/radio.ymlを展開できません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation>RADIO/radio.ymlをロードできません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation>MODELS/labels.ymlをロードできません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation>展開できません </translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation>ロードできません </translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation>ファイルを一覧表示できません</translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation>ファイル削除エラー</translation>
     </message>
@@ -6974,17 +6959,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation>リバース</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation>CH</translation>
     </message>
@@ -6992,7 +6977,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation></translation>
     </message>
@@ -7000,122 +6985,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation>---</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation>タイマー</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation>Sticky:追尾</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation>Edge:端</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation>不明</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation></translation>
     </message>
@@ -7123,112 +7108,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>機能</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>&amp; スイッチ</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>期間</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>遅延</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">持続</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation>利用可能なポップアップメニュー</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation> (無制限)</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation>論理スイッチを削除します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation>論理スイッチを切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation>消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation>論理スイッチを消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation>論理スイッチをすべて消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation>(瞬時)</translation>
     </message>
@@ -7281,52 +7271,52 @@ Are you sure ?</source>
         <translation>ログファイルを開く</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>テレメトリー ログ</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation>時間 (hh:mm:ss.ms)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>プロットタイトルの変更</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>新規プロットタイトル:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>座標軸名の変更</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>新規 座標軸名:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>グラフ名の変更</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>新規グラフ名:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation>エラー: GPSデータが見つかりません</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7335,74 +7325,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 高度『GAlt』と速度『GSpd』の列はオプションです</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>ファイルを書き込めません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>カーソル A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>カーソル B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>時間差: %1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>上昇速度: %1 m/s</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>ログファイルの選択</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>利用可能フィールド</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>選択したログファイルに、合計 %2 行のうち無効な行が %1 含まれています</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation>期間</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>期間 </translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation></translation>
     </message>
@@ -7410,561 +7400,561 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>ファイルがロードされました</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>次回Companionを起動したときに、新しいテーマがロードされます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>機体モデルと設定ファイルを開く</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>ファイル 保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>SDカードを同期</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation>機体モデル・設定を書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation>進行中...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>送信機からファームウェアを読み込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>送信機から機体モデル・設定を読み込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation>機体モデルと設定の読み込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation>この機能はまだ実装されていません</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>送信機のバックアップをファイルに保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>送信機ファームウェアからファイルを読み込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>このプログラムが役に立つと感じた場合は、&lt;a href=&apos;%1&apos;&gt;寄付&lt;/a&gt;でのサポートをお願いします</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>Companionについて</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>新規</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>新規モデルと設定ファイルを作成</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>開く...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>機体モデルと設定ファイルを保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>名前を付けて保存...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>アプリケーションの終了</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation>EdgeTX Companionについて...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation>コンポーネントのダウンロード...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation>EdgeTXコンポーネントとサポートリソースをダウンロード</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation>アップデートを確認...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation>EdgeTXのアップデートとサポートリソースを確認</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation>新しい送信機設定プロファイルを作成</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation>現在の送信機プロファイルをコピー</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation>現在の送信機設定プロファイルを複製します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation>現在の送信機設定プロファイルを削除します</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation>アプリケーション設定のエクスポート..</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation>現在のすべての%1およびシミュレータ設定(送信機プロファイル含)をファイルに保存します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation>アプリケーション設定をインポート..</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation>以前にエクスポートした設定ファイルから%1とシミュレーション設定を読み込みます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>クラシック</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>クラシック Companion9x アイコンテーマ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation>イェリコ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Yellow round honey sweet アイコンテーマ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>モノクローム</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>A monochrome black アイコンテーマ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>モノホワイト</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>A monochrome white アイコンテーマ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation>プロファイルを追加できません</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation>新しいプロファイルを追加する空き容量がありません。新しいプロファイルを追加する前に、既存プロファイルを削除してください。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation>設定をインポートする前に、変更したすべてのファイルを保存するか閉じてください</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;p&gt;%1 およびシミュレータ設定は、以前に保存されたエクスポート(バックアップ)ファイルからインポート(復元)することができます。&lt;/p&gt;&lt;p&gt;これにより、現在の設定がファイル内の設定に置き換えられます。また現在の設定の自動バックアップが試みられます。しかし、現在の設定が有効な場合は、まず手動でバックアップを取ることをお勧めします。&lt;/p&gt;&lt;p&gt;設定をインポートする際に一番良いのは、&lt;b&gt;開いている他の %1 ウィンドウを閉じ、スタンドアロンのシミュレータアプリケーションが起動していないことを確認してください。&lt;/p&gt;&lt;p&gt;続行しますか？&lt;/p&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation>インポートした設定を確認</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation>%1 を選択:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation>バックアップ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation>『無視する』ボタンを押して、とにかく続けます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation>設定をインポートできませんでした。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation>&lt;html&gt;&lt;p&gt;新しい設定がインポートされました:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 が再度初期化されます。&lt;/p&gt;&lt;p&gt;言語やアイコンテーマなど一部の設定が有効になる前に、%2 を閉じて再起動する必要があるかもしれませんのでご注意ください。&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation>&lt;p&gt;以前の設定はこちらにバックアップされました:&lt;br&gt; %1 &lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation>タブ付きウィンドウ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation>ウィンドウのタイトル</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation>ウィンドウを重ねる</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation>すべてのウィンドウを閉じる</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation> - コピー</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation>Companion :: ファイルを開く警告</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation>有効なプロファイルを削除する前に、変更したファイルを保存するか閉じてください。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation>プロファイルを削除することはできません</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation>デフォルトプロファイルは削除できません。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation>プロファイルの削除を確認</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation>本当に『 %1 』送信機プロファイルを削除しますか？この後、操作を取り消すことはできません！</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>モノブルー</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation>アップデートを確認...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation>EdgeTX ホームページ: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation>EdgeTX Companionプロジェクトは、元々&lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;からフォークされたものです</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation>新しい&lt;a href=&apos;%1&apos;&gt;IssueまたはRequest&lt;/a&gt;を提出</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation>EdgeTX Companion %1 - 送信機: %2 - プロファイル: %3</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation>現在の送信機プロファイルを削除...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation>タブを使用し、開いているウィンドウを並べます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation>開いているウィンドウを空いているスペース全体に配置します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation>開いているウィンドウをスタックに並べます。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation>開いているファイルをすべて閉じます (必要に応じ保存を求められます)。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation>ウィンドウ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>A monochrome blue アイコンテーマ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>小サイズ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>小サイズのツールバーアイコンを使用</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>標準サイズ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>標準サイズのツールバーアイコンを使用</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>大サイズ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>大サイズのツールバーアイコンを使用</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>特大サイズ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>特大サイズのツールバーアイコンを使用</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>システム言語</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation>ローカルフォルダ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation>送信機フォルダ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>アプリケーションの『バージョン情報』ボックスを表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>ログファイルを表示...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>ログファイルを開いて表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>設定...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>設定の編集</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>機体モデルの比較...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>機体モデルの比較</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>送信機起動イメージを編集...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>送信機起動イメージを編集</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>送信機からファームウェアを読み込む</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>ファームウェアを送信機へ書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>ファームウェアを送信機へ書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>送信機プロファイルの追加</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
@@ -7973,175 +7963,175 @@ Do you wish to continue?</source>
 続行しますか？</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation>ローカルのSDディレクトリ構造パスが設定されていません！</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation>送信機またはSDカードが検出されません！</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation>機体モデルと設定ファイルを閉じる</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation>最近使用したファイルの一覧</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation>送信機プロファイル</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation>送信機プロファイルの作成または選択</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation>リリースノート...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation>リリースノートを表示</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>機体モデル・設定を書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>機体モデル・設定を書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>送信機から機体モデル・設定を読み込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>通信の設定...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>送信機と通信するソフトウェア設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>バックアップを送信機へ書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>バックアップをファイルから送信機へ書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>送信機をファイルへバックアップ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>送信機のすべての設定とモデルデータの完全なバックアップファイルを保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>SDカードを同期</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation>デフォルトのシステム言語を使用します。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation>%1言語を使用します （一部の翻訳が不完全な場合あり)。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>最近使用したファイル</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>メニュー言語の設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>アイコンテーマの設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>アイコンサイズの設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>ファイル</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation>一部のテキストは次回EdgeTX Companionを更新するまで翻訳されません。翻訳が完全でない場合もありますのでご了承ください。</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>読み取り/書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>ヘルプ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>書き込み</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>準備完了</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation></translation>
     </message>
@@ -8149,292 +8139,292 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation>機体モデルはすでに存在しています！上書きしますか？それとも新しいモデルスロットに書き込みますか？</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation>上書き</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation>機体モデルが編集可能な状態で、送信機設定は編集できません。</translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
             <numerusform>Delete %n selected model?</numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation>送信機設定の編集</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation>エクスポート</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation>送信機設定をコピー</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation>送信機設定を貼り付け</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation>送信機をシミュレート</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation>名称変更</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation>機体モデル エクスポート</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation>機体モデル 複製</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation>機体モデル プリント</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation>機体モデル</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation>送信機 アクションツールバーの表示</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation>機体モデル アクションツールバーの表示</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation>ラベル アクションツールバーの表示</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation>読み取り専用</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation>機体モデルを挿入できません。リストの最後の機体モデルは削除されます。</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation>機体モデルを貼り付けることができません。</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation>送信機の全般設定を上書きしますか？</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation>モデルを追加できません。使用可能なモデルスロットが見つかりません。</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation>ラベル管理</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation>送信機のすべての機体モデルを上書きしようとしています。</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation>続行しますか？</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation>送信機のSDカードが見つかりません！</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation>内部モジュール・プロトコルが機体モデル %1 で &lt;b&gt;OFF&lt;/b&gt; に変更されました！</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation>機体モデル テンプレートファイルを選択</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation>使用する新しい機体モデルを追加</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation>デフォルト値</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation>編集</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation>ウィザード</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation>テンプレート</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation>一時的な機体モデルの削除に失敗しました！</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation>機体モデル エクスポート</translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8442,7 +8432,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8450,155 +8440,155 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation>何も選択されていません</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation>送信機モデル 選択</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation>機体モデル 編集</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation>機体モデル 追加</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation>バックアップから復元</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation>機体モデルウィザード</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation>デフォルト値として設定</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation>機体モデル シミュレート</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation>モデルを複製できません。利用可能なモデルスロットが見つかりません。</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>機体モデル %1 を編集しています: </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>名前を付けて保存</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation>無効なファイル拡張子です！</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 は変更されました。
 変更を保存しますか？</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;現在選択されている送信機タイプ (%1) はファイル %3 (from %2) と互換性がありません。機体モデルと設定を変換する必要があります。&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation>変換を続けますか？</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation>ファイルを変換するには&lt;i&gt;適用&lt;/i&gt;を、変換せずに閉じるには&lt;i&gt;閉じる&lt;/i&gt;を選択します。</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation>&lt;b&gt;変換によっていくつかの重要なメッセージが出力されました。下記の内容を確認してください。&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation>Companion :: 変換結果 %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation>このメッセージを再度表示しません</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation>送信機に書き込まれた機体モデル・設定</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation>送信機への機体モデルと設定の書き込みエラー！</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>一時ファイルを書き込めません！</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>バックアップされたモデルと設定ファイルを開く</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>ファイル %1 が見つかりません！</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>ファイルを開くときにエラーが発生しました %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>ファイルの読み取りエラーです %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>無効なバイナリバックアップファイルです %1</translation>
     </message>
@@ -8606,143 +8596,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation>進捗確認メソッド: ファイル %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation>カウント</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation>サイズ</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation>%3 を追加し %1 を %2 に圧縮しています</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation>Miniz バージョン: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation>既存のアーカイブは上書きされます</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation>既存のアーカイブを開くことができません</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation>既存のアーカイブを開きます</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation>既存のアーカイブに書き込むことができません</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation>既存のアーカイブを初期化します</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation>アーカイブの初期化に失敗しました</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation>アーカイブの初期化</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation>アーカイブするアイテムの数を計算します</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation>アーカイブ作成に失敗しました</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation>圧縮が完了</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation>%1 の追加に失敗しました</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation>ファイルを追加しました: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation>展開しています %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation>ファイルは圧縮アーカイブではないようです</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation>圧縮されたアーカイブにはファイルが含まれていません</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation>ファイル ステータスエラー</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation>インデックスのファイルステータスを取得できません: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation>%1 を %2 に展開できませんでした</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation>ファイル %1 の展開サイズ %2 が元の %3 と一致しません</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation>ファイルを展開しました: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation>展開が完了</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation>フォルダの作成に失敗しました: %1</translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation>フォルダを作成しました: %1</translation>
     </message>
@@ -8750,12 +8745,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation>ミックス</translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation></translation>
     </message>
@@ -8768,50 +8763,67 @@ Do you want to save your changes?</source>
         <translation>ダイアログ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation>イメージ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">30秒 {0.00?}</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Delay: 遅延</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Slow: ゆっくり</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>上</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>下</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">精度</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8836,178 +8848,127 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Slowがゼロではない場合、ミックス値の速度は指定された値で設定されます―＞この値は、-100から100への遷移にかかる秒数を示します。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>トリム含</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>オフセット</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>ウェイト</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>選択元</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>複数ミキサー</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>ミックスで使用するカーブ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>DR/Expo含</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>フライトモード</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>ミキサー警告
-この値を設定すると、この値が有効なときにビープ音が鳴ります。</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 ビープ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2 ビープ</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 ビープ</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>はい</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>ミキサー選択元</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>複数ミキサー
-
-これはミキサー値がどのように追加されるかを決定します。
-
-『 + 』は現在のミキサー値が同じチャンネルの前のミキサー値に加算されることを示します。
-『 * 』は現在のミキサー値が同じチャンネルの前のミキサー値に乗算されることを示します。
-『 R 』は値が以前の値から置換されます。スイッチがオフの場合は値は無視されます。</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>加算</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>乗算</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>置換</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>カーブ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>ミックスで使用されるスイッチ
-空白の場合、ミックスは常に『オン』と見なします。</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation>クリックしてポップアップメニューにアクセス</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation>すべて設定</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation>すべてリバース</translation>
     </message>
@@ -9015,22 +8976,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation>フォントサイズを大きく</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation>フォントサイズを小さく</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation>フォントサイズ初期値</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation></translation>
     </message>
@@ -9038,136 +8999,136 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>ミキサーを消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>ミキサー項目が足りません！</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation>選択したMix行を削除します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation>選択したMix行を切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;追加</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;編集</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>Enter</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>&amp;ハイライト切替</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>&amp;切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>&amp;貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>ミキサーを消去しますか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>すべてのミキサーを本当に消去しますか？</translation>
     </message>
@@ -9175,19 +9136,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation>機体モデル: </translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation>スロットル値</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation>THR</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9235,32 +9201,49 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>マスター/マルチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation>トグル</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
-        <translation>非アクティブ</translation>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
+        <translation type="unfinished">SW</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
-        <translation>アクティブ</translation>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
+        <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished">---</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished">ON</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation>リストア</translation>
     </message>
@@ -9278,63 +9261,58 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>シミュレート</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>セットアップ</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>ヘリ</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>フライトモード</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>入力</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>ミキサー</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>出力</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>カーブ</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>論理スイッチ</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>スペシャルファンクション</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>テレメトリー</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation>カスタム画面</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation>利用可能な機能</translation>
     </message>
@@ -9388,8 +9366,8 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation>フライトモード</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9425,585 +9403,595 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation>Expo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>ステップ微小</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>ステップ小</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>ステップ中</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>ステップ大</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation>不明</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation>無効</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation>True</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation>False</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation>はい</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation>N</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation>ON</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation>bytes</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation>モード</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation>チャンネル</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation>フレーム長</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation>PPM遅延</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation>極性</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation>プロトコル</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation>遅延</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation>受信機</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation>送信機プロトコル</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation>サブタイプ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation>オプション値</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation>サブタイプ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation>送信出力</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation>Raw 12 bits</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation>120X</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation>140</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation>マルチ！</translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation>フライトモード</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation>フライトモード</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation>すべて</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation>Edge:端</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation>Sticky:追尾</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation>タイマー</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation> ミス</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation>期間</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation>拡張制限</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation>ディスプレイ チェックリスト</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation>グローバルファンクション</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation>手動</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation>フェイルセーフモード</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation>ホールド</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation>パルスなし</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation>セットなし</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation>パルスなし</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation>ステップ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation>ディスプレイ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation>拡張</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation>アナログスティック</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation>常に</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation>トリムのみ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation>キーのみ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation>すべて</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation>選択元</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation>トリムアイドルのみ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation>リバース</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation>セル</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation>最小</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation>ナンバー</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation>バー</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation>スクリプト</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation>ファイル名</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation>エラー: ファイルを開けないか、読み取れません！</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation>トリムなし</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation>オフセット(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation>スケール(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation>ウェイト(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation>スイッチ(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation>トリムなし</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation>DR/Expoなし</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation>遅延(u%1:d%2)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation>ゆっくり(u%1:d%2)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation>警告(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>すべてのフライトモードで無効</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation>瞬時</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>カスタム</translation>
     </message>
@@ -10011,27 +9999,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>固定翼機</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>マルチローター</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>ヘリコプター</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>機体モデル名:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>モデルタイプ:</translation>
     </message>
@@ -10039,27 +10027,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation>インデックス</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation>受信 #</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation>機体モデル %1</translation>
@@ -10315,285 +10303,290 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation>リバース</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation>テレメトリー なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation>トレーナーポート</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation>内部送信システム</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation>外部送信モジュール</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation>追加送信システム</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation>送信システム</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation>VBatでのSBUS出力</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation>200mW - 16CH (テレメトリーなし)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation>500mW - 16CH (テレメトリーなし)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation>100mW - 16CH (テレメトリーなし)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation>25 mW</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation>100 mW</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation>500 mW</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation>1 W</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation>2 W</translation>
     </message>
@@ -10601,57 +10594,57 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation>内部</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation>外部</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation>ハードウェア</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation>プロファイル</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation>警告: %1 モジュール・プロトコル &lt;b&gt;%2&lt;/b&gt; は &lt;b&gt;%3 %1 モジュール %4&lt;/b&gt; と互換性がなく &lt;b&gt;OFF&lt;/b&gt; に設定されています！</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation>値</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>ホールド</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>パルスなし</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation>チャンネルへバインド</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
@@ -10659,456 +10652,456 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>入力</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>ウェイト</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation>長周期</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation>側面周期</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>コレクティブ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>フライトモード</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>フライトモード</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation>全般</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation>モデルイメージ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation>スロットル</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation>トリム</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation>中央値でビープ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation>スイッチ警告</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation>ダイヤル警告</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation>その他</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation>タイマー</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation>カウントダウン</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation>モード</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation>スタート</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation>モジュール</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation>トレーナーポート</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation>ヘリコプター</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation>Swash</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation>リング</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation>機能</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation>リピート</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation>プロトコル</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation>低</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation>クリティカル</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation>テレメトリー音源</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation>高度計</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation>バリオ 元値</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation>バリオ リミット値 &gt;</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation>Sink 最大</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation>Sink 最小</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation>クライム 最小</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation>クライム 最大</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation>中央値で消音</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation>トップバー</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation>ボルト 元値</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation>高度 元値</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation>マルチセンサー</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation>インスタンスIDの表示</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>カスタマイズスイッチ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation>スイッチ %1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation>グループ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation>常時ON</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation>パラメータ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation>テレメトリーセンサー</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation>テレメトリースクリーン</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation>グローバルファンクション</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation>チェックリスト</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>チャンネル</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation>ポップアップ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation>出力</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation>サブトリム</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation>ダイレクト</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation>カーブ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation>線形</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation>テレメトリー</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation>最小</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation>持続</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation>グローバル変数</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>グローバル変数</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>入力</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>ミキサー</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>カーブ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>論理スイッチ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>スペシャルファンクション</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>ユニット</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>RF Quality アラーム</translation>
     </message>
@@ -11116,7 +11109,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation>サーボ 更新レート</translation>
     </message>
@@ -11124,22 +11117,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>スロットル チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>ヨー チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>ピッチ チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>ロール チャンネル:</translation>
     </message>
@@ -11147,22 +11140,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation>不明のエラー</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation> ... 追加 %1 エラー</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation>送信機設定を書き込めません</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation>機体モデル %1 を書き込めません</translation>
     </message>
@@ -11170,17 +11163,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>スロットル カット</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>スロットル タイマー</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>フライト タイマー</translation>
     </message>
@@ -11188,41 +11181,41 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>ファイルを開くときにエラーが発生しました %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation>OpenTXアーカイブ %1 を開く際にエラーが発生しました</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation>OpenTXアーカイブライターの初期化エラー</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation>OpenTXファイルの作成エラー %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation>OpenTXアーカイブの作成エラー</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation>OpenTXアーカイブへの %1 追加エラー</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>ファイルに書き込めません %1:
@@ -11252,17 +11245,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>ファイルへ出力</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>ドキュメントを出力</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation>出力ファイルの選択</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation>PDFファイル(*.pdf);;HTMLファイル(*.htm *.html);;すべてのファイル(*)</translation>
     </message>
@@ -11289,12 +11282,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -11310,22 +11303,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation>&lt;p&gt;JumperTXデータをOpenTX 2.3にインポートすることは&lt;b&gt;サポート対象外となり危険な行為です。&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;残念ながら、JumperTXデータを正当なFrSky X10データと区別することができませんが、&lt;b&gt;開いたファイルが実際のFrSky X10で生成されたものである場合にのみ、続行する事ができます。&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;本当に続行しますか？&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation>圧縮された画像サイズが予約領域を超えています。</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation>次回の起動時にこのメッセージをもう一度表示しますか？</translation>
     </message>
@@ -11333,24 +11326,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation>名称 %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation>最後に開かれた %1</translation>
     </message>
@@ -11358,97 +11351,107 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation>無効です</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation>変換しました</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation>確認します</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation>イベント</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation>オリジナル</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation>コンポーネント</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation>サブコンポーネント</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation>フィールド</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation>OLD</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation>実行</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation>新規</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation></translation>
     </message>
@@ -11456,30 +11459,30 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>ファイルを書き込めません %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation>送信機のSDカードが見つかりません！</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation>機体モデル・設定の読み込みに失敗しました</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation>機体モデルと設定ファイルの書き込みに失敗しました</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation>一時ファイルを削除できませんでした: %1</translation>
     </message>
@@ -11487,12 +11490,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation>p&gt;値 (入力): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation>右ダブルクリックして中央にリセットします。</translation>
     </message>
@@ -11600,12 +11603,17 @@ X
 力</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation>FM%1</translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished">FM</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation>GV%1</translation>
     </message>
@@ -11621,358 +11629,458 @@ X
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation>トリムR</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation>トリムE</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation>トリムT</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation>トリムA</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
-        <translation>トリム5</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
-        <translation>トリム6</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
-        <translation>トリム7</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
-        <translation>トリム8</translation>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation>トリム横</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation>トリム縦</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation>リザーブ1</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation>リザーブ2</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation>リザーブ3</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation>リザーブ4</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation>エンコーダ再生a</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation>エンコーダ再生b</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation>最小</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
-        <translation></translation>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">なし</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation>トリム横 左</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation>トリム横 右</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation>トリム縦 下</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation>トリム縦 上</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation>エンコーダ再生a</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation>エンコーダ再生b</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation>ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation>Act</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation>テレメトリー</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation>Trn</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
-        <translation>SW</translation>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished">スイッチ</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">なし</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>はい</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;ラダー チャンネル:</translation>
     </message>
@@ -11980,21 +12088,21 @@ X
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>ファイルを開くときにエラーが発生しました %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation>書き込みモードでファイル %1 を開くときにエラーが発生しました:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation>ファイル削除エラーです %1</translation>
     </message>
@@ -12002,319 +12110,334 @@ X
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation>定式</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation>インスタンス</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation>センサー</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation>選択元</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation>高度</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation>ユニット</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation>精度</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation>レシオ</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation>オフセット</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation>自動オフセット</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation>ブレード</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation>乗算</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation>フィルター</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation>持続</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation>ノーマル</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation>ログ</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation>カスタム</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation>計算値</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation>平均</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation>最低値</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation>最大値</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation>乗算</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation>合計</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation>セル</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation>消費</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation>距離</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation>より低く</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation>セル %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation>より高く</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation>差分</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation>Raw (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation>(デフォルト)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation></translation>
     </message>
@@ -12536,87 +12659,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>タイマー %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation>利用可能なポップアップメニュー</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation>プロファイル設定</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation>SDカード保存先パスが指定されていないか無効です</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation>消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation>タイマーを消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation>タイマーをすべて消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation>タイマーを切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation>タイマーを削除します。よろしいですか？</translation>
     </message>
@@ -12624,7 +12747,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>エレベーター チャンネル:</translation>
     </message>
@@ -12632,204 +12755,204 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation>画面キャプチャ</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation>ENTER</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ メニュー ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ ページ ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ 終了 ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ シフト ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ 上 ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ 下 ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation></translation>
     </message>
@@ -12837,116 +12960,116 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation>EdgeTX シミュレータ</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation>利用可能なプロファイル:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation>ID: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation>名称: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation>利用可能な送信機:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation>シミュレータに使用する送信機プロファイルIDまたは名称。</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation>プロファイル</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation>シミュレートする送信機タイプ(通常はプロファイルで定義)。</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation>送信機</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation>使用するSDカードイメージを含むフォルダです。デフォルトは選択した送信機プロファイルで設定されます。</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation>パス</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation>使用するデータソースタイプ (以下いずれか):</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation>シミュレータ起動時に不明なエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation>データ元</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation>使用する送信機データ(.bin/.eeprom/.etx)イメージファイルまたはデータフォルダパス(Horusスタイルの送信機の場合)。
 注意: 選択した送信機タイプと互換性のない既存のEEPROMデータは上書きされてしまう可能性があります！</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation>[データ元]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation>エラー: プロファイル ID %1 が見つかりません。</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation>認識されない起動データ元タイプ: %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation>警告: SDLを初期化できませんでした。
 %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation>エラー: 利用可能なシミュレータライブラリがありません。</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
@@ -12955,7 +13078,7 @@ Data File: [%3]</source>
 データファイル: [%3]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation>エラー: 送信機プロファイルまたはシミュレータのファームウェアが見つかりません。
@@ -12966,8 +13089,8 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
-        <translation>OpenTX シミュレータ</translation>
+        <source>EdgeTX Simulator</source>
+        <translation type="unfinished">EdgeTX シミュレータ</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
@@ -13115,76 +13238,76 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation>送信機ウィジェットの高さを固定サイズに設定します。</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation>エラー: シミュレータ インタフェイスの作成に失敗しました。おそらくライブラリが見つからない、もしくは不良です。</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation>送信機出力</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation>テレメトリー シミュレータ</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation>トレーナー シミュレータ</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation>デバッグ出力</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation>&lt;b&gt;シミュレータ コントロール:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translatorcomment>注: 各テーブル行のHTMLレイアウトと一致する必要があります (キーテンプレート)。</translatorcomment>
         <translation>&lt;tr&gt;&lt;th&gt;キー/マウス&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translatorcomment>注: ヘルプテキストテーブルのヘッダのHTMLレイアウトと一致する必要があります。</translatorcomment>
         <translation>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation>シミュレータ ヘルプ</translation>
     </message>
@@ -13314,32 +13437,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation>SDパス</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation>起動時オプション</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation>送信機プロファイルが見つかりません。 %1 を使用して作成ください。</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation>すべてのファイル (*.*)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation>データファイルの選択</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation>データフォルダの選択</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation>SDカードイメージフォルダの選択</translation>
     </message>
@@ -13352,69 +13475,74 @@ The default is configured in the chosen Radio Profile.</source>
         <translation>Companion シミュレータ</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation>送信機シミュレータ (%1)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation>起動データ元を特定できませんでした。</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation>データをロードできません、フォーマットが間違っている可能性があります。</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation>データロード エラー</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation>無効な起動データが提供されました。正しいファイル/パスを指定してください。</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation>シミュレータ 初期設定エラー</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation>データ保存エラー: 書き込み用にファイルを開くことができました: 「%1」</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation>データ保存エラー: シミュレータのインターフェイスからデータを取得できませんでした。</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation>送信機データをファイル『 %1 』に保存しようとしたときに予期せぬエラーが発生しました。</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation>データ保存 エラー</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation>スティックが接続不可、もしくはスティックが無効です</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation>送信機 ファームウェア エラー: %1</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
-        <translation> - フライトモード %1 (#%2)</translation>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13439,17 +13567,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>イメージライブラリ - page %1 of %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>ライブラリ %1 の画像が無効です</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>ライブラリに有効な画像が見つかりません。設定を確認してください</translation>
     </message>
@@ -13457,7 +13585,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>チャンネル %1</translation>
     </message>
@@ -13465,7 +13593,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation>ファイル %1 が見つかりません！</translation>
     </message>
@@ -13474,9 +13602,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation>スタイルシート エディタ</translation>
     </message>
@@ -13501,21 +13629,21 @@ The default is configured in the chosen Radio Profile.</source>
         <translation>この機能は変更を検証するものではなく、QTのCSS構文に精通していることを前提としています。</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation>スタイル %1 を取得できません
 エラー: %2</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation>既定のスタイル %1 を取得できません
 エラー: %2</translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation>カスタムスタイル %1 を更新できません
@@ -13525,47 +13653,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation>スタイルシートデータを「%1」から読み取りました</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation>スタイルシートデータを「%1」から読み取れませんでした</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation>フォルダを作成できません 「%1」</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation>書き込むためにファイルを開けません 「%1」: エラー: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation>ファイルに書き込めません 「%1」: エラー: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation>ファイルのバッファをフラッシュできません: 「%1」: エラー: %2</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation>スタイルシートが書き込まれました: 「%1」</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation>カスタムスタイルシートが削除されました: 「%1」</translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation>カスタムスタイルシートを削除できません: 「%1」</translation>
     </message>
@@ -13573,59 +13701,59 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation>[テスト実行] </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation>同期に失敗、コピー対象は見つかりませんでした。</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation>巨大なファイルをスキップ: %1 (%2KB)</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation>フォルダを作成します: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation>フォルダを作成できませんでした: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation>%1のファイル情報を収集しています...</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation>%1にファイルが見つかりません</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation>同期は%2ファイルの%1で中断されました。</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation>同期は%2m%3sの%1ファイルで終了しました。</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation>同期中: %1
    宛先: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
@@ -13634,84 +13762,84 @@ Error: %2</source>
 </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation>
 エラーが多すぎるため、ギブアップします。</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation>フィルター処理されたファイルをスキップしています: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation>リンクファイルをスキップしています: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation>同期を中止しました:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation>同期が完了しました:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation>作成: %1; 更新: %2; スキップ: %3; エラー: %4;</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation>フォルダが存在します: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation>少なくとも1つのファイル変更が未来日です。エラー:%1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation>古いファイルをスキップします: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation>選択元のファイルを開けませんでした 「%1」: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation>指定先ファイルを開けませんでした 「%1」: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation>同一ファイルをスキップ中: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation>ファイルを置き換えています: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation>ファイルを作成しています: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation>指定先ファイルを削除できませんでした 「%1」: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation>コピーに失敗しました 「%1」 to 「%2」: %3</translation>
     </message>
@@ -13719,17 +13847,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>ラダー チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>エレベーター チャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>まだ1つのチャンネルしか利用できません！&lt;br&gt;ウィザードを使用せず手動で機体モデルを設定する必要があります。</translation>
     </message>
@@ -13737,22 +13865,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>エレベーターとラダー</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>エレベーターのみ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>Vテール</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>テール タイプ:</translation>
     </message>
@@ -14084,7 +14212,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation>テレメトリー画面 %1</translation>
     </message>
@@ -14092,29 +14220,968 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>微弱時のアラーム</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>極微弱警告アラーム</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation>Winged Shadow How High</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (サポートなし)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
         <translation>テレメトリーセンサーを削除します。よろしいですか？</translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">フォーム</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished">受信機Batt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">昇降計</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished">ヘッディング</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished">角度(°)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished">2 W {0m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished">2 W {10m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished">2 W {25m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished">2 W {50m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished">2 W {100m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished">2 W {250m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished">2 W {500m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished">2 W {1000m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished">2 W {2000m?}</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished">テレメトリー値 保存</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished">FM</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">電流計</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished">テレメトリー値 ロード</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished">実行</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished">ストップ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished">テレメトリー 保存</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished">.tlmファイル (*.tlm)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished">書き込むファイルを開けません。
+%1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished">テレメトリーファイルを開きます</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished">読み込むファイルを開けません。
+%1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">フォーム</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished">セル</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished">燃料油量</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished">GPS高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished">テレメトリー値 保存</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished">対気速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished">ボルト</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished">実行/停止</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">温度1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished">受信機Batt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished">角度(°)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished">GPSシミュ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished">V/レシオ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished">加速度Z</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished">メートル</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished">相対アンテナ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished">加速度X</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">温度2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished">RPM</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished">加速度Y</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">昇降計</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished">テレメトリー値 ロード</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">燃料</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished">ヘッディング</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">電流計</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished">アンペア</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished">実行</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished">日時</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished">テレメトリー 保存</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished">.tlmファイル (*.tlm)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished">書き込むファイルを開けません。
+%1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished">テレメトリーファイルを開きます</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished">読み込むファイルを開けません。
+%1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished">ストップ</translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">フォーム</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">燃料</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished">RPM</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">温度2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished">実行</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">昇降計</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished">ヘッディング</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished">日時</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished">加速度X</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished">GPS高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">温度1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished">加速度Z</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished">角度(°)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">電流計</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished">テレメトリー値 ロード</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished">テレメトリー値 保存</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished">加速度Y</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished">ストップ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished">テレメトリー 保存</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished">.tlmファイル (*.tlm)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished">書き込むファイルを開けません。
+%1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished">テレメトリーファイルを開きます</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished">読み込むファイルを開けません。
+%1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14230,72 +15297,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation>利用可能なポップアップメニュー</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation>コピー</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation>切り取り</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation>貼り付け</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation>消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation>挿入</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation>上へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation>下へ移動</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation>すべて消去</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation>テレメトリーセンサーを切り取ります。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation>テレメトリーセンサーを消去します。よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation>テレメトリーセンサーのすべてを消去します。よろしいですか？</translation>
     </message>
@@ -14318,427 +15385,151 @@ Too many errors, giving up.</source>
         <translation>シミュレート</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation>実行</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation>GPSシミュ</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation>実行/停止</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation>テレメトリー値 ロード</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation>テレメトリー値 保存</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation>25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation>SDログファイルを再生</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation>再生レート</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation>ロード</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation>Row # 
 タイムスタンプ</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation>1/5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation>5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation>現在ロードされているログファイルなし</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation>相対アンテナ</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">なし</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation>V/レシオ</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation>受信機Batt</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished">外部モジュール</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation>温度1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation>RSSI</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation>温度2</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation>RPM</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>燃料</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation>メートル</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation>高度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation>昇降計</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation>燃料油量</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation>ヘッディング</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation>対気速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation>加速度X</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation>日時</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation>アンペア</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation>加速度Z</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation>GPS高度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation>ボルト</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation>セル</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation>電流計</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation>加速度Y</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation>GPS速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation>角度(°)</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation>RSSIをゼロに設定すると、テレメトリーと送信機リンク損失がシミュレートされます。</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation>一時停止したらRSSIをゼロに設定します。</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation>テレメトリーシミュレータ ウィンドウが非表示になったらテレメトリーデータの送信を停止します。</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation>非表示になったらシミュレーションを一時停止します。</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation>GPSフォーマット異常</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation>緯度、経度は10進数でなければなりません</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation>ログファイル</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation>ログファイル (*.csv)</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
         <translation>エラー - 無効なファイル</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation>テレメトリー 保存</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation>.tlmファイル (*.tlm)</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation>書き込むファイルを開けません。
-%1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation>テレメトリーファイルを開きます</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation>読み込むファイルを開けません。
-%1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
-        <translation>ストップ</translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>はい</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;スロットル チャンネル:</translation>
     </message>
@@ -14764,138 +15555,138 @@ hh:mm:ss</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation>TMR</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation>タイマー %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation>TMR</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation>消音</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation>ビープ</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation>音声</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation>バイブレーション</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation>ビープ＆バイブ</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation>音声＆バイブ</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation>5秒</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation>10秒</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation>20秒</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation>30秒</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation>持続なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation>持続 (フライト)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation>フライト</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation>持続 (手動リセット)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation>手動リセット</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation>ON</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation>スタート</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation>経過時間の表示</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation>残りを表示</translation>
     </message>
@@ -14903,22 +15694,22 @@ hh:mm:ss</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation>+= (合計)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation>:= (置換)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation>CH%1</translation>
     </message>
@@ -14926,27 +15717,27 @@ hh:mm:ss</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation>モード</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation>ウェイト</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation>ソース</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation>乗算</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation>キャリブレーション</translation>
     </message>
@@ -14957,6 +15748,210 @@ hh:mm:ss</source>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
         <translation>トレーナー シミュレータ</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">不明</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished">インストール</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished">インストールに %1 アセットを期待しましたが %2 が見つかりました</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished">フィルター %2 を使用しているファームウェアが %1 で見つかりませんでした</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished">アップデートしたファームウェアを送信機に書き込みますか？</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished">フォルダ %1 の作成に失敗しました！</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14983,47 +15978,47 @@ hh:mm:ss</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation>インストール</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation>アセットフィルターが適用されました: %1 - %2 が見つかりました</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation>インストール用に1つのアセットを期待しましたが見つかりませんでした</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation>フィルター %2 を使用しているインストーラが %1 で見つかりませんでした</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation>AppImageにファイルパーミッションを設定できません</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation>ファイル 保存</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation>イメージ (*.AppImage)</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation>ファイル %1 を削除できません</translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation>ファイル %1 にコピーできません</translation>
     </message>
@@ -15036,22 +16031,42 @@ hh:mm:ss</source>
         <translation>ファームウェア</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation>インストール</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation>インストールに %1 アセットを期待しましたが %2 が見つかりました</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation>フィルター %2 を使用しているファームウェアが %1 で見つかりませんでした</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation>アップデートしたファームウェアを送信機に書き込みますか？</translation>
     </message>
@@ -15059,285 +16074,317 @@ hh:mm:ss</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation>コンポーネント ID: %1 がアプリケーション設定コンポーネントの最大値を超えています: %2！</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation>フィルターパターンをコピーします: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation>アセット・フィルターを適用しました: %1 - %2 が見つかりました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation>ディレクトリ構造をコピーします</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation>更新処理をしています: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation>%1 準備に失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation>%1 ダウンロードに失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation>%1 展開に失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation>%1 から宛先へのコピーに失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation>リリース設定の保存に失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation>%1 非同期開始に失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation>%1 ハウスキーピングに失敗しました</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation>%1 アップデートに成功しました</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation>不明</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation>%1 フォルダがアプリケーション設定で構成されていません！</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation>%1 フォルダ %2 の作成に失敗しました！</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation>フィルター『 %2 』を使用しているリリース『 %1 』でアセットが見つかりませんでした</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation>フィルター『 %4 』を使用して、リリース『 %3 』で %2 が予想されるときに %1 アセットが見つかりました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation>アセット %1 の処理フラグを設定できません</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation>アセット %1 のサブフォルダを設定できません</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation>アセット %1 にコピーフィルターを設定できません</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation>展開しています %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation>展開: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation>%1 展開に失敗しました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation>展開されたファイル構造が %1 で見つかりません</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation>ファイル構造コピー元: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation>フォルダ %1 の作成に失敗しました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation>チェックする/作成するフォルダ: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation>チェックした/作成したフォルダ: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation>既存のファイル %1 の削除に失敗しました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation>ファイル %1 のコピーに失敗しました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation>%1 を %2 にコピーしました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation>コピーされたファイル: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation>アセット %1 のソースフォルダを決定できません</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation>%1 からファイルをコピーします</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation>ファイルが削除されました: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation>フィルター『 %1 』に一致するダウンロードまたは展開されたファイルはありません</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation>準備中</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation>実行フォルダの設定に失敗しました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation>更新リリース『 %1 』のリリースID設定に失敗しました</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation>アセットのフラグ設定</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation>アセットをダウンロードします</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation>フラグの付いたアセットをダウンロードできません</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation>アセットを展開します</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation>フラグの付いたアセットを展開できません</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation>宛先へコピーします</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation>アセットをコピーできません</translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation>ハウスキーピング</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation>ダウンロードフォルダを削除します: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation>ダウンロードフォルダの削除に失敗しました %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation>展開先フォルダを削除します: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation>展開先フォルダの削除に失敗しました %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation>展開先フォルダを削除します: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation>リリース設定の保存</translation>
     </message>
@@ -15353,64 +16400,90 @@ hh:mm:ss</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation>ダウンロード中: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation>ダウンロード: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation>ファイルが存在します: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation>ファイル %1 が存在します。再度ダウンロードしますか？</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation>フォルダ %1 の作成に失敗しました！</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
         <source>Unable to open the download file %1 for writing. Error: %2</source>
         <translation>書き込むためのダウンロードファイル %1 を開けません。エラー: %2</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
         <source>Invalid URL: %1</source>
         <translation>無効なURLです: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
         <source>URL: %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
         <source>Network error has occurred. Error code: %1</source>
         <translation>ネットワークエラーが発生しました。エラーコード: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
         <source>Ssl library version: %1</source>
         <translation>SSLライブラリバージョン: %1</translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
-%3</source>
-        <translation>%1 をダウンロードできません。エラー:%2
-%3</translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation>ダウンロードしたメタデータをjson形式に変換できません。エラー:%1
@@ -15504,32 +16577,32 @@ hh:mm:ss</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation>正確</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation>スタート(共に)</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation>エンド(共に)</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation>内容</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation>パターン</translation>
     </message>
@@ -15542,22 +16615,22 @@ hh:mm:ss</source>
         <translation>SDカード</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation>アセットのフラグ設定</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation>リリース『 %2 』からアセット『 %1 』を取得できません</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation>リポジトリ『 %2 』からファイル『 %1 』を取得できません</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation>送信機フレーバー『 %1 』は『 %2 』にリストされていません</translation>
     </message>
@@ -15570,22 +16643,22 @@ hh:mm:ss</source>
         <translation>音源</translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation>利用可能な音源処理</translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation>言語パックの選択</translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation>言語パックが選択されていません。音源の更新はスキップされます！</translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation>アセットのフラグ設定</translation>
     </message>
@@ -15609,17 +16682,17 @@ hh:mm:ss</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation>現時点で最新情報はありません</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation>アップデートを確認</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15630,37 +16703,37 @@ Process now?</source>
 実行しますか？</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation>アップデート設定でチェックするようフラグの設定がされたコンポーネントはありません！</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation>コンポーネントの更新</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation>スタート...</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation>終了しました %1</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation>成功</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation>エラーを含む</translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation>SDカード Syncをすぐに実行しますか？</translation>
     </message>
@@ -15776,32 +16849,32 @@ Process now?</source>
         <translation>%1 の最新リリース情報を取得しています</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation>デフォルト値として保存</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation>ダウンロードフォルダのパスが設定されていません！</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation>展開先フォルダのパスが設定されていません！</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation>アップデートフォルダのパスが設定されていません！</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation>展開先フォルダとダウンロードフォルダが同じパスに設定されています！</translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation>更新するコンポーネントが選択されていません！</translation>
     </message>
@@ -15809,32 +16882,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation>インフォメーションが入手できません</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation>ロードできません %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation>テーマ</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation>製作者</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation>インフォメーション</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation>トップバー</translation>
     </message>
@@ -15842,12 +16915,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>第1テールチャンネル:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>第2テールチャンネル:</translation>
     </message>
@@ -15855,55 +16928,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
-        <translation>上下スティック位置をホールドします。</translation>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation>スティックの上下の動きを抑止します。</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation>スティックの左右の動きを抑止します。</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
         <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
-        <translation>左右スティック位置をホールドします。</translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>標準翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>全翼機 / デルタウィング</translation>
     </message>
@@ -15911,22 +16984,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15934,273 +17007,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>機体モデルウィザード</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>モデルタイプ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>機体モデル名とモデルタイプを入力してください。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>スロットル</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>この機体モデルはモーター駆動、またはエンジン駆動ですか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>ウィングタイプ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>この機体モデルは全翼機/デルタウィングですか、それとも標準翼ですか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>エルロン</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>この機体モデルはエルロン(補助翼)を搭載していますか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>フラップ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>この機体モデルはフラップを搭載していますか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>エアブレーキ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>この機体モデルはエアブレーキを搭載していますか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>全翼機 / デルタウィング</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>エレボンチャンネルを選択</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>ラダー</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>この機体モデルはラダーはありますか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>テールタイプ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>機体モデルに装備されているテールタイプを選択してください。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>テール</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>テールコントロール用のチャンネルを選択します。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>Vテール</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>エレベーターチャンネルを選択します。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>サイクリック</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>このヘリコプターにはどのタイプのスワッシュコントロールが実装されていますか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>テール ジャイロ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>このヘリコプターはテールのジャイロ調整を実装しましたか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>ロータータイプ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>このヘリコプターはフライバーを実装していますか？</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>ヘリコプター</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>このヘリコプター用コントロールを選択</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>マルチローター</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>マルチローターのコントロールチャンネルを選択してください</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>モデルオプション</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>追加オプションを選択</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>変更を保存</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>手動で各コントロールの向きを確認し、向きが違う場合はチャンネルをリバースにします。初めて機体モデルを制御する前にはプロペラを取り外してください。&lt;br&gt;続行すると古い機体モデル設定がすべて削除されます！</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>機体モデル名を入力しモデルタイプを選択します。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>ESCまたはスロットルサーボに接続されている受信機チャンネルを選択します。&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>ほとんどの固定翼機は主翼と操縦翼面を持つテールを持っています。全翼機とデルタウィング機は単一の翼しか持っていません。標準翼の主操縦翼面は固定翼機のロールを制御します。この挙動はエルロンと呼ばれます。&lt;br&gt;デルタウィングのコントロールの挙動は、ロールとピッチの両方を制御します。この挙動はエレボンと呼ばれます。 </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>1つまたは2つのチャンネルを使用してエルロンを制御します。&lt;br&gt;いわゆるY字ケーブルを使用して、1つの受信機チャンネルを2つの別々のエルロンサーボに接続できます。サーボがY字ケーブルで接続されている場合は、シングルサーボオプションを選択してください。&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>このウィザードはあなたのフラップがスイッチによって制御されていると仮定しています。フラップがポテンショメーターにより制御されている場合は、後で手動で変更できます。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>エアブレーキは高機能セールプレーン (固定翼機グライダー) のスピードを下げるために使用されます。&lt;br&gt;他のタイプの固定翼機ではめったにありません。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>機体モデルは2つのチャンネルを使用してエレベーターを制御します&lt;br&gt;これら2つのチャンネルを選択します</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>ラダーに接続されている受信機チャンネルを選択します。&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>あなたの固定翼機のテールタイプを選択してください。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>ラダーチャンネルとエレベーターチャンネルを選択します。&lt;br&gt;&lt;br&gt;ラダー - Spektrum: CH4, Futaba: CH4&lt;br&gt;エレベーター - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>エレベーターチャンネルを選択します。&lt;br&gt;&lt;br&gt;エレベーター -  Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>マルチローターのコントロールチャンネルを選択します。&lt;br&gt;&lt;br&gt;スロットル - Spektrum: CH1, Futaba: CH3&lt;br&gt;ヨー - Spektrum: CH4, Futaba: CH4&lt;br&gt;ピッチ - Spektrum: CH3, Futaba: CH2&lt;br&gt;ロール - Spektrum : CH2, Futaba: CH1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>現在のページに利用可能なヘルプはありません。</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>機体モデルウィザード ヘルプ</translation>
     </message>
@@ -16208,37 +17281,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>固定翼機</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>マルチコプター</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>ヘリコプター</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>機体モデル名: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>モデルタイプ: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>オプション: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>キャンセル %1: </translation>
     </message>
@@ -16246,47 +17319,47 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>ファイルを開くときにエラーが発生しました %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation>書き込みモードでファイル %1 を開くときにエラーが発生しました:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation>%1 を読み取れません</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation>ファイル %1 は有効な形式ではありません</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation>ロードできません </translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation>すべての送信機と機種の設定をご確認ください。</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation>ファイル %1 には送信機設定が含まれているようで、インポートはサポートされていません。</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation>ファイル コンテンツタイプを判別できません %1</translation>
     </message>
@@ -16294,20 +17367,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
-        <translation>警告:  送信機設定ファイルのバージョン %1 は、このバージョンのEdgeTX Companionではサポートされていません！
-
-続行すると、機体モデルおよび送信機設定が破損する場合があります。
-
-ご了承頂けますようよろしくお願い致します。</translation>
+Model and radio settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16320,13 +17392,28 @@ Do you wish to continue?</source>
 そのまま続行しますか？</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
         <translation>設定ファイルボード (%1) が現在のプロファイルボード (%2) と一致しません。
 
 そのまま続行しますか?</translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -16432,18 +17519,18 @@ v4.1ボード用m2560</translation>
         <translation>詳細設定を使用</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>DFU-Utility 設定</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>SAM-BA 設定</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>場所の選択</translation>
     </message>
@@ -16486,70 +17573,70 @@ v4.1ボード用m2560</translation>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation>割り当てなし</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation>スティックが認識できません</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>スティックを接続することができません。</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation>スタートボタンを押すと、スティックレンジのキャリブレーション手順が始まります。
 チャンネル割り当てやリバース設定はいつでも変更することができます。</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation>スティックとダイヤルをあらゆる方向に末端まで動かします
 終了したら『次へ』を押してください</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>次へ</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation>スティックとダイヤルを中央に合わせます。
 完了したら『次へ』を押してください</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation>コンボボックスを使用してスティックチャンネルをマッピングします。
 完了したら『次へ』を押してください。</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation>方向を逆にする必要がある場合は、『リバース』チェックボックスをオンにします。
 完了したら『次へ』を押してください。</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation>OKを押して設定を保存します
 保存せずにスティックキャリブレーションを中止するには、『キャンセル』を押します。</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation>キャリブレーションが完了していません。そのまま保存しますか？</translation>
     </message>

--- a/companion/src/translations/companion_nl.ts
+++ b/companion/src/translations/companion_nl.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,23 +60,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -169,22 +169,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -207,662 +207,657 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,29 +865,29 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -930,33 +925,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -967,255 +962,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1223,17 +1228,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1241,132 +1246,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1409,56 +1414,56 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1474,12 +1479,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,173 +1492,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1691,22 +1706,22 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1732,7 +1747,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1740,17 +1755,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1758,22 +1773,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1856,32 +1871,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1889,7 +1904,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1897,22 +1912,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1920,113 +1935,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2034,343 +2049,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2378,123 +2413,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2502,22 +2537,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,47 +2560,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2622,82 +2657,82 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2705,22 +2740,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2728,53 +2763,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2782,52 +2817,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2906,101 +2941,82 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3009,12 +3025,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3022,12 +3038,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3035,12 +3051,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3048,40 +3064,40 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,23 +3105,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3113,110 +3129,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3226,22 +3227,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3249,22 +3250,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,262 +3273,262 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3535,367 +3536,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3903,27 +3948,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3932,7 +3977,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3997,49 +4042,49 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4117,103 +4162,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4221,83 +4266,83 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4305,7 +4350,7 @@ You are currently using:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4356,225 +4401,240 @@ You are currently using:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4582,17 +4642,17 @@ You are currently using:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4600,17 +4660,17 @@ You are currently using:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4618,17 +4678,17 @@ You are currently using:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4636,13 +4696,13 @@ You are currently using:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4660,17 +4720,18 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4680,7 +4741,12 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4688,8 +4754,13 @@ You are currently using:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4785,13 +4856,13 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4799,43 +4870,33 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4863,57 +4924,57 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4952,7 +5013,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
+        <source>%1 Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4989,184 +5050,207 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5183,201 +5267,199 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5385,7 +5467,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5395,72 +5477,72 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5483,222 +5565,82 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5706,295 +5648,328 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6009,92 +5984,92 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6105,12 +6080,14 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,179 +6095,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6298,17 +6275,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6316,118 +6293,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6508,22 +6495,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6531,18 +6518,18 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
@@ -6551,159 +6538,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="52"/>
         <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <source>Ctrl+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,96 +6731,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6841,17 +6828,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6859,7 +6846,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6867,122 +6854,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6990,112 +6977,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7148,125 +7140,125 @@ Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7274,736 +7266,736 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8011,125 +8003,125 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation type="unfinished">
@@ -8138,7 +8130,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation type="unfinished">
@@ -8147,195 +8139,195 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -8343,124 +8335,124 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8468,143 +8460,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8612,12 +8609,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8630,50 +8627,67 @@ Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8688,170 +8702,127 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8859,22 +8830,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8882,136 +8853,136 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="47"/>
         <location filename="../modeledit/mixes.cpp" line="441"/>
+        <source>Ctrl+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9019,18 +8990,23 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9079,32 +9055,49 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9122,63 +9115,58 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9232,7 +9220,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
+        <source>%1 Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9269,585 +9257,595 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9855,27 +9853,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9883,27 +9881,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10159,285 +10157,290 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10445,57 +10448,57 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10503,456 +10506,456 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10960,7 +10963,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10968,22 +10971,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10991,22 +10994,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11014,17 +11017,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11032,40 +11035,40 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11093,17 +11096,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11130,12 +11133,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11151,22 +11154,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11174,24 +11177,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11199,97 +11202,107 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11297,29 +11310,29 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11327,12 +11340,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11428,12 +11441,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11449,358 +11467,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11808,19 +11926,19 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11828,319 +11946,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12359,87 +12492,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12447,7 +12580,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12455,204 +12588,204 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12660,121 +12793,121 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
@@ -12784,7 +12917,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12933,74 +13066,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13125,32 +13258,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13163,68 +13296,73 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13250,17 +13388,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13268,7 +13406,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13276,7 +13414,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13285,9 +13423,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13312,19 +13450,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13333,47 +13471,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13381,141 +13519,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13523,17 +13661,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13541,22 +13679,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13888,7 +14026,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13896,28 +14034,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14034,72 +15105,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14112,305 +15183,118 @@ Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14419,127 +15303,40 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
         <source>When enabled, sends any non-blank values as simulated telemetry data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14565,138 +15362,138 @@ Timestamp</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14704,22 +15501,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14727,27 +15524,27 @@ Timestamp</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14757,6 +15554,210 @@ Timestamp</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14784,47 +15785,47 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14837,22 +15838,42 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14860,285 +15881,317 @@ Timestamp</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15154,63 +16207,90 @@ Timestamp</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15303,32 +16383,32 @@ Timestamp</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15341,22 +16421,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15369,22 +16449,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15408,17 +16488,17 @@ Timestamp</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15426,37 +16506,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15572,32 +16652,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15605,32 +16685,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15638,12 +16718,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15651,55 +16731,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15707,22 +16787,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15730,273 +16810,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16004,37 +17084,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -16042,45 +17122,45 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16088,16 +17168,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16106,10 +17189,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16211,18 +17309,18 @@ m2560 for v4.1 boards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16260,59 +17358,59 @@ m2560 for v4.1 boards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16322,7 +17420,7 @@ Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_pl.ts
+++ b/companion/src/translations/companion_pl.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Tak, kontrolowane przez 1 kanał</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Tak, kontrolowane przez 2 kanały</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt; Pierwszy kanał lotek:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>Drugi kanał lotek:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Tak, kontrolowane przez 1 kanał</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Tak, kontrolowane przez 2 kanały</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt; Pierwszy kanał hamulców:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>Drugi kanał hamulców:</translation>
     </message>
@@ -60,23 +60,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -169,22 +169,22 @@
         <translation>Profil radia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>Bazowa kolejność kanałów</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>Bazowy mod drążków</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>Wybierz obrazek</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -207,662 +207,657 @@ Mode 4:
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Mod 1 (SK.SW.Gaz.Lot)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Mod 2 (SK.Gaz.SW.Lot)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Mod 2 (Lot.SW.Gaz.SK)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Mod 4 (Lot.Gaz.SW.SK)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>Ekran startowy</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>Katalog profili, jeśli ustawiony zmieni główny katalog backupów</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>Katalog Backupów</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>Jeśli ustawione, nadpisze główne ustawienia aplikacji</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>Jeśli ustawione, nadpisze główne ustawienia backupów</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kolejność kanałów&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Definiuje kolejność standardowych mikserów dla nowego modelu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>K W G L</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>K W L G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>K G W L</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>K G L W</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>K L W G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>W K G L</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>W K L G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>W G K L</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>W G L K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>W L K G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>W L G K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>G K W L</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>G K L W</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>G W K L</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>G W L K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>G L K W</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>G L W K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>L K W G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>L R G W</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>L W K G</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>L W G K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>L G K W</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>L G W K</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>Wybierz Folder</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>Wybierz EXE</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished">Profile radia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>Głośność symulatora</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>Nazwa profilu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>Wyczyść obrazek</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>Typ Radia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>Inne ustawienia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>Główne ustawienia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>Struktura karty SD</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>Ustawienia Aplikacji</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>Uaktywnij automatyczny backup przed zapisem firmware</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>Biblioteka ekranów startowych</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Plik wykonywalny Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>Pokaż tylko ekrany startowe użytkownika</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>Pokaż ekrany startowe użytkownika i Companion</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>Użyj ekranu startowego</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>Automatyczny Katalog Backupów</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>Ustawienia Symulatora</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>Podświetlenie symulatora</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>Aktywuj</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation>Akcje na nowym modelu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>Niebieskie</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>Zielone</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>Czerwone</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>Pomarańczowe</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>Żółte</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>Joystick</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>Kalibracja</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>Zapisz tylko do schowka</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Moje Radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Katalog zrzutów</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Brak joysticka</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>PUSTY:Brak ustawień radia w profilu</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>DOSTĘPNY:Nieznany wiek ustawień radia</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>DOSTĘPNY:Zapamiętane ustawienia radia %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Wybierz katalog biblioteki</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Wybierz folder do backupowania Modeli i Ustawień</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Wybierz wykonywalny plik Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Wybierz folder do zreplikowania struktury Twojej karty SD</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Otwórz obrazek do załadowania</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Obrazki (%1)</translation>
     </message>
@@ -870,31 +865,31 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished">Błąd odczytu %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished">Nie mogę zapisać EEPROMu</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished">Nie mogę otwprzyć pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Błąd zapisu pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished">Nieprawidłowy binarny plik EEPROMu %1</translation>
     </message>
@@ -932,33 +927,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -969,255 +964,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">Lewy poziomy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished">Lewy pionowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished">Prawy pionowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">Prawy poziomy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished">Dodatk. 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished">Dodatk. 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished">Przełącznik</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">Lot</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Potencj. z zapadką</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2 Poz. Przełącznik chwilowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 Pozycje</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 Pozycje</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Funkcja</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">Małe</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">Obie</translation>
     </message>
@@ -1225,17 +1230,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished">Ujemny zakres</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished">Wartość środkowa</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished">Dodatni zakres</translation>
     </message>
@@ -1243,132 +1248,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished">Nazwa</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished">Subtrim</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished">Maks</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished">Kierunek</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">Krzywa</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished">Środek PPM</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished">Liniowy Subtrim</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished">Kan %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished">Odwr</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished">Skopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished">Wytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished">Wklej</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished">Wyczyść</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished">Wprowadź</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished">Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished">W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished">Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1411,58 +1416,58 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Nie mogę zapisać pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished">Nie mogę otwprzyć pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1478,12 +1483,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1491,173 +1496,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished">Informacja</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished">Ostrzeżenie</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished">Błąd</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished">Ustawienia Aplikacji</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished">Pliki</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished">Ustawienia Radia i Modeli</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished">Nie jest dostępny symulator dla tego firmware</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished">Nieznany błąd w trakcie startu Symulatora.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished">Błąd Symulatora</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished">Błąd odczytu danych</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished">Błąd wystąpił w trakcie startu Symulatora.</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1695,22 +1710,22 @@ Do you want to import settings from a file?</source>
         <translation>Drukuj do pliku</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation>Nienazwany Model %1</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation>Klinij by usunąć ten model.</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Drukuj dokument</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>Wybierz plik docelowy PDF</translation>
     </message>
@@ -1736,7 +1751,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>OK, Rozumiem.</translation>
     </message>
@@ -1744,17 +1759,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>Błąd Zapisu</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>Nie mogę zapisać %1 (powód %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation>Nie mogę otworzyć %1 (powód %2)</translation>
     </message>
@@ -1762,22 +1777,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished">%1 punktowa</translation>
     </message>
@@ -1860,32 +1875,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">Liniowa</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">Pojedyncze expo (wykładnicza)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">Symetryczna (nieparzysta) f(x)=-f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">Symetryczna (parzysta) f(x)=f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1893,7 +1908,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1901,22 +1916,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished">Różnicowość</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished">Expo</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished">Funkcja</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1924,113 +1939,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished">Dodaj</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">Edycja</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished">Skopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished">Wytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished">Wklej</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished">Wyczyść</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished">Wprowadź</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished">Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished">W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished">Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2038,343 +2053,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished">SF</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished">Nadpisanie %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished">Trener - SK</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished">Trener - SW</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished">Trener - Gaz</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished">Trener - Lotki</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished">Natychmiastowe trymowanie</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished">Odtwórz dźwięk</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished">Wibracje</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished">Reset</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>Wycisz wzmacniacz audio</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished">Odtwarzaj raz, nie w trakcie uruchomienia</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished">Bez powtórzeń</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished">1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished">%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished">Wartość</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation type="unfinished">Źródło</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished">Wariometr</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished">Odtwórz ścieżkę</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished">Odtwórz oba</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished">Odtwórz wartość</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished">Logi SD</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished">Głośność</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished">Podświetlenie</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished">Zrzut ekranu</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished">Muzyka tła</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished">Muzyka tła - pauza</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished">Bindowanie Wew. Modułu</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished">Bindowanie Zew. Modułu</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished">Lot</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished">s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished">Wyłączone</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2382,123 +2417,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Przełącznik</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Akcja</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Parametry</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished">Aktywuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation>FG%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished">Skopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished">Wytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished">Wklej</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished">Wyczyść</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished">Wprowadź</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished">Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished">W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished">Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2506,22 +2541,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished">Liczby</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">Paski</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished">Skrypt</translation>
     </message>
@@ -2529,47 +2564,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">Faza lotu</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2626,82 +2661,82 @@ Do you want to import settings from a file?</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>Nie mogę załadować pliku obrazka %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>Nie mogę załadować obrazu Profilu %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>Nie mogę załadować obrazu biblioteki %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>Plik Zapisany</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>Obraz został zapisany do pliku %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>Błąd odświeżenia obrazka</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>Nieudane odświeżenie obrazka z pliku %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>Błąd zapisu pliku</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>Nieudany zapis obrazka do %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>Otwórz obrazek do załadowania</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished">FW:%1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished">Obrazek:%1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished">Obrazek Profilu</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>Otwórz plik Firmware</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>Nie mogę załadować wbudowanego obrazka z pliku Firmware %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>Obrazki (%1)</translation>
     </message>
@@ -2709,22 +2744,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2732,53 +2767,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished">Błąd konwersji pola %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished">Przełącznik</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished">Przełącznik</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished">nie może być wyeksportowana na tę platformę!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished">Źródło</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished">Źródło %1 nie może być wyeksportowane na tę płytę!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX zezwala tylko na %1 punktów we wszystkich krzywych</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX zezwala tylko na %1 punktów we wszystkich krzywych</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished">OpenTX na tej platformie nie dopuszcza tej funkcji</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished">OpenTX nie obsługuje tego protokołu radiowego</translation>
     </message>
@@ -2786,52 +2821,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished">Włącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished">Nie</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished">Tak</translation>
     </message>
@@ -2911,102 +2946,83 @@ W celu &lt;b&gt;usunięcia filtru&lt;/b&gt; z listy, najpierw wybierz go, a nast
         <translation>Przełącz filtr on/off.</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished">&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation>Debug Konsola Filtr Help</translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished">Pobierz: </translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation type="unfinished">Pobieranie nieudane: %1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished">Możliwe przyczyny tego:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished">- Eeprom jest z nowszej wersji OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished">- Eeprom nie jest z OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished">- Eeprom nie jest z ErSky9X</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished">- Nieprawidłowa wielkość Eeproma</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished">- Błedny system plików Eeproma</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished">- Eeprom z nieznanej płyty</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished">- Eeprom ze złej płyty</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished">- Backup Eepromu nieobsługiwany</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished">- Coś czego nie można odgadnąć, przepraszam</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished">Ostrzeżenie:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished">- Twoje radio prawdopodobnie używa złego firmware,
 wielkość eepromu to 4096 ale tylko pierwsze 2048 jest użyte</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3015,12 +3031,12 @@ wielkość eepromu to 4096 ale tylko pierwsze 2048 jest użyte</translation>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3028,12 +3044,12 @@ wielkość eepromu to 4096 ale tylko pierwsze 2048 jest użyte</translation>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished">Nie mogę otworzyć %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished">Nieprawidłowy plik EEPROMu %1</translation>
     </message>
@@ -3041,12 +3057,12 @@ wielkość eepromu to 4096 ale tylko pierwsze 2048 jest użyte</translation>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt; Pierwszy Kanał Sterolotek:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>Drugi Kanał Sterolotek:</translation>
     </message>
@@ -3054,42 +3070,42 @@ wielkość eepromu to 4096 ale tylko pierwsze 2048 jest użyte</translation>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Błąd otwarcia pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Błąd zapisu pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3097,23 +3113,23 @@ wielkość eepromu to 4096 ale tylko pierwsze 2048 jest użyte</translation>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">Włącz</translation>
     </message>
@@ -3121,111 +3137,95 @@ wielkość eepromu to 4096 ale tylko pierwsze 2048 jest użyte</translation>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Waga</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation>Skala</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Uwzględnij trymer</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Krzywa</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Wyrównanie</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation>Źródło miksera</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Wprowadź Nazwę</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation>ZG</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Fazy lotu</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Przełącznik</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>Źródło</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Nazwa linii</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Strona drążka</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation>Źródło miksera.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Przełącznik używany do aktywacji linii.
-Jeśli puste linia jest uznawana za aktywną cały czas.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation>x&lt;0(Ujemna)</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation>x&gt;0(Dodatnia)</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation>Wszystkie</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation>Krzywa załączona do źródła.</translation>
     </message>
@@ -3235,22 +3235,22 @@ Jeśli puste linia jest uznawana za aktywną cały czas.</translation>
         <translation>Edycja %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation>Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation>Ustaw wszystko</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation>Odwróć wszytko</translation>
     </message>
@@ -3258,22 +3258,22 @@ Jeśli puste linia jest uznawana za aktywną cały czas.</translation>
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>Kanał gazu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>Kanał odchylenia:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>Kanał pochylenia:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>Kanał przechylenia:</translation>
     </message>
@@ -3281,262 +3281,262 @@ Jeśli puste linia jest uznawana za aktywną cały czas.</translation>
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished">Zamknij</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished">Start</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3544,367 +3544,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished">Brak dostępnych Funkcji Nadpisania Kanału</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished">Umożliwienie uaktywniania trybu FAI(brak telemetrii) w menu na lotnisku</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished">Tryb FAI (brak telemetrii) zawsze aktywny</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished">Usuwa wsparcie dla protokołu D8 FrSky, który jest nielegany w UE w radiach spradawanych po 01-01-2015</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Dezaktywowane menu Heli i wsparcie dla cyklicznych mikserów</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">dezaktywowane zmienne globalne</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished">Użyj alternatywnego fontu SQT5</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished">Użycie potencjometrów do nawigacji w menu</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished">FrSky Taranis X9D+</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished">FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">Moduł wibracji zainstalowany</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished">FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished">Potwierdzenie przez wyłączeniem radia</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished">Zainstalowane gimbale Horusa (na czujnikach Halla)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished">Użyć tylko dla pierwszych deweloperskich platform</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Uaktywnij menu HELI i cyklicznych mikserów</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished">Globalne zmienne</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished">W menu ustawień modelu automatycznie wybierz źródło poprzez poruszenie nim</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished">W menu ustawień modelu automatycznie wybierz źródło poprzez poruszenie nim</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished">Brak graficznych pol wyboru i suwaków</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished">Grafika baterii</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished">Nie używaj podświetlenia dla wybranych aktywnych elementów, mikserów, krzywych, expo, etc</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished">Szybkie nastawianie wartości
 (+) a (-) neguje wartość
@@ -3916,27 +3960,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Tak, kontrolowane przez 1 kanał</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Tak, kontrolowane przez 2 kanały</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt; Pierwszy kanał klap:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>Drugi kanał Klap:</translation>
     </message>
@@ -3945,7 +3989,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Zapisz Modele i Ustawienia do radia</translation>
     </message>
@@ -4010,51 +4054,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Zapisz do radia</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>Aktualny profil %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>Wybierz plik Backupu radia</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>Błędna kalibracja radia w profilu, Ustawienia nie spatchowane</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>Błędne ustawienia radia w profilu, Ustawienia nie spatchowane</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Nie mogę zapisać pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Błąd zapisu pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>Firmware radia należy do innej rodziny produktów, sprawdź plik i preferencje !</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>Firmware w radiu jest przestarzały. Proszę zaktualizować!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>Nie mogę potwierdzić kompatybilności Modeli i Ustawień. Kontynuować?</translation>
     </message>
@@ -4132,103 +4176,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Zapisz do radia</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>Otwórz plik Firmware</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 może nie być prawidłowym plikiem firmware</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>Plik firmware jest błędny.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>Brak obrazka ekranu startowego w firmware.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>Obraz profilu %1 nieprawidłowy.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>Otwórz plik obrazka by użyć go jako ekran startowy radia</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>Obrazki (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>Obrazek nie może być załadowany z %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>Obrazek z biblioteki nie może być załadowany</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>Obrazek startowy nie znaleziony</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>Nie mogę zapisać przystosowanego firmware</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>Zapisz firmware do radia</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>Sprawdzenie firmawe nieudane</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>Nie mogę sprawdzić firmware w radiu</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>Nowe firmware niekompatybilne z aktualnie zainstalowanym!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>Konwersja nieudana</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>Nie mogę skonwertować Modeli i Ustawień na ten rodzaj firmware, zostaną użyte oryginalne dane</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>Zapis nieudany</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>Nie mogę odtworzyć Modeli i Ustawień do radia. Plik modeli i ustawień można znaleźć w: %1</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>Sflashowanie zakończone</translation>
     </message>
@@ -4236,47 +4280,47 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation>Plik wykonywany %1 nie znaleziony</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation>Zapis...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation>Czytanie...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation>Weryfikacja...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation>nieznany</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>ie: OpenTX dal platformy 9X lub OpenTX lub 9XR</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>ie: OpenTX dla platformy M128 / 9X lub OpenTX dla platformy 9XR z chipem M128</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>ie: OpenTX dla platformy Gruvin9X</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4285,7 +4329,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 Sprawdź zaawansowane opcje aby ustalić prawidłowy procesor.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4294,7 +4338,7 @@ Please select an appropriate firmware type to program it.</source>
 Proszę wybrać poprany rodzaj firmware.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4303,22 +4347,22 @@ Aktualnie używasz:
  %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>Radio nie jest podłączone do USB lub driver nie został zainicjalizowany!!!.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>Flaszowanie zakończone( z kodem %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>Flashowanie zakończone z Błędami</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>Bezpieczniki: Low=%1 High=%2 Ext=%3</translation>
     </message>
@@ -4326,7 +4370,7 @@ Aktualnie używasz:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
@@ -4377,225 +4421,240 @@ Aktualnie używasz:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>Pokrętło %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>Źródło wartości</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>Wartość</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>ZmGl%1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Wyskakujące okna aktywne</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished">Trymery wyłączone</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished">Własne trymery</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished">Użyj trymerów dla Fazy Lotu %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished">Użyj trymerów dla Fazy Lotu %1 + Własne trymery jako wyrównania</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished">Jednostka</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished">Maks</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">ZG%1</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Własna Wartość</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished">Skopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished">Wytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished">Wklej</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished">Wprowadź</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished">Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished">W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished">Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>Wyczyść</translation>
     </message>
@@ -4603,17 +4662,17 @@ Aktualnie używasz:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation>Faza lotu %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation> (%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (bazowa)</translation>
     </message>
@@ -4621,17 +4680,17 @@ Aktualnie używasz:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>Posiada flaybar</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>Bez flybara</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>Flaybar:</translation>
     </message>
@@ -4639,17 +4698,17 @@ Aktualnie używasz:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4657,13 +4716,13 @@ Aktualnie używasz:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished">V</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
@@ -4681,17 +4740,18 @@ Aktualnie używasz:
         <translation>Ustawiane przełączniki</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Nazwa</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished">Start</translation>
     </message>
@@ -4701,7 +4761,12 @@ Aktualnie używasz:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4709,8 +4774,13 @@ Aktualnie używasz:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4855,13 +4925,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Rób to tylko wtedy gdy masz absolutną pewność i wiedzę.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>Zresetuj bezpieczniki radia</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>Odczytaj bezpieczniki radia</translation>
     </message>
@@ -4869,44 +4939,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished">Własna Wartość</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation type="unfinished">Wartość Fazy lotu FL%1</translation>
     </message>
 </context>
 <context>
@@ -4934,57 +4994,57 @@ These will be relevant for all models in the same EEPROM.</source>
 Będą one obowiązywać dla wszystkich modeli w tym samym EEPROM-ie.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Trener</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>Funkcje Globalne</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation>Sprzęt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation>Kalibracja</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>Błędne dane w profilu, kalibracja nie została odzyskana</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>Błędne dane w profilu, Ustawienia przełączników/potencjometrów nie uzyskane</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>Błędne dane w profilu, parametry HW nie zostały odzyskana</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>Chcesz zapamiętać dane kalibracji profilu %1&lt;br&gt; Zastąpią one aktualne dane kalibracji?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>Kalibracja i parametry HW zapamiętane.</translation>
     </message>
@@ -5023,8 +5083,8 @@ Będą one obowiązywać dla wszystkich modeli w tym samym EEPROM-ie.</translati
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Fazy lotu</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5060,185 +5120,208 @@ Będą one obowiązywać dla wszystkich modeli w tym samym EEPROM-ie.</translati
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished">Sprzęt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished">Przełącznik</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished">Wewnętrzny</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">Trener</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">Trener SBUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">Debugowanie</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished">mA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished">Tylko trymy</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished">Tylko przyciski</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished">Przełączane</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished">Globalne</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">Mod 1 (SK.SW.Gaz.Lot)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished">Mod 2 (SK.Gaz.SW.Lot)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">Mod 2 (Lot.SW.Gaz.SK)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">Mod 4 (Lot.Gaz.SW.SK)</translation>
     </message>
 </context>
 <context>
@@ -5249,132 +5332,132 @@ Będą one obowiązywać dla wszystkich modeli w tym samym EEPROM-ie.</translati
         <translation>Formularz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>Koordynaty GPS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>Wysokość tonów (tylko dźwięki)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Jednostki miar</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation>NMEA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Język komunikatów</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Strefa czasowa względem UTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Metryczne</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Imperialne</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Kod kraju</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>Ameryka</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Japonia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>Europa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>Bardzo krótka</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Krótka</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>Normalna</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>Długa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>Bardzo długa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>Kolor 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>Kolor 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Długość piknięcia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Nawigacja pokrętłem</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Tryb pikania</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Ton Wario dla zera</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation>Optrex</translation>
     </message>
@@ -5384,12 +5467,12 @@ Będą one obowiązywać dla wszystkich modeli w tym samym EEPROM-ie.</translati
         <translation>Odblokuj &quot;Tylko do odczytu&quot;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Tryb dźwiękowy</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -5406,61 +5489,61 @@ Będą one obowiązywać dla wszystkich modeli w tym samym EEPROM-ie.</translati
 4 - Bardzo głośna.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Cichy</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Tylko alarmy</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>Bez przycisków</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>Wszystkie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Tylko Alarmy</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Tryb wibracji</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>Pikanie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Głośnik</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>Pikanie i głosy</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>Głośnik i głosy</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5475,216 +5558,243 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Wartości z zakresu 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation>SC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation>SE</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation>SA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation>SF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation>SH</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation>SD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation>SB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation>SG</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation>Hz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Ostrzeżenie o zasilaniu</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Ton Wario dla Maks</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Jeśli ta wartość jest różna od 0, każde naciśnięcie klawisza włączy podświetlenie, które zgaśnie po ustalonej liczbie sekund.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation>s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation> ms</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>Jasność Podświetlenia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Powtarzanie dla Wario zero</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>Wyłącz podświetlenie po</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>Kolor Podświetlenia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation>V</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation>Maks</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>Kontrast</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Zakres Pomiaru Baterii</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Radio zasygnalizuje dźwiękiem brak aktywności po określonej liczbie minut. 0- wyłącza tę funkcję.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">5x {0s?}</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">5x {0.5s?}</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation>4800 bps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation>9600 bps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation>14400 bps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation>19200 bps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation>38400 bps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation>57600 bps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation>76800 bps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation>115200 bps</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>Przełącznik Podświetlenia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Pokazuj ekran startowy z logo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
         <translation>To jest przełącznik do włączenia podświetlenia (jeśli zainstalowane).</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>Typ ekranu LCD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Dostosuj Zegar</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5709,122 +5819,126 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Ostrzeżenie cichej pracy - będzie ostrzegało gdy pikanie jest ustawione na cicho(0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>Prędkość przesyłu MAVLink</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Głośność dźwięków</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Długość wibracji</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Timer bezczynności</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation>---</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation>2s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation>3s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation>4s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation>6s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation>8s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation>10s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation>15s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Ostrzeżenie &quot;Brak Dźwięku&quot;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Siła wibracji</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Głośność sygnałów</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Głośność WAV</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Głośność wariometru</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Głośność tła</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Mod drążków</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Bazowa kolejność kanałów</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>Tryb FAI</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>Dostrój automatycznie zegar radia jesli GPS jest podłączony do telemetri.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>Jacność wyłączonego podświetlenia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5865,252 +5979,112 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>Mod 1 (SK.SW.Gaz.Lot)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>Mod 2 (SK.Gaz.SW.Lot)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>Mod 4 (Lot.Gaz.SW.SK)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kolejność kanałów&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Definiuje kolejność standardowych mikserów dla nowego modelu.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation>K W G L</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation>K W L G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation>K G W L</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation>K G L W</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation>K L W G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation>K L G W</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation>W K G L</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation>W K L G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation>W G K L</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation>W G L K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation>W L K G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation>W L G K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation>G K W L</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation>G K L W</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation>G W K L</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation>G W L K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation>G L K W</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation>G L W K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation>L K W G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation>L R G W</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation>L W K G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation>L W G K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation>L G K W</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation>L G W K</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -6121,109 +6095,111 @@ Ustala próg ostrzeżenia.
 Dopuszczalne wartości 3v-12v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished">Trener</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>Tryb grzybków</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Rewers drążków</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Opóźnienie odtwarzania (pozycja środkowa przełącznika)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>Błyskanie podświetleniem przy alarmie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished">1s</translation>
     </message>
@@ -6231,179 +6207,179 @@ Dopuszczalne wartości 3v-12v</translation>
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished">Przyciski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished">Drążki</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished">Przyciski i Drążki</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished">Włącz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished">Angielski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished">Holenderski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished">Francuski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished">Włoski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished">Niemiecki</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished">Czeski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished">Słowacki</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished">Hiszpański</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished">Polski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished">Portugalski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished">Szwedzki</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished">Węgierski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished">Nie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished">Pokrętło :A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">Pokrętło :B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">Pokrętło :C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">Pokrętło :D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">Pokrętło :E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6411,17 +6387,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Tak, kontrolowane przez przełącznik</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Tak, kontrolowane przez potencjometr</translation>
     </message>
@@ -6429,118 +6405,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished">Bluetooth</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished">Filtr ADC</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished">Aktuany ofset</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Odwróć</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6621,22 +6607,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>Kanał gazu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>Kanał odchylenia:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>Kanał pochylenia:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>Kanał przechylenia:</translation>
     </message>
@@ -6644,19 +6630,19 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished">Nieprawidłowy plik EEPROMu %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished">Nie mogę otwprzyć pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Błąd zapisu pliku %1:
@@ -6666,159 +6652,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Wyczyść wszystkie wejścia</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished">Łamana</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>&amp;Dodaj</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>&amp;Edycja</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation>Enter</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>&amp;Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>W&amp;ytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>W&amp;klej</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;Zduplikuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished">Wejście</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished">Wprowadź</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished">Wyczyść</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished">Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6859,96 +6845,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6956,17 +6942,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished">Odwr</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished">NormalnyNOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6974,7 +6960,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6982,122 +6968,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished">---</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished">a&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished">a&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished">|a|&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished">|a|&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished">I (logiczne)</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished">Lub (logiczne)</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished">XOR (Logiczne)</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished">a=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished">a!=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished">a&gt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished">a&lt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished">a&gt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished">a&lt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished">d&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished">|d|&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished">a=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished">a~x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished">Timer</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished">Trwałe przełączenie</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished">Brzeg</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished">Nieznany</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7105,112 +7091,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation>Wartość 1</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation>Wartość 2</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation>Funkcja</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>Przełącznik &quot;I&quot;</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation>Czas trwania</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation>Opóźnienie</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">Stały</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished">Skopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished">Wytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished">Wklej</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished">Wyczyść</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished">Wprowadź</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished">Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished">W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished">Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation>(natychmistowy)</translation>
     </message>
@@ -7263,52 +7254,52 @@ Are you sure ?</source>
         <translation>Sesja lotów</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>Logi Telemetrii</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>Zmiana tytułu pilota</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>Nowy tytuł pilota:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>Zmiana oznaczenia osi</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>Nowe oznaczenie osi:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>Zmiana nazwy wykresu</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>Nowa nazwa wykresu:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7317,74 +7308,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 Kolumny wysokości &quot;GAlt&quot; i prędkości &quot;GSpd&quot; są opcjonalne</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Nie mogę zapisać pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>Wskaźnik A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>Wskaźnik B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>Delta czasu: %1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>Wznoszenie: %1 m/s</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>Wybierz plik logów</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>Dostępne pola</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>Wybrany plik zawiera %1 błędnych linii z %2 wszystkich linii</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>Czas trwania</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation>(L1)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation>(R1)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation>(L2)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation>(R2)</translation>
     </message>
@@ -7392,736 +7383,736 @@ Kolumny wysokości &quot;GAlt&quot; i prędkości &quot;GSpd&quot; są opcjonaln
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Plik załadowany</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation>Zamknij plik modeli i ustawień</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation>Lista użytych plików</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation>Profile radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation>Utwórz lub Wybierz Profile Radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation>Skasuj Aktualny Profil Radia...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation>Zakładkowane okna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation>Użyj zakładek do ustawienia otwartych okien.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation>Tytuł Okien</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation>Ustaw otwarte okna na całej dostępnej przestrzeni.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation>Okna kaskadowo</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation>Ustaw wszytkie otwarte okna na stosie.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation>Zamknij wszytkie okna</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation>Zamknij wszystkie otwarte pliki (zapytaj by zapisać jeśli trzeba).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation>Część tekstów nie będzie przetłumaczona do następnego uruchomienia Comapnion. Zwróć uwagę ze część tłumaczeń może nie być dokończona.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Plik zapisany</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation>Odczytaj Modele i Ustawienia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation>Funkcja niezaimplementowana jeszcze</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Nowy</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>Otwórz...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Zapisz</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Zapisz jako...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>Obejrzyj plik logów...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Otwórz i obejrzyj plik logów</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Edycja Ustawień</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Ustawienia...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation>Ctrl+Alt+L</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation>Ctrl+Alt+D</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation>Ctrl+Alt+R</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation>Alt+%1</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation> - Skopiuj</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation>Usunięcie profilu jest niemożliwe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation>Podstawowy profil nie może być usunięty.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation>Potwierdź usunięcie profilu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation>Jesteś pewien że chcesz wykasować profil radia %1? Nie ma możliwości cofnięcia tego działania!</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation>Kopiuj aktualny profil radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation>Uzyj języja bazowego systemu.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation>Użyj języka %1 (częsć tłumaczeń może być niekompletna).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>Monochromatyczny czarny wygląd ikon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Otwórz plik Modeli i Ustawień</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Wczytaj Modele i Ustawienia z radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>Zapisz Backup radia do pliku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Odczytaj Firmware radia do pliku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Utwórz nowy plik Modeli i Ustawień</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Zapisz plik Modeli i Ustawień</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>Klasyczny zestaw ikon Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>Monochromatyczny biały wygląd ikon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>Monochromatyczny niebieski wygląd ikon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Małe</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>Użyj małych ikon paska narzędzi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>Użyj normalnych ikon paska narzędzi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Normalne</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>Użyj dużych ikon paska narzędzi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Duże</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>Użyj olbrzymich ikon paska narzędzi</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Olbrzymie</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Edytor ekranu startowego radia...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>Edytuj ekran startowy swojego radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Odczytaj Firmware z radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>Odczytaj Firmware z radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Zapisz firmware do radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Zapisz firmware do radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Zapisz Modele i Ustawienia do radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Zapisz Modele i Ustawienia do radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Wczytaj Modele i Ustawienia z radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>Ustaw oprogramowanie komunikacyjne z radiem</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Zapisz Backup do radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Zbackupuj radio do pliku</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>Zachowaj kompletny plik backup wszystkich ustawień i danych modeli z radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>Ostatnie Pliki</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Ustaw wygląd ikon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Ustaw wielkość ikon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>Wybrany wygląd będzie użyty po ponownym uruchomieniu Comapnion.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>Jeśli uważasz, że ten program jest użyteczny, wesprzyj poprzez &lt;a href=&apos;%1&apos;&gt;donację&lt;/a&gt; </translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>O aplikacji Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Zakończ</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>Zsynchronizuj kartę pamięci</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>Monochromatyczny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>Mono-Biały</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>Mono-Niebieski</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>Język systemu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Porównaj modele...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Dodaj profil radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>Ustaw komunikację...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Żółty zaokrąglony miodowy motyw ikon</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>Zapis</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation>%2</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Porównaj modele</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Zakończ aplikację companion9x</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>O aplikacji companion9x</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>Klasyczny</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Zapisz Backup z pliku do radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>Synchronizacja karty SD</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation>Utwórz nowy Profil Ustawień Radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation>Zdupilkuj aktualny Profil Ustawień Radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation>Skasuj aktualny Profil Ustawień Radia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Ustaw język menu</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Plik</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Edycja</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Odczyt/Zapis</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Pomoc</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Gotowe</translation>
     </message>
@@ -8129,89 +8120,89 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Edycja modelu %1: </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Nie mogę odnaleźć pliku %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>Błąd otwarcia pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Zapisz jako</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation>Alt+Shift+E</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation>Ctrl+Alt+C</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation>Ctrl+Alt+V</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation>Alt+Shift+S</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation>Alt+R</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation>Alt+W</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation>Alt+U</translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8221,7 +8212,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8231,241 +8222,241 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation>Brak wyboru</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation>Edytuj model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation>Wytnij</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation>Skopiuj</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation>Wklej</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation>Wprowadź</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation>Edytuj ustawienia radia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation>Skopiuj ustawienia radia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation>Wklej ustawienia radia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation>Symulacja radia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Edycja</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation>Dodaj model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation>Model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation>Odtworzyć z backupu</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation>Kreator ustawień modelu</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation>Ustaw jako bazowy</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation>Wydrukuj model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation>Zasymuluj model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation>Duplikuj model</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation>Pokar pasek akcji radia</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation>Pokar pasek akcji modelu</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation>Nie moge dodać modelu, ostatni model z listy zostanie skasowany.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation>Nie moge dodać modelu, brak dostępnego miejsca.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation>Nie moge wkleić modelu, brak dostępnego miejsca.</translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
             <numerusform>Wykasuj %n wybrany model?</numerusform>
@@ -8474,117 +8465,117 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation>Nie moge powielić modelu, brak dostępnego miejsca.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Błąd odczytu pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 został zmieniony.
 Zapisać?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation>Wykasuj</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation>Alt+S</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished">Dodaj</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished">W górę</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation>Czy chcesz nadpisać główne ustawienia radia?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Nie mogę zapisać pliku tymczasowego!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>Otwórz plik backupu Modeli i Ustawień</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>nieprawidłowy binarny plik %1</translation>
     </message>
@@ -8592,143 +8583,148 @@ Zapisać?</translation>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8736,12 +8732,12 @@ Zapisać?</translation>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8754,201 +8750,167 @@ Zapisać?</translation>
         <translation>Dialog</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Źródło</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>Źródło miksera</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Waga</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Wyrównanie</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">Precyzja</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Uwzględnij trymer</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation>Zm-Gl</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Tak</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Krzywa</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Krzywa użyta do miksera</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Przełącznik użyty do miksera
-Jeśli pusty - mikser będzie stale aktywny.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Przełącznik</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Ostrzeżenie</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>Ostrzeżenie miksera.
-Ustawienie tej wartości spowoduje emitowanie dźwięku kiedy wartość będzie aktywna.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>Wyłącz</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 piknięcie</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2 piknięcia</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 piknięcia</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Połączenie</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Multiplexer
-
-Ustala w jaki sposób miksery są łączone.
-
-&quot;+&quot; oznacza dowanie wartości miksera do wcześniejszych mikserów na tym kanale.
-&quot;*&quot; oznacza mnożenie wartości miksera przez wcześniejsze miksery na tym kanale.
-&quot;R&quot; oznacza zastąpienie wartością miksera, wcześniejszych mikserów na tym kanale.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>Dodawaj</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>Pomnóż</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>Zastąp</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Fazy lotu</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>Dołącz DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">5x {0.00?}</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Opóźnienie</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Spowolnienie</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Do góry / (+)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Do dołu / (-)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8973,27 +8935,27 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Jeśli spowolnienie nie jest równe 0 wtedy prędkość miksera zostanie ustawiona na podaną wartość-&amp;gt; wartość oznacza liczbę sekund jaką mikser potrzebuje by pokonać drogę od -100 do 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation>Kliknij by uzyskać wyskakujące menu</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation>Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation>Ustaw wszystko</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation>Odwróć wszytko</translation>
     </message>
@@ -9001,22 +8963,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9024,136 +8986,136 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Wyczyść miksery</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>Za mało dostępnych mikserów!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>&amp;Dodaj</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation>Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>&amp;Edycja</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>Enter</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>&amp;Przełącz podświetlenie</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>&amp;Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation>Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation>Ctrl+X</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>&amp;Wytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>&amp;Wklej</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation>Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>&amp;Zduplikuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation>Ctrl+U</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>Wyczyść miksery?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>Czy na pewno wyczyścić wszystkie miksery?</translation>
     </message>
@@ -9161,19 +9123,24 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished">Źródło gazu</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation type="unfinished">THR</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9221,32 +9188,49 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
+        <translation type="unfinished">Wyłącz</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished">---</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9264,63 +9248,58 @@ p, li { white-space: pre-wrap; }
         <translation>Symulacja</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Ustawienia</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>Heli</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Wejścia</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Przełączniki logiczne</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Miksery</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Fazy lotu</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>Wyjścia</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Funkcje Specjalne</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Krzywe</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Telemetria</translation>
     </message>
@@ -9374,8 +9353,8 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Fazy lotu</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9411,585 +9390,595 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation>Exponential</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>Bardzo dokładny</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>Dokładny</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>Średni</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>Zgrubny</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation>Nieznany</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished">Aktywuj</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished">Tak</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished">Nie</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished">Y</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished">Włącz</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished">Tryb</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished">Kanały</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished">Opóźnienie PPM</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished">Polaryzacja</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished">Protokół</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished">Opóźnienie</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished">Odbiornik</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished">Podtyp</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished">Wartość opcjonalna</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation>120X</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation>140</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished">Fazy lotu</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished">Faza lotu</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished">Wszystkie</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished">Brzeg</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished">Trwałe przełączenie</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished">Timer</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished">Czas trwania</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished">Rozszerzone limity (125%)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished">Wyświetl Czeklistę</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished">Funkcje Globalne</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished">Automatyczne</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished">Tryb Failsafe</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished">Utrzymuj</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished">Brak impulsu</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished">BRAK</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished">Tryb grzybków</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished">Nigdy</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished">Zawsze</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished">Tylko trymy</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished">Tylko przyciski</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished">Przełączane</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished">Globalne</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished">Źródło</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished">Ostrzeżenie</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished">FrSky D</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished">FrSky D (kabel)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished">Wysokościomierz</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished">Wysokościomierz+</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished">Prędkość Pionowa</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished">A1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished">A2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished">A3</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished">A4</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished">FAS</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished">Cele</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished">Maks</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished">Liczby</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished">Paski</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished">Skrypt</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished">Nazwa pliku</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation>Wyrównanie(%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation>Wyłącz</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation>FM%1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation>FM%1%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation>FM%1+%2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation>Bez Trymera</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation>Bez DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>Wyłaczone we wszystkich fazach lotu</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation>natychmiastowy</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>Własny</translation>
     </message>
@@ -9997,27 +9986,27 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Samolot</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>Multikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Śmigłowiec</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Nazwa Modelu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Typ Modelu:</translation>
     </message>
@@ -10025,27 +10014,27 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished">Indeks</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Nazwa</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished">Model %1</translation>
@@ -10301,285 +10290,290 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished">Ujemna</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished">Port trenera</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished">Wewnętrzny moduł radiowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished">Zewnętrzny moduł radiowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished">System Radiowy Ekstra</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished">System radia</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10587,57 +10581,57 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation>Wartość</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>Utrzymuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>Brak impulsu</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10645,456 +10639,456 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>Wejście</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>Waga</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation>Długi cykl</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation>Boczny cykl</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>Pochylenie (Collective)</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>Fazy lotu</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>Faza lotu</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>Przełącznik</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished">Obrazek modelu</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished">Gaz</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished">Ostrzeżenie o przełącznikach</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished">Ostrzeżenie o potencjometrach</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished">Czas</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished">Odliczanie</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">Tryb</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished">Start</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished">Śmigłowiec</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Funkcja</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished">Protokół</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished">Wysokościomierz</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished">Źródło wario</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished">Górny pasek</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished">Źródło napięcia</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished">Źródło wysokości</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>Ustawiane przełączniki</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished">Parametry</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished">FG%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished">Funkcje Globalne</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation>ZG%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation>RE%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>Kanał</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished">Wyjścia</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished">Subtrim</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished">Krzywa</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished">Liniowa</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation>Maks</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>Zmienne globalne</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>Wejścia</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>Miksery</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>Krzywe</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation>L%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>Przełączniki logiczne</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>Funkcje Specjalne</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>Jednostka</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>Alarmy RSSI</translation>
     </message>
@@ -11102,7 +11096,7 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11110,22 +11104,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Kanał gazu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Kanał odchylenia:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Kanał kąta:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Kanał rotacji:</translation>
     </message>
@@ -11133,22 +11127,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished">Nieznany błąd</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished">,,, plus %1 błędów</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished">Nie mogę zapisać ustawień radia</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished">Nie mogę zapisać modelu %1</translation>
     </message>
@@ -11156,17 +11150,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Odcięcie Gazu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Timer Gazu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Timer Lotu</translation>
     </message>
@@ -11174,40 +11168,40 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Błąd otwarcia pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Błąd zapisu pliku %1:
@@ -11237,17 +11231,17 @@ p, li { white-space: pre-wrap; }
         <translation>Drukuj do pliku</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Drukuj dokument</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11274,12 +11268,12 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>Zamknij</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished">Przerwij</translation>
     </message>
@@ -11295,22 +11289,22 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11318,24 +11312,24 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11343,97 +11337,107 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished">Akcja</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished">Nowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11441,30 +11445,30 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Nie mogę zapisać pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished">Nie mogę skasować pliku tymczasowego: %1</translation>
     </message>
@@ -11472,12 +11476,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Wartość (wejściowa): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation>Podwójny klik PPM w celu zresetowania środka.</translation>
     </message>
@@ -11588,12 +11592,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
-        <translation type="unfinished">FM%1</translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished">ZG%1</translation>
     </message>
@@ -11609,358 +11618,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished">V</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished">s</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation type="unfinished">Trymer SK</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation type="unfinished">Trymer SW</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation type="unfinished">Trymer gazu</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation type="unfinished">Trymer lotek</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
-        <translation type="unfinished">Trymer 5</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
-        <translation type="unfinished">Trymer 6</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished">Bateria</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished">Czas</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished">Pokrętło :a</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished">Pokrętło :b</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished">LUA%1%2</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Źródło</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">Żadne</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation>↑</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation>↓</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation>!</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished">Pokrętło :a</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished">Pokrętło :b</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished">Włącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished">THs</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished">TH%</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished">THt</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished">Jeden</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished">----</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished">Przełącznik</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">Żadne</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation>Tak</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt; Kanał Steru Kierunku:</translation>
     </message>
@@ -11968,21 +12077,21 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Błąd otwarcia pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished">Błąd otwarcia pliku %1 w trybie zapisu:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11990,319 +12099,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished">Id</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished">Wystąpienie</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished">Wysokość</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished">Jednostka</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished">Precyzja</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished">Współczynnik</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished">Wyrównanie</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished">Wyrównanie automatyczne</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished">Mnożnik</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished">Filtr</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished">Obliczone</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished">Dodaj</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished">Średnio</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished">Mnożenie</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished">Całkowite</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished">Cela</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished">Zużycie</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished">Najniższy</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished">Cela %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished">Najwyższy</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished">Delta</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished">Bezwymiarowe (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished">V</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished">A</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished">mA</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished">kts</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished">m/s</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished">km/h</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished">mph</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished">m</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished">f</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished">°C</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished">°F</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished">mAh</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished">W</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished">mW</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished">dB</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished">rpms</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished">g</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished">°</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished">Rad</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished">ml</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished">godziny</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished">minuty</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished">sekundy</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12523,87 +12647,87 @@ Wolne obroty będą na górze, trymer i ostrzeżenie o otwartym gazie również 
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>Timer %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished">Skopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished">Wytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished">Wklej</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished">Wyczyść</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished">Wprowadź</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished">Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished">W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished">Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12611,7 +12735,7 @@ Wolne obroty będą na górze, trymer i ostrzeżenie o otwartym gazie również 
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Kanał Steru Wysokości:</translation>
     </message>
@@ -12619,204 +12743,204 @@ Wolne obroty będą na górze, trymer i ostrzeżenie o otwartym gazie również 
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation>zrzut ekranu</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation>ENTER</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation>PG-UP</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation>PG-DN</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation>DEL</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation>BKSP</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation>ESC</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation>INS</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;+&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;-&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ WYJŚCIE ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ GÓRA ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ DÓŁ ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</translation>
     </message>
@@ -12824,115 +12948,115 @@ Wolne obroty będą na górze, trymer i ostrzeżenie o otwartym gazie również 
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished">Dostępne profile:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished">ID: </translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished">Dostępne radia:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished">Profil radia lub ID użyte w symulatorze.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished">Typ radia do symulacji (zwykle zdefiniowane w profilu).</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished">Osrzeżenie: nie mogę zainicjalizować SDL:
 %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished">BŁĄD: biblioteki symulatora niedostępne.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
@@ -12941,7 +13065,7 @@ ID Profilu: [%1]; ID Radia: [%2];
 Plik Danych: [%3]</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished">BŁĄD: Porfil radia lub fimware symulatora nie znalezione. ID Profilu: [%1]; ID Radia: [%2]</translation>
@@ -12951,8 +13075,8 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
-        <translation>Symulator OpenTX</translation>
+        <source>EdgeTX Simulator</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
@@ -13100,74 +13224,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation>Ustaw stałą wysokość widgetu radia.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation>BŁĄD: Nieudane utoerzenie interfacu symulatora, mozliwa zła lub brakująca biblioteka.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation>Alt+T</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation>Wyjścia radia</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation>F2</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation>Symulator telemetrii</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation>F4</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation>Symulator trenera</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation>F5</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation>Wyjście debugera</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation>F6</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation>&lt;b&gt;Sterowanie Symulatora:&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation>&lt;tr&gt;&lt;th&gt;Klawisz/Mysz&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation>Pomoc Symulatora</translation>
     </message>
@@ -13295,32 +13419,32 @@ Domyślny jest skonfigurowany w wybranym Profilu Radia.</translation>
         <translation>Scieżka SD</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation>Wszytkie pliki (*.*)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished">Wybierz plik danych</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished">Wybierz katalog danych</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished">Wybierz folder obrazu karty SD</translation>
     </message>
@@ -13333,69 +13457,74 @@ Domyślny jest skonfigurowany w wybranym Profilu Radia.</translation>
         <translation>Symulator Companion</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation>Symulator Radia (%1)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation>Nie mogę ustalić startowego źródła danych.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation>Nie mogę załadować danych, prawdopodobnie zły format.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation>Błąd odczytu danych</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation>Dostarczone błędne dane startowe. Proszę określić prawidłowy plik/ścieżkę.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation>Błąd startu symulatora</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation>Błąd zapisu danych: nie mogę otworzyć pliku do zapisu: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation>Błąd zapisu danych: nie mogę pobrać danych z interfacu symulatora.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation>Nastąpił nieoczekiwany błąd w trakcie próby zapisu danych radia do pliku &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation>Błąd zapisu danych</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation>Nie mogę otworzyć joysticka, dezaktywowany</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation>Błąd Firmware Radia: %1</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
-        <translation> - Faza lotu %1 (#%2)</translation>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -13420,17 +13549,17 @@ Domyślny jest skonfigurowany w wybranym Profilu Radia.</translation>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>Biblioteka obrazków - strona %1 z %2</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>Nieprawidłowy obrazek w bibliotece %1</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>Nie znaleziono prawidłowego obrazka w bibliotece, sprawdź ustawienia</translation>
     </message>
@@ -13438,7 +13567,7 @@ Domyślny jest skonfigurowany w wybranym Profilu Radia.</translation>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>Kanał %1</translation>
     </message>
@@ -13446,7 +13575,7 @@ Domyślny jest skonfigurowany w wybranym Profilu Radia.</translation>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished">Nie mogę odnaleźć pliku %1!</translation>
     </message>
@@ -13455,9 +13584,9 @@ Domyślny jest skonfigurowany w wybranym Profilu Radia.</translation>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13482,19 +13611,19 @@ Domyślny jest skonfigurowany w wybranym Profilu Radia.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13503,47 +13632,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13551,141 +13680,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13693,17 +13822,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>Kanał Steru Kierunku:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Kanał Steru Wysokości:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>TYlko jeden kanał jest dostepny!&lt;br&gt;Prawdopoobnie musisz skonfigurować swój model bez użycia konfiguratora.</translation>
     </message>
@@ -13711,22 +13840,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Ster Wysokości i Ster Kierunku</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Tylko Ster Wysokości</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>Usterzenie motylkowe</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Typ ogona:</translation>
     </message>
@@ -14058,7 +14187,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">Panel Telemetrii %1</translation>
     </message>
@@ -14066,28 +14195,965 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Alarm niski</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Alarm krytyczny</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation>Winged Shadow How High</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (Nie obsługiwane)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Formularz</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished">RxBt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished">km/h</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Pr.Wznoszenia</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Kurs</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished">Stopnie</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished">Szer. Dł.
+(dec.deg)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished">Pr.w.Ziemi</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished">mAh</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">Natężenie</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Wysokość</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Formularz</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished">Cele</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished">Ilość Paliwa</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished">Wys</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished">Napięcie</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished">ml</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished">A4</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished">Prędk. Pow</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished">°C</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished">Wolty</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">Tmp1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished">RxBt</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished">Stopnie</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished">km/h</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished">V / współczynnik</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished">dd-MM-yyyy
+hh:mm:ss</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished">Metry</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">Tmp2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished">RPM</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Pr.Wznoszenia</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished">Szer. Dł.
+(dec.deg)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished">A3</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Paliwo</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Kurs</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">Natężenie</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished">Ampery</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Wysokość</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished">Pr.w.Ziemi</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">Formularz</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Paliwo</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished">RPM</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">Tmp2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">Pr.Wznoszenia</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Kurs</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished">°C</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished">Data</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished">m/s</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished">A2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished">Bateria</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished">Wys</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished">A1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished">Napięcie</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">Tmp1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished">%</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Wysokość</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished">Stopnie</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">Natężenie</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished">Pr.w.Ziemi</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished">GPS</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished">Szer. Dł.
+(dec.deg)</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished">dB</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14204,72 +15270,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished">Skopiuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished">Wytnij</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished">Wklej</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished">Wyczyść</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished">Wprowadź</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished">Wykasuj</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished">W górę</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished">W dół</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished">Wyczyść wszytko</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14282,358 +15348,125 @@ Too many errors, giving up.</source>
         <translation>Symulator telemetrii</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation>Napięcie</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation>RSSI</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation>A1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation>A2</translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
         <translation>Symulacja</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished">dB</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished">25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation>Odtwórz plig logów z SD</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation>Współczynnik odtwarzania</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation>Załaduj</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation>|&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation>&lt;|</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation>&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation>&lt;-</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation>Czysty # 
 Timestamp</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation>1/5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation>5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation>Nie jest załadowany żaden plik logu</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation>V / współczynnik</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation>RxBt</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation>Tmp1</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation>A3</translation>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation>A4</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation>Tmp2</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>Paliwo</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation>°C</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation>ml</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation>%</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation>Metry</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation>Wysokość</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation>Pr.Wznoszenia</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation>m/s</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation>Ilość Paliwa</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation>km/h</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation>Kurs</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation>Prędk. Pow</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation>GPS</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation>Szer. Dł.
-(dec.deg)</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation>AccX</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation>dd-MM-yyyy
-hh:mm:ss</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation>Data</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation>Ampery</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation>AccZ</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation>Wys</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation>Wolty</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation>Cele</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation>Natężenie</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation>AccY</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation>Pr.w.Ziemi</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation>Stopnie</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation>RPM</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
@@ -14641,78 +15474,35 @@ hh:mm:ss</translation>
         <translation>Kiedy aktywne, wysyła jakiekolwiek dane jako symulację danych telemetrii.</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation>Plik Logu</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation>Pliki LOGu (*.csv)</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
         <translation>BŁĄD - błędny plik</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Tak</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;Kanał gazu:</translation>
     </message>
@@ -14738,138 +15528,138 @@ hh:mm:ss</translation>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished">Timer %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished">Cisza</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">Dźwięk</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">Komunikaty głosowe</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">Wibracje</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished">5s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished">10s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished">20s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished">30s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">Niestałe</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">Stałe (lot)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished">Lot</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">Stałe (Ręczny reset)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">Włącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished">Start</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished">THs</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished">TH%</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished">THt</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14877,22 +15667,22 @@ hh:mm:ss</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Suma)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Zastąpienie)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished">Kan %1</translation>
     </message>
@@ -14900,27 +15690,27 @@ hh:mm:ss</translation>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">Tryb</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Waga</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Źródło</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished">Mnożnik</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished">Kalibracja</translation>
     </message>
@@ -14931,6 +15721,210 @@ hh:mm:ss</translation>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
         <translation>Symulator trenera</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">nieznany</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -14957,47 +15951,47 @@ hh:mm:ss</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15010,22 +16004,42 @@ hh:mm:ss</translation>
         <translation type="unfinished">Firmware</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15033,285 +16047,317 @@ hh:mm:ss</translation>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished">nieznany</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15327,63 +16373,90 @@ hh:mm:ss</translation>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15476,32 +16549,32 @@ hh:mm:ss</translation>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15514,22 +16587,22 @@ hh:mm:ss</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15542,22 +16615,22 @@ hh:mm:ss</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15581,17 +16654,17 @@ hh:mm:ss</translation>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15599,37 +16672,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15745,32 +16818,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15778,32 +16851,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">Informacja</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished">Górny pasek</translation>
     </message>
@@ -15811,12 +16884,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>Pierwszy Kanał Ogona:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>Drugi Kanał Ogona:</translation>
     </message>
@@ -15824,55 +16897,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation>Trzymaj Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
-        <translation>Trzymaj pionową pozycję drążka.</translation>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation>Ustal Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation>Zabroń pionowego ruchu drążka.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation>Ustal X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation>Zabroń poziomego ruchu drążka.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
         <translation>Trzymaj X</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
-        <translation>Trzymaj poziomą pozycję drążka.</translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Standardowe Skrzydło</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Latające skrzydło / Delta</translation>
     </message>
@@ -15880,22 +16953,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15903,273 +16976,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Kreator ustawień modelu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Typ modelu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Wprowadź nazwę modelu i typ.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Gaz</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>Czy Twój model posiada silnik?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Rodzaj Skrzydeł</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>Czy Twój model jest latającym skrzydłem/deltą czy posiada standardowe skrzydła?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>Lotki</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>Czy Twój model posiada lotki?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Klapy</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>Czy Twój model posiada klapy?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Hamulce aerodynamiczne</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>Czy Twój model posiada hamulce aerodynamiczne?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Latające skrzydło / Delta</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Wybierz kanały Elevon</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Ster Kierunku</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>Czy Twój model posiada ster kierunku?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Typ Ogona</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Wybierz typ ogona Twojego modelu.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Ogon</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Wybierz kanały kontrolujące ogon.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>Motylkowy</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Wybierz kanał Steru Wysokości.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>Okresowy</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>Jaki typ sterowania tarczy ma Twój śmigłowiec?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>Gyro ogonowe</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>Czy Twój śmigłowiec posiada regulowane Gyro ogonowe?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>Typ Wirnika</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>Czy Twój model posiada flybar?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Śmigłowiec</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>Wybierz sterowanie Twojego śmigłowca</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>Wielowirnikowiec</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Wybierz sterowanie Twojego wielowirnikowca</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Opcje Modelu</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Wybierz dodatkowe opcje</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation>Zapisz Zmiany</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Ręcznie sprawdź kierunki działania płaszczyzn sterowych i odwróć kanał którego kontrola działa w nieprawidłowym kierunku. Zdemontuj śmigło(a) przed sprawdzeniem pierwszy rac Twojego modelu.&lt;br&gt; Uwaga: kontynuacja usunie stare ustawienia modelu!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Wprowadź nazwę modelu i typ.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Wybierz kanał odbiornika który kontroluje ESC/serwo gazu.&lt;br&gt;&lt;br&gt;Gaz - Spektrum: Kn1, Futaba: Kn3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>Większość samolotów posiada powierzchnie sterowe na skrzydłach i ogonie. Latające skrzydło oraz delta posada tylko sterowanie na skrzydłach. Główne powierzchnie sterowe standardowych skrzydeł powodują obrót samolotu w osi podłużnej. Są to lotki.&lt;br&gt; Powierzchnie sterowe na skrzydle w delcie i latającym skrzydle działają jako lotki i ster wysokości. Są to sterolotki.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>Większość modelu używa jednego lub 2ch kanałów do sterowania lotkami.&lt;br&gt;&lt;br&gt;Przez tzw. Y-kabel mogą być kontrolowane 2 serwa na jednym kanale. Jeśli używasz Y-kabla wybierz opcję z jednym serwem.&lt;br&gt;&lt;br&gt; Lotki - Spektrum: Kan2, Futaba: Kan1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>Modele używają dwóch kanałów do kontrolowania sterolotek.&lt;br&gt;Wybierz dwa kanały</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>Kreator uznaje że kontroluje klapy tylko przełącznikiem. Jeśli chcesz kontrolować klapy potencjometrem możesz zmienić to ręcznie później.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>Hamulce aerodynamiczne są używane do zmniejszenia prędkości szybowca.&lt;br&gt; Sa bardzo rzadko używane w innych typach samolotów.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Wybierz kanał odbiornika który kontroluje Ster Kierunku.&lt;br&gt;&lt;br&gt;Ster Kierunku - Spektrum: Kn4, Futaba: Kn4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Wybierz typ ogona Twojego modelu.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Wybierz kanały sterów wysokości i kierunku.&lt;br&gt;&lt;br&gt;Ster Kierunku - Spektrum: Kn4, Futaba: Kn4&lt;br&gt;Ster Wysokości - Spektrum: Kn3, Futaba: Kn2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Wybierz kanał Steru wysokości.&lt;br&gt;&lt;br&gt;Ster Wysokości - Spektrum: Kn3, Futaba: Kn2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation>TBD.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Wybierz kanały kontroli Twojego wielowirnikowca.&lt;br&gt;&lt;br&gt;Gaz - Spektrum: Kn1, Futaba: Kn3&lt;br&gt;&gt;Odchylenie - Spektrum: Kn4, Futaba: Kn4&lt;br&gt;Kąt - Spektrum: Kn3, Futaba: Kn2&lt;br&gt;Rotacja - Spektrum: Kn2, Futaba: Kn1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>Brak pomocy dla aktualnej strony.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Pomoc kreatora modelu</translation>
     </message>
@@ -16177,37 +17250,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>Samolot</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>Multikopter</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>Śmigłowiec</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>Nazwa Modelu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>Typ Modelu:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>Opcje:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>Kanał %1:</translation>
     </message>
@@ -16215,47 +17288,47 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">Błąd otwarcia pliku %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished">Błąd otwarcia pliku %1 w trybie zapisu:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16263,16 +17336,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16281,10 +17357,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16394,18 +17485,18 @@ m2560 dla platformy V4</translation>
         <translation>Port szeregowy sam-ba</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>Konfiguracja DFU-UTIL</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>Konfiguracja SAM-BA</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Wybierz położenie</translation>
     </message>
@@ -16443,7 +17534,7 @@ m2560 dla platformy V4</translation>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>Następny</translation>
     </message>
@@ -16453,65 +17544,65 @@ m2560 dla platformy V4</translation>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation>Nieprzypisany</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation>Brak joysticka</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>Nie mogę otworzyć joysticka.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation>W celu uruchomeinia procedury kalibracji wciśnij przycisk Start.
 W każdej chwili możesz zmienić przypisanie kanału lub rewers.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation>Porusz drążkami i potencjometrami we wszytkich kierunkach po oporach
 Wciśnij Dalej kiedy skończysz</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation>Wyśrodkuj drążki i potencjomety.
 Wciśnij Dalej kiedy skończysz</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation>Zmapuj kanały joystika do elementów sterujących używając pól kombi.
 Wciśnij Dalej kiedy skończysz.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation>Zaznacz pola wyboru rewersu jeśli konieczne jest odwrócenie działania.
 Wciśnij Dalej kiedy skończysz.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation>Naciśnij OK w celu zapisania konfiguracji
 Naciśnij Porzuć w celu zakończyć kalibrację joystika bez zapisu.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation>Kalibracja nie zakończona, zapisać mimo to?</translation>
     </message>

--- a/companion/src/translations/companion_pt.ts
+++ b/companion/src/translations/companion_pt.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -60,23 +60,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -169,22 +169,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation type="unfinished">Ordem dos Canais por Defeito</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation type="unfinished">Modo do Rádio por Defeito</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -207,662 +207,657 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Modo 1 (RUD ELE THR AIL)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Modo 2 (RUD THR ELE AIL)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Modo 3 (AIL ELE THR RUD)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Modo 4 (AIL THR ELE RUD)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation type="unfinished">Parâmetros Gerais</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,29 +865,29 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -930,33 +925,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -967,255 +962,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished">Interruptor</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Função</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1223,17 +1228,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1241,132 +1246,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished">INV</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1409,56 +1414,56 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1474,12 +1479,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,173 +1492,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished">Aviso</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished">Erro</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1691,22 +1706,22 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation type="unfinished">Imprimir Documento</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1732,7 +1747,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1740,17 +1755,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1758,22 +1773,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1856,32 +1871,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1889,7 +1904,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1897,22 +1912,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1920,113 +1935,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2034,343 +2049,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished">%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation type="unfinished">Fonte</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2378,123 +2413,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation type="unfinished">Interruptor</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2502,22 +2537,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2525,47 +2560,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2622,82 +2657,82 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2705,22 +2740,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2728,53 +2763,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished">Interruptor</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished">Fonte</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2782,52 +2817,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished">Inactivo</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished">Activo</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2906,101 +2941,82 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3009,12 +3025,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3022,12 +3038,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3035,12 +3051,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3048,40 +3064,40 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3089,23 +3105,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3113,110 +3129,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation type="unfinished">Peso</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation type="unfinished">Desvio</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation type="unfinished">A fonte para a mistura</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation type="unfinished">Interruptor</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation type="unfinished">Fonte</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation type="unfinished">Incluir Ajustes (Trim)</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3226,22 +3227,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3249,22 +3250,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3272,262 +3273,262 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished">Fechar</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3535,367 +3536,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3903,27 +3948,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3932,7 +3977,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3997,49 +4042,49 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4117,103 +4162,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4221,83 +4266,83 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation type="unfinished">FUSES: Baixo=%1 Alto=%2 Ext=%3 </translation>
     </message>
@@ -4305,7 +4350,7 @@ You are currently using:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4356,225 +4401,240 @@ You are currently using:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4582,17 +4642,17 @@ You are currently using:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4600,17 +4660,17 @@ You are currently using:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4618,17 +4678,17 @@ You are currently using:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4636,13 +4696,13 @@ You are currently using:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4660,17 +4720,18 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4680,7 +4741,12 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4688,8 +4754,13 @@ You are currently using:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4785,13 +4856,13 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4799,43 +4870,33 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4853,12 +4914,12 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Parâmetros</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4873,47 +4934,47 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4952,7 +5013,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
+        <source>%1 Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4989,185 +5050,208 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished">Interruptor</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished">Activo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">Modo 1 (RUD ELE THR AIL)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished">Modo 2 (RUD THR ELE AIL)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">Modo 3 (AIL ELE THR RUD)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">Modo 4 (AIL THR ELE RUD)</translation>
     </message>
 </context>
 <context>
@@ -5183,201 +5267,199 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation type="unfinished">seg.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5385,7 +5467,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5395,72 +5477,72 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5483,222 +5565,82 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished">Modo 1 (RUD ELE THR AIL)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished">Modo 2 (RUD THR ELE AIL)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished">Modo 3 (AIL ELE THR RUD)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished">Modo 4 (AIL THR ELE RUD)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5706,295 +5648,328 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation type="unfinished">Modo do Emissor</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation type="unfinished">Ordem dos Canais por Defeito</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation type="unfinished">v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation type="unfinished">Temporizador de Inatividade</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation type="unfinished">Contraste</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation type="unfinished">Alerta de Bateria</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation type="unfinished">min.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6009,92 +5984,92 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation type="unfinished">Modo dos Alarmes Sonoros</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6105,12 +6080,14 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6118,179 +6095,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6298,17 +6275,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6316,118 +6293,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Inverter</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6508,22 +6495,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6531,18 +6518,18 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
@@ -6551,159 +6538,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="52"/>
         <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <source>Ctrl+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation type="unfinished">&amp;Adicionar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation type="unfinished">Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation type="unfinished">&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation type="unfinished">Enter</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation type="unfinished">&amp;Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation type="unfinished">Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation type="unfinished">Co&amp;lar</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation type="unfinished">Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6744,96 +6731,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6841,17 +6828,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished">INV</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished">NOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6859,7 +6846,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6867,122 +6854,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished">Temporizador</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6990,112 +6977,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation type="unfinished">Atraso</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation type="unfinished">Função</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7148,125 +7140,125 @@ Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7274,736 +7266,736 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Ficheiro carregado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Ficheiro gravado</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Sair da aplicação</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>Sobre a aplicação</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation type="unfinished">%2</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation type="unfinished">Fechar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Ficheiro</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Pronto</translation>
     </message>
@@ -8011,83 +8003,83 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished">Alt+S</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation type="unfinished">
@@ -8096,7 +8088,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation type="unfinished">
@@ -8105,195 +8097,195 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -8301,166 +8293,166 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>A editar o modelo %1:</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Impossível encontrar o ficheiro %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Editar</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Gravar Como</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Impossível gravar ficheiro temporário!</translation>
     </message>
@@ -8468,143 +8460,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8612,12 +8609,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8630,87 +8627,90 @@ Do you want to save your changes?</source>
         <translation>Dialogo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Fonte</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>A fonte para a mistura</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Peso</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <oldsource>The value of the mixer is multiplied by this value and divided by 100.</oldsource>
-        <translation type="unfinished">O valor da mistura é multiplicado por este valor e dividido por 100.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Desvio</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Incluir Ajustes (Trim)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Curva</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Curva a usar pela mistura</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Interruptor</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8725,135 +8725,104 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 Beep</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <oldsource>2 Beeo</oldsource>
-        <translation type="unfinished">2 Beeps</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 Beeps</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Multiplexar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>ADICIONAR</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>MULTIPLICAR</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>SUBSTITUIR</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Atraso</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Lento</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Cima</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Baixo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8861,22 +8830,22 @@ This determines how mixer values are added.
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8884,136 +8853,136 @@ This determines how mixer values are added.
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
-        <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="47"/>
         <location filename="../modeledit/mixes.cpp" line="441"/>
+        <source>Ctrl+Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation type="unfinished">&amp;Adicionar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation type="unfinished">Ctrl+A</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation type="unfinished">&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation type="unfinished">Enter</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation type="unfinished">&amp;Copiar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation type="unfinished">Ctrl+C</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation type="unfinished">Co&amp;lar</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation type="unfinished">Ctrl+V</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9021,19 +8990,24 @@ This determines how mixer values are added.
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation type="unfinished">THR</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9081,32 +9055,49 @@ This determines how mixer values are added.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9119,64 +9110,59 @@ This determines how mixer values are added.
         <translation>Dialogo</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Configuração</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Misturas</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Curvas</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9234,7 +9220,7 @@ This determines how mixer values are added.
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
+        <source>%1 Modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9271,585 +9257,595 @@ This determines how mixer values are added.
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation type="unfinished">Exponencial</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation type="unfinished">Extra-fino</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation type="unfinished">Fino</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation type="unfinished">Médio</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation type="unfinished">Aberto</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished">Canais</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished">Protocolo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished">Atraso</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished">Temporizador</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished">Fonte</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished">Aviso</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9857,27 +9853,27 @@ This determines how mixer values are added.
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9885,27 +9881,27 @@ This determines how mixer values are added.
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10161,285 +10157,290 @@ This determines how mixer values are added.
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10447,57 +10448,57 @@ This determines how mixer values are added.
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10505,456 +10506,456 @@ This determines how mixer values are added.
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation type="unfinished">Interruptor</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation type="unfinished">Min</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation type="unfinished">Max</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished">Acelerador</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation type="unfinished">Peso</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished">Curva</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation type="unfinished">Curvas</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Função</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished">Activo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished">Protocolo</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10962,7 +10963,7 @@ This determines how mixer values are added.
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10970,22 +10971,22 @@ This determines how mixer values are added.
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10993,22 +10994,22 @@ This determines how mixer values are added.
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11016,17 +11017,17 @@ This determines how mixer values are added.
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11034,40 +11035,40 @@ This determines how mixer values are added.
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11095,17 +11096,17 @@ This determines how mixer values are added.
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation type="unfinished">Imprimir Documento</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11132,12 +11133,12 @@ This determines how mixer values are added.
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation type="unfinished">Fechar</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11153,22 +11154,22 @@ This determines how mixer values are added.
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11176,24 +11177,24 @@ This determines how mixer values are added.
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11201,97 +11202,107 @@ This determines how mixer values are added.
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11299,29 +11310,29 @@ This determines how mixer values are added.
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11329,12 +11340,12 @@ This determines how mixer values are added.
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11430,12 +11441,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11451,358 +11467,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Fonte</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished">Interruptor</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11810,19 +11926,19 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11830,319 +11946,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished">Desvio</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12361,87 +12492,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12449,7 +12580,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12457,204 +12588,204 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12662,121 +12793,121 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
@@ -12786,7 +12917,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -12935,74 +13066,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13127,32 +13258,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13165,68 +13296,73 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13252,17 +13388,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13270,7 +13406,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13278,7 +13414,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished">Impossível encontrar o ficheiro %1!</translation>
     </message>
@@ -13287,9 +13423,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13314,19 +13450,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13335,47 +13471,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13383,141 +13519,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13525,17 +13661,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13543,22 +13679,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13890,7 +14026,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13898,28 +14034,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14036,72 +15105,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14114,305 +15183,118 @@ Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14421,127 +15303,40 @@ Timestamp</source>
         <translation type="unfinished">Simular</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
         <source>When enabled, sends any non-blank values as simulated telemetry data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14567,138 +15362,138 @@ Timestamp</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14706,22 +15501,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
@@ -14729,27 +15524,27 @@ Timestamp</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Peso</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Fonte</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14759,6 +15554,210 @@ Timestamp</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14786,47 +15785,47 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14839,22 +15838,42 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14862,285 +15881,317 @@ Timestamp</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15156,63 +16207,90 @@ Timestamp</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15305,32 +16383,32 @@ Timestamp</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15343,22 +16421,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15371,22 +16449,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15410,17 +16488,17 @@ Timestamp</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15428,37 +16506,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15574,32 +16652,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15607,32 +16685,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15640,12 +16718,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15653,55 +16731,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation type="unfinished">Fixar Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation type="unfinished">Fixar X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15709,22 +16787,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15732,273 +16810,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation type="unfinished">Acelerador</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation type="unfinished">Leme</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16006,37 +17084,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -16044,45 +17122,45 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16090,16 +17168,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16108,10 +17189,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16203,18 +17299,18 @@ Please only use this if you know what you are doing.  There are no error checks 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Selecionar localização</translation>
     </message>
@@ -16264,59 +17360,59 @@ m2560 for v4.1 boards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16326,7 +17422,7 @@ Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_ru.ts
+++ b/companion/src/translations/companion_ru.ts
@@ -4,27 +4,27 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Да, управляются одним каналом</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translation>Да, управляются двумя каналами</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;Первый канал элеронов:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>Второй канал элеронов:</translation>
     </message>
@@ -32,27 +32,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Да, управляются одним каналом</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>Да, управляются двумя каналами</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;Первый канал воздушного тормоза:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>Второй канал воздушного тормоза:</translation>
     </message>
@@ -60,24 +60,24 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation>Настройки приложения сохранены в
  %1</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation>Не удалось сохранить настройки приложения в файл &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation>файл нельзя сохранить (проверьте права доступа).</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation>причина неизвестна.</translation>
     </message>
@@ -170,35 +170,35 @@
         <translation>Профиль передатчика</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translation>Порядок каналов</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>Режим стиков (мода)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translation>Выбрать картинку</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>Выбрать папку</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -239,649 +239,644 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translation>Заставка при включении</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>Папка с резервными копиями. Относится к выбранному профилю, переопределяет настройки приложения</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>Резервное копирование</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>Переопределяет папку, заданную в настройках приложения</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>Переопределяет настроки приложения</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Порядок каналов&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Задает порядок микшеров при создании новой модели.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation>Язык</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation>Запрос на запись прошивки в радио после обновления</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished">Параметры</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation>Добавьте номер версии к имени файла встроенного ПО</translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation>Запрос на запуск SD-синхронизации после обновления</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation>Показать заставку</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation>Запрос на ввод профиля радио</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation>Удаляйте пустые слоты для моделей при удалении моделей (применяется только для радио без надписей)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation>Запрос на запуск программы установки после обновления</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation>Обновление</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished">Профили передатчиков</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>Усиление звука в симуляторе</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation>Сохранение положения тумблера/потенциомеира при выходе из симулятора</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation>Очистить сохраненные позиции</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation>Обновить настройки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation>Частота проверки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation>Сброс к значениям по умолчанию</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation>Папки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation>Загрузка</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation>Создайте папки в папке загрузки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation>Распаковывать</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation>Используйте структуру SD радиопрофиля</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation>Компоненты</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation>удалить загрузки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation>Удалить распаковки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation>Регистрация</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>Название профиля</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>Убрать картинку</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>Тип передатчика</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>Другие настройки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>Основные настройки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>Папка с содержимым SD</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>Настройки приложения</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>Автоматически делать резервную копию перед обновлением прошивки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>Галерея изображений</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Запуск Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>Показывать только пользовательские изображения</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>Показывать встроенные и пользовательские изображения</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>Пользовательские заставки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>Папка для резервн. копий</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>Настройки симулятора</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>Подсветка в симуляторе</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>Включить</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation>часто используемых файлов</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation>Запуск приложения</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation>Запомнить</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Это опция нужна, чтобы при удалении или перемещении модели сохранить поведение как старых версиях OpenTX. &lt;/p&gt;&lt;p&gt;Если отключить, то при удалении модели другие модели могут быть перемещены, чтобы убрать пустые слоты&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation>Папка с журналами</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation>Журнал событий</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>Указать файл</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation>Создание новой модели</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation>Приложения (Компаньон/Симулятор)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Сохранение всех сообщений прошивки запущенной в симуляторе. Это те же сообщения, что вы можете увидеть в симуляторе, в окне &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation>Прошивки передатчика (в симуляторе)</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation>Версии обновлений</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>Синяя</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>Зеленая</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>Красная</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>Оранжевая</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>Желтая</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation>Папка для скриншотов</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>Джойстик</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>Калибровка</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>Не сохранять, только копировать в буфер обмена</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Мой передатчик</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Если есть несохраненные изменения, то нельзя поменять тип передатчика и параметры прошивки. Что делать?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Сохранить все&lt;/i&gt; - Сохранить все открытые файлы, прежде чем менять настройки.&lt;li&gt;&lt;li&gt;&lt;i&gt;Сбросить&lt;/i&gt; - Перед сохранением вернуть все настройки назад.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Отмена&lt;/i&gt; - Ничего не делать, вернуться к настройкам..&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation>Настройки обновления: отсутствует путь к папке загрузки!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation>Обновить настройки: отсутствует путь к папке распаковки!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation>Настройки обновления: отсутствует путь к папке обновления!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation>Обновить настройки: папки распаковки и загрузки имеют одинаковый путь!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Джойстик не найден</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>ПУСТО: в профиле нет настроек аппаратуры</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>ДОСТУПНО: Настройки радио неизвестного возраста</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>ДОСТУПНО: Настройки радиоприемника сохранены %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation>Сбросьте все настройки обновления до значений по умолчанию. Ты уверен?</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation>Настройки обновления были сброшены. Пожалуйста, закройте и перезапустите Компаньон, чтобы избежать неожиданного поведения!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation>Выберите папку для загрузки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation>Выберите папку для распаковки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation>Выберите папку назначения обновления</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation>Проверка</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Выберите папку</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Выберите папку для резервного копирования моделей и настроек</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation>Выберите папку для хранения журнала событий</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Выбрать исполняемый файл Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Выберите папку, в которой хранится содержимое SD карточки</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Выберите изображение</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Изображения (%1)</translation>
     </message>
@@ -889,31 +884,31 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation>Ошибка чтения %1: %2</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation>Не удалось сохранить EEPROM</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Не удалось открыть файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Ошибка при записи файла %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation>Неправильный бинарный EEPROM файл %1</translation>
     </message>
@@ -951,33 +946,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -988,255 +983,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished">Тумблер</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">Функция</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">Стандартный</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">Маленькие</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">Обе</translation>
     </message>
@@ -1244,17 +1249,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation>Отрицательный промежуток</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation>Среднее значение</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation>Положительный промежуток</translation>
     </message>
@@ -1262,132 +1267,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished">Название</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished">Субтриммер</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished">Мин</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished">Макс</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished">Направление</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">Кривая</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation>Сюжет</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation>PPM Центр</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished">Линайный субтриммер</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation>Доступно всплывающее меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation>Удалить канал. Ты уверен?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation>Вырезать канал. Ты уверен?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation>Очистить</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation>Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation>Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation>Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation>Очистить канал. Ты уверен?</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation>Очистить все каналы. Ты уверен?</translation>
     </message>
@@ -1430,61 +1435,61 @@ Error description: %4</source>
         <translation>Файл: неизвестен</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation>Открыть контрольную карту</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation>Контрольные карты (*.txt)</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation>Не удается открыть файл для записи %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation>Не удается выполнить запись в файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Не удается записать файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation>Не удалось открыть файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Не удается прочитать файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation>Строка %1, столбец %2</translation>
     </message>
@@ -1500,12 +1505,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation>пользовательский интерфейс</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation>Основной вид %1</translation>
     </message>
@@ -1513,174 +1518,184 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation>Сохраненные настройки не удалось импортировать, пожалуйста, повторите попытку или продолжайте с текущими настройками.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation>Импорт из файла</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation>Не импортируйте</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation>Мы нашли возможные файлы резервной копии сопутствующих настроек.
 Вы хотите импортировать настройки из файла?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation>Импортируйте настройки из файла или начните с текущих значений.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation>Выбор %1:</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation>Сохраните настройки приложения в файл...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation>Загрузите настройки приложения из файла или предыдущей версии...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation>Сбросьте ВСЕ настройки приложения по умолчанию и удалите профили радиосвязи...</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation>Выйдите перед инициализацией настроек и запуском приложения.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation>Выведите номер версии и завершите работу.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation>Распечатайте этот текст.</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation>Сбросить ВСЕ настройки приложения к значениям по умолчанию и удалить профили радиосвязи, вы уверены?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation>Хотели бы вы сначала выполнить резервное копирование?</translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation>Настройки приложения были сброшены и сохранены.</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished">EdgeTX Компаньон</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation>Предупреждение</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation>файлы</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation>Настройки радио и моделей</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation>Настройки приложения</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation>Выберите или создайте файл для экспортируемых настроек:</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation>Нажмите &apos;Повтор&apos; выберите другой файл.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation>Симулятор для этой прошивки пока недоступен</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation>Неизвестная ошибка при запуске симулятора.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation>Ошибка симулятора</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation>Ошибка загрузки данных</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation>Произошла ошибка при запуске симулятора.</translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation>настройки</translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1718,22 +1733,22 @@ Do you want to import settings from a file?</source>
         <translation>В файл</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation>Неизвестная модель %1</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation>Нажмите, чтобы убрать эту модель.</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translation>Распечатать</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translation>PDF файл для сохранения</translation>
     </message>
@@ -1759,7 +1774,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translation>Хорошо, я понял.</translation>
     </message>
@@ -1767,17 +1782,17 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translation>Ошибка записи</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translation>Не удается записать %1 (причина: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translation type="unfinished">Не удается открыть %1 (причина: %2)</translation>
     </message>
@@ -1785,22 +1800,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation>Стандартный</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation>Другой</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation>%1 балл</translation>
     </message>
@@ -1883,32 +1898,32 @@ Do you want to import settings from a file?</source>
         <translation>Размер точки</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation>Линейный</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation>Экспонента</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation>Симметричная f(x)=-f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation>Симметричная f(x)=f(-x)</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation>Недостаточно свободных точек в массиве глобальных точек для хранения кривой.</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation>Редактирование кривой %1: %2</translation>
     </message>
@@ -1916,7 +1931,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation>Дважды щелкните, чтобы отредактировать</translation>
     </message>
@@ -1924,22 +1939,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation>Разница</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation>Экспо</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation>Функция</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation>Другой</translation>
     </message>
@@ -1947,113 +1962,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished">Примечание: чтобы создать кривую, щелкните правой кнопкой мыши на метке строки кривой</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation>Доступно всплывающее меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation>Имя:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation>Тип:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation>Точки:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation>Гладкий:</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation>Правка</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation>Очистить</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation>Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation>Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation>Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation>Четкая кривая %1: %2. Ты уверен?</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation>Очистите все кривые. Ты уверен?</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished">Вырезать кривую %1:%2. Ты уверен?</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation>Удалите кривую %1:%2. Ты уверен?</translation>
     </message>
@@ -2061,343 +2076,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished">Переопределить %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished">Вибрацией</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished">1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished">Триммеры</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished">Тарелка</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished">Значение</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
-        <translation type="unfinished">Источник</translation>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished">Телеметрия</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished">с</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2405,123 +2440,123 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation type="unfinished">Тумблер</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation type="unfinished">Параметры</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished">Доступно всплывающее меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished">Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished">Вырезать</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished">Очистить</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished">Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished">Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished">Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
@@ -2529,22 +2564,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2552,47 +2587,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished">Триммеры</translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished">Триммеры</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2649,82 +2684,82 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished">...</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation type="unfinished">Выбрать файл с прошивкой</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation type="unfinished">Выберите изображение</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation type="unfinished">Изображения (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2732,22 +2767,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation type="unfinished">90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation type="unfinished">120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation type="unfinished">120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation type="unfinished">140</translation>
     </message>
@@ -2755,53 +2790,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished">Тумблер</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished">Источник</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2809,52 +2844,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished">Всегда включена</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished">Да</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2933,101 +2968,82 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3036,12 +3052,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3049,12 +3065,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3062,12 +3078,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>Первый канал элевонов:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>Второй канал элевонов:</translation>
     </message>
@@ -3075,41 +3091,41 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Ошибка при записи файла %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3117,23 +3133,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">Всегда включена</translation>
     </message>
@@ -3141,111 +3157,95 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Вес</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translation>Смещение</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translation type="unfinished">Источник данных для микшера</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translation>Название Входа</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translation>Полётные режимы</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translation>Тумблер</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translation>Источник</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translation>Название строки</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translation>Сторона стика</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translation>Использовать триммер</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translation type="unfinished">Кривая применяется к источнику.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translation type="unfinished">МИНУС</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translation>Тумблер используется для активации линии.
-Если не указан, тогда Вход всегда активен.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translation type="unfinished">ПЛЮС</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translation type="unfinished">ОБЕ</translation>
     </message>
@@ -3255,22 +3255,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation type="unfinished">Редактирование %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished">Доступно всплывающее меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished">Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished">Выбрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished">Инвертировать всё</translation>
     </message>
@@ -3278,22 +3278,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished">Газ:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished">Рысканье (yaw):</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished">Тангаж (pitch):</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation type="unfinished">Крен (roll):</translation>
     </message>
@@ -3301,109 +3301,109 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished">Определяет, как обрабатывать файлы, которые уже существуют.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation>Копировать только если новее и отличается содержимое</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation>Копировать только если новее (не сравнивать содержимое)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation>Копировать только если разные (игнорировать дату файла)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation>Всегда копировать (перезаписывать существующие файлы)</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished">Пропускать, если файл больше указанного размера. Поставьте 0, если ограничение не нужно.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished">Уровень журналирования синхронизации. Будут показываться событие выбранного и более высоких уровней.
 ПРЕДУПРЕЖДЕНИЕ: высокий уровень журналирования может временно заблокировать интерфейс.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished">Пропущенные</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished">Новые</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished">Обновленные</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished">Только ошибки</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation>Только тестирование</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished">Запускает обычную синхронизацию, только ничего не копирует. Полезно для проверки результатов перед реальной синхронизацией.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation>Журнал:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation>Фильтры:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
@@ -3412,156 +3412,156 @@ The Include filter is evaluated first.</source>
 Вначале учитывается фильтр &quot;Включить&quot;.</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">Один или несколько шаблонов, разделенных запятыми
 Пустое поле означает обработку всех файлов, допускаются маски ?, * и [...].</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">Один или несколько шаблонов, разделенных запятыми
 Пустое поле означает обработку всех файлов, допускаются маски ?, * и [...].</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation>Включить:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation>Исключить:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation>Чувствительный к регистру</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation>Учитывать ссылки</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation>Учитывать скрытые</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation>Рекурсивно</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation>Пропускать пустые</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation>Применять фильтры</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation>Настройки фильтров:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation>Параметры папок:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation>Показать дополнительные настройки</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation>Использовать настройки по умолчанию</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation>Направление синхронизации:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation>Существующие файлы:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation>Макс. размер файла:</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished">Остановить</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation>Начать</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished">Итого: &lt;b&gt;%1&lt;/b&gt;; Создано: &lt;b&gt;%2&lt;/b&gt;; Обновлено: &lt;b&gt;%3&lt;/b&gt;; Пропущено: &lt;b&gt;%4&lt;/b&gt;; Ошибки: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished">Обработано: &lt;b&gt;%1&lt;/b&gt; Всего. </translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3569,367 +3569,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3937,27 +3981,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>Да, управляются одним каналом</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>Да, управляются двумя каналами</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;Первый канал закрылков:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>Второй канал закрылков:</translation>
     </message>
@@ -3966,7 +4010,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Записать настройки и модели в передатчик</translation>
     </message>
@@ -4031,51 +4075,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Записать</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>Выберите файл с резервной копией</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Не удается записать файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>Ошибка при записи файла %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4153,103 +4197,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Записать</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation type="unfinished">Выбрать файл с прошивкой</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation type="unfinished">%1 - не прошивка</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation type="unfinished">Битый файл с прошивкой.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation type="unfinished">Выбрать картинку для заставки</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation type="unfinished">Изображения (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation type="unfinished">Файл с заставкой не найден</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation type="unfinished">Записать прошивку в передатчик</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation type="unfinished">Не удалось проверить прошивку</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation type="unfinished">Не удалось проверить прошивку передатчика</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation type="unfinished">Невозможно сконвертировать модели и настройки для этой прошивки, будут использованы оригинальные данные</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation type="unfinished">Обновление завершено</translation>
     </message>
@@ -4257,83 +4301,83 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4341,7 +4385,7 @@ You are currently using:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
@@ -4392,225 +4436,240 @@ You are currently using:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished">Доступно всплывающее меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation>Триммер отключен</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation>Свой триммер</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation>Использовать триммер Полётного режима %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation>Использовать триммер Полётного режима %1 + &apos;Свой триммер&apos; как смещение</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>Источник значений</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>Значение</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation>Ед.</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished">Точность</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation>Мин</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation>Макс</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished">Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished">Вырезать</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished">Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished">Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished">Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation type="unfinished">Очистить</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4618,17 +4677,17 @@ You are currently using:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translation type="unfinished">Полётный режим %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation type="unfinished"> (%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation type="unfinished"> (по умолчанию)</translation>
     </message>
@@ -4636,17 +4695,17 @@ You are currently using:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4654,17 +4713,17 @@ You are currently using:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished">Желтая</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished">Оранжевая</translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished">Красная</translation>
     </message>
@@ -4672,13 +4731,13 @@ You are currently using:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4696,17 +4755,18 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished">Название</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4716,7 +4776,12 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4724,8 +4789,13 @@ You are currently using:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4821,13 +4891,13 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4835,43 +4905,33 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4890,12 +4950,12 @@ These will be relevant for all models in the same EEPROM.</source>
 Это относится ко всем моделям сохраненным в EEPROM.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translation>Настройка</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translation>Тренер</translation>
     </message>
@@ -4910,47 +4970,47 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translation>Глобальные функции</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translation>Оборудование</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translation>Калибровка</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation type="unfinished">Параметры оборудования и калибровки сохранены.</translation>
     </message>
@@ -4989,8 +5049,8 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Полетные режимы</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5026,184 +5086,207 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished">Параметры передатчика</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished">Оборудование</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished">Тумблер</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">Телеметрия</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">Тренер</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">Отладка</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -5220,201 +5303,199 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Смещение от UTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Язык для голоса</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Регион</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Реверс стиков</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>Режим FAI</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Коррекция часов</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Макс. тон вариометра</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation> Гц</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Громкость динамика</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>Включение подсветки</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Режим звука</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>Цвет 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>Цвет 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation type="unfinished">Тон динамика</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Если не равно нулю, то любое нажатие кнопок будет включать подсветку и выключать её через указанное кол-во секунд.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation> сек</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>Цвет фона</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Динамик</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Громкость писка</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Громкость Wav</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Громкость варио</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Громкость фон. музыки</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation> мс</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>Отключать подсветку через</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>Мигать подсветкой при увед.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Мин. тон вариометра</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Повтор если вариометр 0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5422,7 +5503,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5432,62 +5513,62 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>Яркость фона</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Навигация крутилкой</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>Яркость отключенной подсветки</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>Америка</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Япония</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>Европа</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation>Если включить режим FAI, то будут работать только датчики RSSI и напряжения. Эту функцию нельзя отключить в передатчике.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5528,222 +5609,82 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Порядок каналов&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Задает порядок микшеров при создании новой модели.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5754,305 +5695,338 @@ Acceptable values are 3v..12v</source>
 Диапазон 3В..12В</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation>Пауза при включении</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation>Режим разъема наушников</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation>Спросить при подключении</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation>Тренер</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation>Предупреждать, если мало памяти (EEPROM)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation>Предупреждать, если есть сигнал RSSI</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Режим стиков</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation>Пауза при выключении</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Метрическая (метры)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Имперская (мили, футы)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Порядок следов. каналов</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>GPS координаты</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation>Мин</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation>В</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation>Макс</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Таймер активности</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Показывать заставку при включении</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>Конраст</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Напряжение аккумулятора</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Сила вибрации</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>Тип LCD экрана</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Предупреждать, если отключен звук</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Напряж. при разряде</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Продолжительность вибрации</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>Скорость MAVLink</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Тихо</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Только предупреждения</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>Все, кроме кнопок</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>Стандартный</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation>Optrex</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Если не равно нулю, то передатчик начнет пищать при отсутсвии активности через указанное кол-во минут.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation> мин</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">0s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">0.5s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation>2 сек.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation>3 сек.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation>4 сек.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation>6 сек.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation>8 сек.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation>10 сек.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation>15 сек.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation>4800</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation>9600</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation>14400</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation>19200</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation>38400</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation>57600</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation>76800</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation>115200</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6071,92 +6045,92 @@ p, li { white-space: pre-wrap; }
 &quot;Тишина&quot; - Предупреждение о &quot;тихом&quot; режиме (без звука)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>Очень кратко</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Кратко</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>Нормальная</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>Долго</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>Очень долго</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Пауза воспр. (тумблер в сред. полож.)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation>Режим работы USB порта</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation>Джойстик</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation>Съемный диск</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation>Последовательный порт</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Система мер</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Режим вибрации</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Продолжительность писка</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Уведомления (писк)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6173,12 +6147,14 @@ p, li { white-space: pre-wrap; }
 4 - Очень громкая.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Только предупреждения</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished">1s</translation>
     </message>
@@ -6186,179 +6162,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation>Всегда выключена</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation>Кнопки</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation>Стики</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation>Кнопки + Стики</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation>Всегда включена</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6366,17 +6342,17 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>Да, управляется тумблером</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>Да, управляется крутилкой</translation>
     </message>
@@ -6384,118 +6360,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Инверт</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6576,22 +6562,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation type="unfinished">Газ:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation type="unfinished">Рысканье (yaw):</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation type="unfinished">Тангаж (pitch):</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation type="unfinished">Крен (roll):</translation>
     </message>
@@ -6599,19 +6585,19 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished">Не удалось открыть файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Ошибка при записи файла %1:
@@ -6621,159 +6607,159 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>Очистить все Входы</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>Сделать копию</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished">Вход</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished">Очистить</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished">Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6814,96 +6800,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6911,17 +6897,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6929,7 +6915,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6937,122 +6923,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished">неизвестно</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7060,112 +7046,117 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translation type="unfinished">Задержка</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished">Доступно всплывающее меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished">Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished">Вырезать</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished">Очистить</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished">Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished">Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished">Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translation type="unfinished">Функция</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7218,126 +7209,126 @@ Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Не удается записать файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7345,736 +7336,736 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>Файл загружен</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>Файл записан</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>Синхронизация содержимого SD</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>Открыть...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>Сохранить как...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>Сравнить модели</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>Выйти из программы</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>Показать окно &quot;О программе&quot;</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>Язык меню</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation>Использовать язык системы.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>О программе OpenTX Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>Монохромная черная тема</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>Монохромная белая тема</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>Монохромная синяя тема</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation>Локальная папка</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation>Папка в передатчике</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation>Закрыть окно с моделями с настройками</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation>Список недавно открытых файлов</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation>Профили передатчиков</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation>Выбрать профиль передатчика или создать новый</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation>Описание версии ПО...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation>Показать информацию о текущей версии ПО</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation>Создать новый профиль передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation>Копировать текущий профиль передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation>Копировать текущий профиль передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation>Удалить текущий профиль передатчика...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation>Удалить текущий профиль передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation>Экспорт настроек приложения...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation>Сохранить все текущие настройки %1 и симулятора (включая профиль передатчика) в файл.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation>Импорт настроек приложения...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation>Чтение ранее экспортированных настроек %1 и симулятора из файла.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation>В виде закладок</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation>Использовать закладки для переключения между окнами.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation>По горизонтали</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation>Выравнивание открытых окон по горизонтали.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation>Каскадом</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation>Выравнивание открытых окон каскадом.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation>Закрыть все окна</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation>Закрыть все окна (с запросом на сохранение изменений).</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation>Окно</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation>Некоторые сообщения не будут переведены, пока вы не перезапустите Companion. Учтите, что не все сообщения переведены на выбранный язык.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>Маленькие</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>Использовать маленькие иконки</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>Использоват иконки стандартного размера</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translation>Стандартные</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>Использовать большие иконки</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>Большие</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>Использовать огромные иконки</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>Огромные</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation>Невозможно удалить профиль</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation>Нельзя удалить профиль по умолчанию.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished">Выбор %1:</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished">Невозможно импортировать настройки.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>Открыть файл с моделями и настройками</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>Прочитать модели и настройки из передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>Сохранить прошивку из передатчика в файл</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>Создать новую модель и настройки передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>Сохранить модели и настройки в файл</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>Выход</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>Классическая тема companion9x</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>Желтая тема</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>Язык ОС</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>Открыть журнал...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>Открыть и просмотреть журнал (логи)</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>Настройки...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>Сравнить модели...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>Редактировать заставку передатчика...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>Скачать прошивку из передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation type="unfinished">Сохранить прошивку из передатчика в файл</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>Обновить прошивку передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>Обновить прошивку передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>Добавить профиль передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>Записать модели и настройки в передатчик</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>Записать модели и настройки в передатчик</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>Прочитать модели и настройки из передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>Настройка подключения...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>Настройка подключения к передатчику</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>Записать резервную копию из файла в передатчик</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>Записать резервную копию из файла в передатчик</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>Сделать резервную копию передатчика</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>Сделать полную копию всех моделей и настроек, хранящихся в передатчике</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>Синхронизация содержимого SD карточки</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>Последние</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>Стиль иконок</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>Размер иконок</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>Файл</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>Правка</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>Чтение/Запись</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>Помощь</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>Готово</translation>
     </message>
@@ -8082,100 +8073,100 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>Редактирование модели %1: </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>Невозможно найти файл %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>Ошибка при считывании файла %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
@@ -8185,7 +8176,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
@@ -8195,186 +8186,186 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation>Редактировать модель</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation>Вырезать</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation>Параметры передатчика</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation>Копировать настройки передатчика</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation>Вставить настройки передатчика</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation>Симулятор передатчика</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation>Добавить модель</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation>Модель</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation>Восстановить из резервной копии</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation>Мастер по настройке</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation>Модель по умолчанию</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation>Распечатать модель</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation>Симулятор модели</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation>Сделать копию</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
             <numerusform>Удалить выбранную модель?</numerusform>
@@ -8383,160 +8374,160 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>Сохранить как</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1 изменен.
 Вы хотите сохранить изменения?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished">Добавить</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished">Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished">Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation>Не удается записать временный файл!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">Правка</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished">Шаблон</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8544,143 +8535,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8688,12 +8684,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8707,88 +8703,90 @@ Do you want to save your changes?</source>
         <translation type="unfinished">Настройки микшера</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translation>Источник</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>Источник данных для микшера</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>Вес</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <oldsource>The value of the mixer is multiplied by this value and divided by 100.</oldsource>
-        <translation>Микшер можно активировать тумблером.
-Если тумблер не указан, тогда микшер будет включен всё время.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>Смещение</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>Использовать триммер</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>Кривая, используемая микшером</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>Тумблер</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>Звук</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8813,141 +8811,104 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Если замедление не равно 0, то это скорость применения микшера. Т.е. значение в секундах для перехода от -100 к +100 (например, плавный выпуск закрылков/шасси)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>Передатчик будет издавать звуки пока микшер активен.</translation>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translation>ВЫКЛ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1 сигнал</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <oldsource>2 Beeo</oldsource>
-        <translation>2 сигнала</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3 сигнала</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>Мультиплексор
-
-Определяет, каким образом вычисляется значение микшера.
-
-&quot;+&quot; - значение текущего микшера добавляется к предыдущему микшеру на этом же канале.
-&quot;*&quot; - значение текущего микшера умножается на значение предыдущего микшера на этом же канале
-&quot;R&quot; - значение текущего микшера заменяет предыдущее значение. Если тумблер отключен, то значение игнорируется.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>СЛОЖЕНИЕ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>УМНОЖЕНИЕ</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translation>ЗАМЕНА</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>Полётные режимы</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">15 сек. {0.00?}</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>Задержка</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>Замедление</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>Вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>Вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished">Нажмите, чтобы открыть меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation>Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation>Выбрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation>Инвертировать</translation>
     </message>
@@ -8955,22 +8916,22 @@ This determines how mixer values are added.
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8978,136 +8939,136 @@ This determines how mixer values are added.
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>Удалить микшеры</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>Недостаточно микшеров!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>Редактировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>Сделать копию</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>Удалить все микшеры?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>Вы действительно хотите удалить все микшеры?</translation>
     </message>
@@ -9115,18 +9076,23 @@ This determines how mixer values are added.
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished">Канал газа</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9175,32 +9141,49 @@ This determines how mixer values are added.
         <translation type="unfinished">Главный (мультимодуль)</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9213,65 +9196,60 @@ This determines how mixer values are added.
         <translation>Диалог</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>Основные</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>Вертолёт</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Входы</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Логические переключатели</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Микшеры</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>Выходы</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Кривые</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Специальные функции</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Телеметрия</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>Полетные режимы</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.ui" line="51"/>
@@ -9328,8 +9306,8 @@ This determines how mixer values are added.
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">Полетные режимы</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9365,585 +9343,595 @@ This determines how mixer values are added.
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished">Вкл.</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished">Всегда включена</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation>ВЫКЛ</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translation>по экспоненте</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>очень точно</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>точно</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>средне</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>грубо</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translation>неизвестно</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation>Каналы</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished">Полярность</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation>Протокол</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished">Задержка</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation>Приёмник</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished">Протокол</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished">Подтип</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished">Подтип</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation>Выходная мощность передатчика</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation type="unfinished">90</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation type="unfinished">120</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation type="unfinished">120X</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation type="unfinished">140</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished">Полетные режимы</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished">Полетный режим</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished">Все</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation>Расш. лимиты</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation>Показать контрольную карту</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation>Глобальные функции</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished">вручную</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation>автоматически</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation>Режим Failsafe</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished">удержание</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation>без сигнала</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation>не задан</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation>Без сигнала</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation>Шаг</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation>Показывать</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation>Расширенные</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation>никогда</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation>при изменении</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation>всегда</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation>Источник</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation>Триммировать только холостой ход</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation>Предупреждать</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation>Реверс</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished">Мин</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished">Макс</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation>Ошибка: невозможно открыть файл!</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished">Параметры</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation type="unfinished">Отключен во всех полетных режимах</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>Другой</translation>
     </message>
@@ -9951,27 +9939,27 @@ This determines how mixer values are added.
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>Самолёт</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>Мультикоптер</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>Вертолет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>Название модели:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>Тип модели:</translation>
     </message>
@@ -9979,27 +9967,27 @@ This determines how mixer values are added.
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished">Номер</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished">Название</translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished">Модель %1</translation>
@@ -10255,285 +10243,290 @@ This determines how mixer values are added.
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation>Встроенный радиомодуль</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation>Внешний радиомодуль</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation>10 мВт - 16 каналов</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation>100 мВт - 16 каналов</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation>500 мВт - 16 каналов</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation>Автоматически: &lt; 1 Вт - 16 каналов</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation>25 мВт - 8 каналов</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation>25 мВт - 16 каналов</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation>200 мВт - 16 каналов (без телеметрии)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation>500 мВт - 16 каналов (без телеметрии)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation>100 мВт - 16 каналов (без телеметрии)</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished">Положительный</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10541,57 +10534,57 @@ This determines how mixer values are added.
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translation type="unfinished">Значение</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation type="unfinished">без сигнала</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished">Параметры</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
@@ -10599,456 +10592,456 @@ This determines how mixer values are added.
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>Полетные режимы</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>Режим</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>Тумблер</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>Канал</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>Название</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation>Основные параметры</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation>Изображение</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation>Газ</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation>Триммеры</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation>Сигнал в центре</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation>Проверка тумблеров</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation>Проверка крутилок</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation>Прочее</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation>Таймеры</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation>Время</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation>Отсчет</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation>Ежеминутный сигнал</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation>Постоянный</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">Режим</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation>Радиомодули</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation>Тренерский разъем</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation>Вертолет</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation>Автомат перекоса</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished">Тарелка</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation type="unfinished">Вход</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation type="unfinished">Вес</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation>Глобальные переменные</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished">Точность</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation>Выходы</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation>Субтриммер</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation>Кривая</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished">Линейный</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">Функция</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation>Телеметрия</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation>Протокол</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished">Низкий</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation>Критический</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation>Звук телеметрии</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation>Измерение высоты</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation>Вариометр</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation>Пределы вариометра &gt;</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation>Сниж. макс.</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation>Сниж. мин.</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation>Набор мин.</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation>Набор макс.</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation>Тишина в 0</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation>Верхняя строка</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation>Напряжение</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation>Высота</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation>Параметры</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation>Датчики телеметрии</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished">Глобальные функции</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation>Контрольная карта</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation>Мин</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation>Макс</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>Глобальные переменные</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>Входы</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>Микшеры</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>Кривые</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>Логические переключатели</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>Специальные функции</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation type="unfinished">Ед.</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>Уровень RSSI</translation>
     </message>
@@ -11056,7 +11049,7 @@ This determines how mixer values are added.
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11064,22 +11057,22 @@ This determines how mixer values are added.
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>Газ:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>Рысканье (yaw):</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>Тангаж (pitch):</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>Крен (roll):</translation>
     </message>
@@ -11087,22 +11080,22 @@ This determines how mixer values are added.
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11110,17 +11103,17 @@ This determines how mixer values are added.
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>Отсечка газа (throttle cut)</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>Таймер газа</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>Таймер полетного времени</translation>
     </message>
@@ -11128,39 +11121,39 @@ This determines how mixer values are added.
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">Ошибка при записи файла %1:
@@ -11190,17 +11183,17 @@ This determines how mixer values are added.
         <translation>В файл</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>Распечатать</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11227,12 +11220,12 @@ This determines how mixer values are added.
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation type="unfinished">Закрыть</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished">Отмена</translation>
     </message>
@@ -11248,22 +11241,22 @@ This determines how mixer values are added.
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished">Показывать это сообщение при следующем запуске?</translation>
     </message>
@@ -11271,24 +11264,24 @@ This determines how mixer values are added.
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11296,97 +11289,107 @@ This determines how mixer values are added.
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished">Новый</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11394,30 +11397,30 @@ This determines how mixer values are added.
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Не удается записать файл %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11425,12 +11428,12 @@ This determines how mixer values are added.
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11526,12 +11529,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11547,358 +11555,458 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished">с</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished">Время</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished">Источник</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">Нет</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished">ВЫКЛ</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished">Всегда включена</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished">Телеметрия</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished">Тумблер</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">Нет</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translation type="unfinished">Есть</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation type="unfinished">Канал руля направления:</translation>
     </message>
@@ -11906,19 +12014,19 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11926,319 +12034,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished">Ед.</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished">Коэффициент</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished">Постоянный</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished">Положительный</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished">Журнал</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished">Другой</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished">Добавить</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished">м</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12460,87 +12583,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation type="unfinished">Таймер %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished">Доступно всплывающее меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished">Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished">Вырезать</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished">Очистить</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished">Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished">Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished">Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12548,7 +12671,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>Канал руля высоты:</translation>
     </message>
@@ -12556,204 +12679,204 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12761,121 +12884,121 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
@@ -12885,7 +13008,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13034,74 +13157,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13226,32 +13349,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished">Путь к SD</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished">Все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished">Выбор файла с данными моделей</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13264,68 +13387,73 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished">Ошибка загрузки данных</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -13351,17 +13479,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished">...</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13369,7 +13497,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13377,7 +13505,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished">Невозможно найти файл %1!</translation>
     </message>
@@ -13386,9 +13514,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13413,19 +13541,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13434,47 +13562,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13482,44 +13610,44 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation>[ТЕСТОВЫЙ ЗАПУСК] </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished">Собираем информацию о %1...</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation>Файлы не найдены: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished">Ошибка синхронизации, файлы не найдены.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished">Синхронизация остановлена. Обработано %1 из %2.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation>Синхронизация завершена %1 файлов за %2 мин %3 с.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished">Синхронизация: %1
     в: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
@@ -13528,99 +13656,99 @@ Error: %2</source>
 </translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished">
 Слишком много ошибок.</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished">Пропускаем большой файл: %1 (%2КБ)</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished">Пропускаем файл из-за фильтра: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished">Пропускаем ссылку на %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation>Синхронизация прервана:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished">Синхронизация завершена:</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation>Создано: %1; Обновлено: %2; Пропущено: %3; Ошибок: %4;</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation>Создаем папку: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished">Невозможнос создать папку %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished">Папка уже существует: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished">Как минимум у одного файла дата модификации в будущем, ошибка: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished">Пропускаем старый файл: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished">Невозможно открыть файл &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished">Невозможно открыть файл в папке передатчика: &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished">Пропускаем одинаковые файлы: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished">Заменяем файл: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished">Невозможнос удалить файл в папке передатчика e &apos;%1&apos;: %2</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation>Создаем файл: %1</translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished">Ошибка копирования: &apos;%1&apos; в &apos;%2&apos;: %3</translation>
     </message>
@@ -13628,17 +13756,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>Руль направления:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>Руль высоты:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation type="unfinished">Доступен только один канал!&lt;br&gt;Возможно стоит настроить модель без использования этого мастера.</translation>
     </message>
@@ -13646,22 +13774,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>Руль высоты и руль направления</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>Только руль высоты</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>V-образное оперение</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>Тип хвостового оперения:</translation>
     </message>
@@ -13993,7 +14121,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14001,28 +14129,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>Низкий уровень</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>Критический уровень</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished">м</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished">м</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14139,72 +15200,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished">Доступно всплывающее меню</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished">Копировать</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished">Вырезать</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished">Очистить</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished">Сдвинуть вверх</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished">Сдвинуть вниз</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished">Убрать всё</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14217,354 +15278,123 @@ Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
         <translation type="unfinished">Симулятор</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished">25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished">1/5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished">5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">Нет</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -14573,78 +15403,35 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>Да</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>Канал газа:</translation>
     </message>
@@ -14670,138 +15457,138 @@ Timestamp</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished">Таймер %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished">Тихо</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">Писком</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">Голосом</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">Вибрацией</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished">5 сек.</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished">10 сек.</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished">20 сек.</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished">30 сек.</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">Сбрасываемый</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">Постоянный (только полет)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">Постоянный (только ручной сброс)</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">Всегда включена</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14809,22 +15596,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14832,27 +15619,27 @@ Timestamp</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">Режим</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished">Вес</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished">Источник</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished">Калибровка</translation>
     </message>
@@ -14862,6 +15649,210 @@ Timestamp</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14889,47 +15880,47 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14942,22 +15933,42 @@ Timestamp</source>
         <translation type="unfinished">Прошивка</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14965,285 +15976,317 @@ Timestamp</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15259,63 +16302,90 @@ Timestamp</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15408,32 +16478,32 @@ Timestamp</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15446,22 +16516,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15474,22 +16544,22 @@ Timestamp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15513,17 +16583,17 @@ Timestamp</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15531,37 +16601,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15677,32 +16747,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15710,32 +16780,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">Информация</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished">Верхняя строка</translation>
     </message>
@@ -15743,12 +16813,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>Первый канал управления:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>Второй канал управления:</translation>
     </message>
@@ -15756,55 +16826,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>Классическая схема</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>Летающее крыло</translation>
     </message>
@@ -15812,22 +16882,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15835,273 +16905,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>Мастер по настройке модели</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>Тип модели</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>Введите название модели и выберите её тип.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>Газ</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>У вашей модели есть двигатель?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>Тип крыла</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>У вас классический самолет или летающее крыло?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>Элероны</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>У вашей модели есть элероны?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>Закрылки</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>У вашей модели есть закрылки?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>Воздушные тормоза</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>У вашей модели есть воздушные тормоза?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>Летающее крыло</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>Выберите каналы элевонов</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>Руль направления</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>У вашей модели есть руль направления?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>Тип хвостового оперения</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>Выберите тип хвостового оперения модели.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>Хвостовое оперение</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>Выберите каналы для хвостового оперения.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>V-образное оперение</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>Выберите канал руля высоты.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>Вертолет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>Мультикоптер</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>Выберите каналы управления коптером</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>Дополнительные опции</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation>Выберите необходимое</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation type="unfinished">Сохранить изменения</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>Вручную проверьте направление движения всех управляющих поверхностей, настройке реверсы там, где это необходимо. &lt;br&gt;Снимите пропеллер перед тестированием.&lt;br&gt;Учтите, что сохранение перезапишет старые настройки модели!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>Введите название модели и выберите её тип.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>Выберите канал на приемнике, к которому подключен регулятор скорости или сервомашинка для газа.&lt;br&gt;&lt;br&gt;Spektrum: Канал1, Futaba: Канал3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>Большинство самолетов имеют нормальную аэродинамическую схему (классическую). У летающих крыльев нет хвостового оперения. &lt;br&gt;В классической схеме за крен отвечают элероны.&lt;br&gt;У летающих крыльев элевоны отвечают и за крен и за тангаж. </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>Для управления элеронами используется 1 или 2 канала.&lt;br&gt;Так называемый Y-кабель нужен для подключения одного канала к двум сервомашинкам.&lt;br&gt;Если сервомашнки подключены таким кабелем, то выберите вариант с одним каналом&lt;br&gt;&lt;br&gt;Элероны на Spektrum: Канал2. На Futaba: Канал1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>В этом мастере подразумевается, что закрылки управляются тумблером. Если вы используете крутилку, тогда придется настроить её вручную.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>Воздушные тормоза нужны для снижения скорости планеров.&lt;br&gt;Они редко используются на других типах самолетов.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>Для управления элевонами нужно 2 канала. Выберите их</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>Выберите канал, к которому подключен руль направления.&lt;br&gt;&lt;br&gt;Руль направления - Spektrum: Канал4, Futaba: Канал4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>Нужно выбрать тип хвостового оперения модели.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Выберите каналы для руля высоты и руля направления.&lt;br&gt;&lt;br&gt;Руль направления - Spektrum: Канал4, Futaba: Канал4&lt;br&gt;Руль высоты - Spektrum: Канал3, Futaba: Канал2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>Выберите канал руля высоты.&lt;br&gt;&lt;br&gt;Руль высоты - Spektrum: Канал3, Futaba: Канал2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>Выберите каналы управления коптером.&lt;br&gt;&lt;br&gt;Газ: Spektrum: Канал1, Futaba: Канал3&lt;br&gt;Рысканье: Spektrum: Канал4, Futaba: Канал4&lt;br&gt;Тангаж: Spektrum: Канал3, Futaba: Канал2&lt;br&gt;Крен: Spektrum: Канал2, Futaba: Канал1&lt;br&gt;</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>Помощь по использованию мастера</translation>
     </message>
@@ -16109,37 +17179,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation type="unfinished">Самолёт</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation type="unfinished">Вертолет</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation type="unfinished"></translation>
     </message>
@@ -16147,45 +17217,45 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16193,16 +17263,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16211,10 +17284,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16307,18 +17395,18 @@ Please only use this if you know what you are doing.  There are no error checks 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>Выбрать расположение</translation>
     </message>
@@ -16368,59 +17456,59 @@ m2560 for v4.1 boards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished">Джойстик не найден</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>Дальше</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16430,7 +17518,7 @@ Press Cancel to abort joystick calibration without saving.</source>
         <translation>Ок</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>Не удалось подключить джойстик.</translation>
     </message>

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -527,64 +527,64 @@ Mode 4:
         <translation>Spara läget för alla brytare när simulatorn avslutas</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>Min radio</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>Välj katalog för skärmbilder från simulatorn</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="599"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>Ingen joystick hittades</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="328"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>TOM: Det finns inga radioinställningar i profilen</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="333"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>TILLGÄNGLIGA: Radioinställningar av okänd ålder</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="335"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>TILLGÄNGLIGA: Radioinställningar sparade %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="530"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translation>Välj bibliotekskatalog</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="554"/>
-        <location filename="../apppreferencesdialog.cpp" line="564"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translation>Välj folder för automatisk säkerhetskopiering</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="582"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translation>Sökväg till Google Earth</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="633"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translation>Välj katalog med en kopia av din SD-struktur</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="664"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>Öppna bild för laddning</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="664"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>Bilder (%1)</translation>
     </message>
@@ -693,12 +693,12 @@ Mode 4:
         <translation>Katalog för skärmbilder</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>&lt;p&gt;&lt;b&gt;Du kan inte byta radiotyp eller ändra bygginställningarna när det finns filer med osparade ändringar. Vad vill du göra?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Spara alla&lt;/i&gt; - Spara öppna filer innan inställningarna sparas.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Gå tillbaka till tidigare radiotyp och bygginställningar innan inställningarns sparas.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Avbryta&lt;/i&gt; - Återgå till dialogen för inställningar.&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="574"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation>Välj katalog för programloggar</translation>
     </message>
@@ -735,7 +735,7 @@ Mode 4:
     <message>
         <location filename="../apppreferencesdialog.ui" line="83"/>
         <location filename="../apppreferencesdialog.ui" line="1560"/>
-        <location filename="../apppreferencesdialog.cpp" line="469"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation>Alternativ</translation>
     </message>
@@ -791,12 +791,12 @@ Mode 4:
         <translation>Komponenter</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="438"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation>Kolla</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="441"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation>Publiceringskanal</translation>
     </message>
@@ -811,27 +811,27 @@ Mode 4:
         <translation>Förvald intern modul</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="355"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation>Återställ alla uppdateringsinställningar till förvalda värden. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="359"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation>Inställningar för uppdatering har ändrats. Vänligen stäng och starta om Companion för att undvika oväntade problem!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="399"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation>Välj katalog för nerladdning</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="406"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation>Välj din katalog för uppackning</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="413"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation>Välj katalog för uppdateringen</translation>
     </message>
@@ -846,22 +846,22 @@ Mode 4:
         <translation>Radera uppackade filer</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="114"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation>Uppdateringsinställningar: Sökväg till katalog för nerladdning saknas!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="119"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation>Uppdateringsinställningar: Sökväg till katalog för uppackning saknas!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="124"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation>Uppdateringsinställningar: Sökväg till katalog för uppdateringar saknas!</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="130"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation>Uppdateringsinställningar: Sökväg till katalog för uppackning och nerladdning är identiska!</translation>
     </message>
@@ -946,36 +946,36 @@ Mode 4:
         <translation>GAS</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="823"/>
-        <location filename="../firmwares/boardjson.cpp" line="829"/>
-        <location filename="../firmwares/boardjson.cpp" line="838"/>
-        <location filename="../firmwares/boardjson.cpp" line="848"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation>Ladda hårdvarudefinitionen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation>Kort: %1
 Fel: Kan inte ladda fil %2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="830"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation>Kort: %1
 Fel: Kan inte öppna fil %2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="839"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation>Kort: %1
 Fel: Kan inte läsa fil %2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="849"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -989,255 +989,265 @@ Felbeskrivning: %4</translation>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="362"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation>Vänster horisontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="363"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation>Vänster Vvrtikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="364"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation>Höger vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="365"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation>Höger horisontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="366"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="367"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation>VH</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation>VV</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="385"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation>HV</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="386"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation>HH</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="397"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="403"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="442"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="460"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation>RG1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation>V4</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="413"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <location filename="../firmwares/boards.cpp" line="461"/>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation>RG2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="414"/>
-        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation>RG3</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="415"/>
-        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation>RG4</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation>V5</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="598"/>
-        <location filename="../firmwares/boards.cpp" line="804"/>
-        <location filename="../firmwares/boards.cpp" line="834"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="600"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation>2 lägen momentan</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="602"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation>2 lägen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="604"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation>3 lägen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="606"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation>Funktion</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="836"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation>Vred</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="838"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation>Vred med mittklick</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="840"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation>Reglage</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="842"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation>Flerlägesbrytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="844"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation>X-axel</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="846"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation>Y-axel</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="848"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation>Brytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="404"/>
-        <location filename="../firmwares/boards.cpp" line="408"/>
-        <location filename="../firmwares/boards.cpp" line="419"/>
-        <location filename="../firmwares/boards.cpp" line="424"/>
-        <location filename="../firmwares/boards.cpp" line="430"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="457"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
-        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">Flygning</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation>V1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="409"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="440"/>
-        <location filename="../firmwares/boards.cpp" line="448"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
-        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation>V2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="441"/>
-        <location filename="../firmwares/boards.cpp" line="449"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation>V3</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="391"/>
-        <location filename="../firmwares/boards.cpp" line="393"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="392"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="806"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="808"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation>Liten</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="810"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation>Båda</translation>
     </message>
@@ -1501,12 +1511,12 @@ Felbeskrivning: %4</translation>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="442"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation>Användargränssnitt</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="444"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation>Huvudvy %1</translation>
     </message>
@@ -1554,27 +1564,27 @@ Felbeskrivning: %4</translation>
         <translation>Radio- och modellinställningar</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="371"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation>Det finns ännu ingen simulator för denna typ av firmware</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="398"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation>Okänt fel vid start av simulatorn.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="399"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation>Simuatorfel</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="409"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation>Fel vid dataladdning</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="409"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation>Ett fel uppstod vid start av simulatorn.</translation>
     </message>
@@ -1661,12 +1671,12 @@ Vill du hämta inställningarna från en fil?</translation>
         <translation>Programinställningar</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="295"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation>Välj eller skapa fil för exporterade inställningar:</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="305"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation>Tryck på &apos;Försök igen&apos; för att välja en annan fil.</translation>
     </message>
@@ -2212,12 +2222,12 @@ Vill du hämta inställningarna från en fil?</translation>
         <translation type="unfinished">Tryck på Anpassingsbar brytare %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="300"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation>Flygning</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="303"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
@@ -2227,107 +2237,107 @@ Vill du hämta inställningarna från en fil?</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="306"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
         <source>Trims</source>
         <translation>Trimmar</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation>Varning 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation>Varning 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="358"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="358"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="358"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="358"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="358"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="358"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="358"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation>Syrsa</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="358"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation>Väckarklocka</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="388"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
         <source>Source (%)</source>
         <translation>Källa (%)</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="390"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
         <source>Source (value)</source>
         <translation>Källa (värde)</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="392"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation>Global variabel</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="394"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation>Räkna upp/ner</translation>
     </message>
@@ -2407,7 +2417,7 @@ Vill du hämta inställningarna från en fil?</translation>
         <translation>Audioförstärkare av</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="386"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
@@ -2418,7 +2428,7 @@ Vill du hämta inställningarna från en fil?</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="421"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation></translation>
     </message>
@@ -2428,7 +2438,7 @@ Vill du hämta inställningarna från en fil?</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation>På</translation>
     </message>
@@ -2436,124 +2446,124 @@ Vill du hämta inställningarna från en fil?</translation>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="116"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translation>Brytare</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="116"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translation>Parametrar</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="116"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translation>Funktion</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="127"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation>Radera</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation>Kopiera</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation>Klipp ut</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation>Klistra in</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="129"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="116"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation>Repetera</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="116"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation>Aktivera</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="123"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation>Popupmeny tillgänglig</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="254"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation>Fel vid uppspelning av ljud, möjligen är ljudfilen redan öppnad. (Err: %1 [%2])</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="281"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation>Kan inte hitta eller öppna ljudfil:
 %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="651"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation>Rensa</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="658"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation>Rensa alla</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="744"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation>Rensa alla funktioner. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="733"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation>Rensa funktionen. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="635"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation>Klipp ut specialfunktionen. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="612"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation>Radera specialfunktionen. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="167"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation>Lägg till</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="656"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation>Flytta ner</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation>Flytta upp</translation>
     </message>
@@ -2584,47 +2594,47 @@ Vill du hämta inställningarna från en fil?</translation>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="238"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="325"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation>Övre raden</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="328"/>
-        <source>Flight mode</source>
-        <translation>Flygläge</translation>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
+        <source>%1 mode</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="331"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
         <source>Sliders</source>
         <translation>Skjutreglage</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="334"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
         <source>Trims</source>
         <translation>Trimmar</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="337"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
         <source>Mirror</source>
         <translation>Spegla</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="340"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation>Alternativ #%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="234"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="263"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation></translation>
     </message>
@@ -3174,6 +3184,11 @@ EEPROM storlek är 4096 men bara de första 2048 används</translation>
         <translation>Inkludera trim</translation>
     </message>
     <message>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translation>Kurva</translation>
@@ -3230,11 +3245,6 @@ EEPROM storlek är 4096 men bara de första 2048 används</translation>
         <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translation>Vikt</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="86"/>
-        <source>Flight modes</source>
-        <translation>Flyglägen</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="93"/>
@@ -3571,404 +3581,411 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1191"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation>Inga funktioner tillgängliga för att åsidosätta kanaldata</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1187"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation>Möjlighet att styra FAI-LÄGE på fältet</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation>FAI-LÄGE (ingen telemetri) alltid aktivt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation>Tar bort stöd för FrSky D8-protokoll, vilket är olagligt inom EU för sändare sålda efter 1 januari 2015</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1230"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1405"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1415"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1425"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1435"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1445"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1455"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1515"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1535"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1546"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Avaktivera helikoptermenyn och stöd för cykliska mixar</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1231"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1273"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1426"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1436"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1516"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1526"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1536"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1547"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1557"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1575"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation>Avaktivera Globala variabler</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1280"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
         <source>Fatfish F16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1396"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
         <source>HelloRadioSky V16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
         <source>Jumper T-Pro V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1443"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
         <source>Jumper T-Pro S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1464"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
         <source>Jumper T12 MAX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
         <source>Jumper T14</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1478"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
         <source>Jumper T15</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1506"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
         <source>Jumper T20 V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1267"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation>Stöd intern GPS-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1232"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1274"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1407"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1417"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1427"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1437"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1447"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1457"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1527"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1537"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Aktivera stöd för Lua-mixerskript</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation>Använd SQT5 typsnitt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1246"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation>Använd potentiometrar för menyskrollning</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1368"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1376"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation>Avaktivera RAS (SWR)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1369"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation>Vibratormodul är installerad</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Bekräfta avstängning av radion</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Horusspakar installerade (hall sensor)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1325"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>Använd endast med första versionen av DEV pcb</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation>Slå på helikoptermenyn och stöd för cyklisk mix</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation>Globala variabler</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation>Välj automatisk kontroller i menyn för modellinställningar genom att använda dem</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation>Välj automatisk brytare i menyn för modelinställningar genom att använda dem</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation>Använd inte grafiska kontroller</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1250"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation>Batterigraf</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation>Använd inte feta typsnitt för att markera aktiva objekt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1254"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation>Slå på nollställning av värden genom att hålla ner upp- och ned-knappen samtidigt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation>Tillåt icke-certifierad firmware</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>Stöd för utbyte av intern ACCESS-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation>Aktivera stöd för AFHDS3</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation>Tillåt parkoppling via &quot;bindknapp&quot;</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation>Stöd för Bluetooth-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1458"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1486"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation>Stöd för intern MULTI-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation>Aktivera stöd för AFHDS2</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1367"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1361"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1349"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1309"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1413"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1484"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1499"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1544"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1554"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1572"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1466"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1577"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation>Välj om intern ELRS-modul är installerad</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1533"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1564"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation>Stöd för intern hårdvarumodd: FlySky Paladin EV Gimbals</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1288"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1295"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1403"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1513"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation></translation>
     </message>
@@ -4441,239 +4458,254 @@ Du använder för närvarande:
         <source>FM</source>
         <translation>FL</translation>
     </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="152"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation>Inmatningshjul %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="224"/>
-        <source>GVAR%1</source>
-        <translation>GVAR%1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="216"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>Popup aktiv</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="184"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation>Namn</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="190"/>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation>Värdets källa</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="195"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation>Värde</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="685"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1066"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished">GV%1</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">Eget värde</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>Rensa</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="692"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1073"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation>Rensa alla</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="764"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
-        <translation>Rensa alla flyglägen. Är du säker?</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1187"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation>Rensa alla globala variabler för alla flyglägen. Är du säker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1198"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation>Rensa alla globala variabler för detta flygläge. Är du säker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="727"/>
-        <source>Clear Flight Mode. Are you sure?</source>
-        <translation>Rensa flygläget. Är du säker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1163"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Rensa den globala variabeln i alla flyglägen. Är du säker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1174"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation>Rensa den globala variabeln. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation>Kopiera</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation>Klipp ut</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="799"/>
-        <source>Cut Flight Mode. Are you sure?</source>
-        <translation>Klipp ut flygläget. Är du säker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1250"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Klipp ut den globala variabeln från alla flyglägen. Är du säker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1254"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation>Klipp ut den globala variabeln. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation>Radera</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="807"/>
-        <source>Delete Flight Mode. Are you sure?</source>
-        <translation>Radera flygläget. Är du säker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation>Radera den globala variabeln. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation>Lägg till</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation>Flytta upp</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="690"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1071"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation>Flytta ned</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation>Klistra in</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1328"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation>Klistra in den globala variabeln i alla flyglägen. Är du säker?</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation>Trim inaktiv</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="114"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation>3-läges momentan</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="118"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation>Egen trim</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="121"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation>Använd trim från flygläge %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="123"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation>Använd trim från flygläge %1 + egen trim som offset</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="200"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation>Enhet</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="204"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation>Prec</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="208"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="212"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation>0._</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="390"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation>0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="40"/>
-        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation>Popupmeny tillgänglig</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="499"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
-        <translation>Varning: globla variabeln länkar till sig själv. Värdet från flygläge 0 används.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="608"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
-        <translation>Varning: Inmatningshjulet länkar till sig själv. Värdet från flygläge 0 används.</translation>
     </message>
 </context>
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1433"/>
-        <source>Flight Mode %1</source>
-        <translation>Flygläge %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1436"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translation> (%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1439"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translation> (förval)</translation>
     </message>
@@ -4969,16 +5001,6 @@ p, li { white-space: pre-wrap; }
         <source>GV</source>
         <translation>GV</translation>
     </message>
-    <message>
-        <location filename="../helpers.cpp" line="231"/>
-        <source>Own value</source>
-        <translation>Eget värde</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="234"/>
-        <source>Flight mode %1 value</source>
-        <translation>Värde från flygläge %1</translation>
-    </message>
 </context>
 <context>
     <name>GeneralEdit</name>
@@ -5094,8 +5116,8 @@ Dessa inställningar gäller för alla modeller.</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation>Flyglägen</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5131,186 +5153,206 @@ Dessa inställningar gäller för alla modeller.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="380"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation>Radioinställningar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="382"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation>Hårdvara</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="383"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation>Intern modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="398"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation>Axlar och vred</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="403"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation>Axlar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="403"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation>Vred</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="432"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation>Brytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="437"/>
-        <location filename="../firmwares/generalsettings.cpp" line="449"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation>Flexbrytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="438"/>
-        <location filename="../firmwares/generalsettings.cpp" line="450"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation>Funktionsbrytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="438"/>
-        <location filename="../firmwares/generalsettings.cpp" line="450"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation>Brytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="521"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation>Intern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="523"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation>Fråga</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="525"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation>Per modell</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="528"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation>Intern + Extern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="528"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation>Extern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="541"/>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation>AV</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="544"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="544"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="546"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation>Lärare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="559"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation>Speglad telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="561"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation>Telemetri in</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="563"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation>SBUS Lärare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="565"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="567"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="707"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="709"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="754"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation>Endast trimm</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="756"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation>Endast knapp</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="758"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation>Ändringsbar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="760"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation>Global</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished">Mode 1 (ROD HÖJ GAS SKE)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished">Mode 2 (ROD GAS HÖJ SKE)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished">Mode 3 (SKE HÖJ GAS ROD)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">Mode 4 (SKE GAS HÖJ ROD)</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation>Extern modul</translation>
     </message>
@@ -5323,137 +5365,137 @@ Dessa inställningar gäller för alla modeller.</translation>
         <translation>Formulär</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2120"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>GPS-koordinater</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>Högtalarton (endast högtalare)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>Måttenheter</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1758"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translation>NMEA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="563"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>Röstspråk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="834"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation>Läge för inmatningshjul</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="768"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>Tidsskillnad mot UTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2373"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>Metrisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2378"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>Brittisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>Landskod</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>Amerika</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>Japan</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>Europa</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1779"/>
-        <location filename="../generaledit/generalsetup.ui" line="2276"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translation>Extra kort</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1784"/>
-        <location filename="../generaledit/generalsetup.ui" line="2281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translation>Kort</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1789"/>
-        <location filename="../generaledit/generalsetup.ui" line="2286"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1794"/>
-        <location filename="../generaledit/generalsetup.ui" line="2291"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translation>Lång</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1799"/>
-        <location filename="../generaledit/generalsetup.ui" line="2296"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>Extra lång</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>Färg 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>Färg 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1873"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>Längd på summerton</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="965"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>Rullhjulsnavigering</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2496"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>Summerläge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="958"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>Vario tonläge vid noll</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2611"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2616"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translation></translation>
     </message>
@@ -5463,12 +5505,12 @@ Dessa inställningar gäller för alla modeller.</translation>
         <translation>Upphäv skrivskyddet</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>Ljudläge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2164"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -5485,61 +5527,61 @@ Dessa inställningar gäller för alla modeller.</translation>
 4 - Extra högt.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1500"/>
-        <location filename="../generaledit/generalsetup.ui" line="2174"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translation>Tyst</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2179"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translation>Endast för alarm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1510"/>
-        <location filename="../generaledit/generalsetup.ui" line="2184"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translation>Ej vid knapptryck</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1515"/>
-        <location filename="../generaledit/generalsetup.ui" line="2189"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translation>För alla händelser</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translation>Endast vid alarm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1292"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translation>Vibrationsläge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="725"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>Summer</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="730"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>Högtalare</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="735"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>Summerton</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="740"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>Högtalarton</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="857"/>
-        <location filename="../generaledit/generalsetup.ui" line="2210"/>
+        <location filename="../generaledit/generalsetup.ui" line="823"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5554,173 +5596,173 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Värden mellan 20 och 45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation>SC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation>SE</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation>SA</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation>SF</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation>SH</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation>SD</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation>SB</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation>SG</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation> Hz</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2591"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>Batterivarning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>Vario tonläge vid max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>Anger antalet sekunder som bakgrundsbelysningen förblir påslagen efter senaste knapptryck.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation> sek</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="2218"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation> ms</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>Ljusstyrka</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>Repetition av vario vid noll</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>Bakgrundsbelysning av efter</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>Färg på bakgrundsbelysningen</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1314"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>LCD-kontrast</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1339"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation>Efter det angivna antalet minuter av inaktivitet ljuder en varningssignal. 0 förhindrar larm.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1342"/>
-        <location filename="../generaledit/generalsetup.ui" line="2738"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation> min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1584"/>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translation>4800 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1589"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation>9600 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1594"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation>14400 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1599"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation>19200 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1604"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation>38400 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1609"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation>57600 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1614"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation>76800 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1619"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation>115200 Baud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>Brytare för bakgrundsbelysning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2139"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>Visa startbild</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2249"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>LCD-typ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1560"/>
-        <location filename="../generaledit/generalsetup.ui" line="1667"/>
-        <location filename="../generaledit/generalsetup.ui" line="1715"/>
-        <location filename="../generaledit/generalsetup.ui" line="2412"/>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5745,116 +5787,116 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Tyst varning - varnar om summern är satt till tyst läge&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2721"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>MAVLink Baud Rate</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="820"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>Högtalarvolym</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2636"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>Vibrationstid</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2365"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>Inaktivitetstimer</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2531"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2061"/>
-        <location filename="../generaledit/generalsetup.ui" line="2340"/>
-        <location filename="../generaledit/generalsetup.ui" line="2536"/>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2066"/>
-        <location filename="../generaledit/generalsetup.ui" line="2345"/>
-        <location filename="../generaledit/generalsetup.ui" line="2541"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2546"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2551"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2556"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2561"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2566"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2515"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>Varna för avstängt ljud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1535"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>Vibrationsstyrka</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="572"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>Ljudstyrka varning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>Ljudstyrka Wav</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="618"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Ljudstyrka vario</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="641"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>Ljudstyrka bakgrund</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2093"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>Spakkonfiguration</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2317"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>Kanalordning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>FAI-läge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1358"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5895,417 +5937,267 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1383"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>Mode 1 (ROD HÖJ GAS SKE)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1388"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>Mode 2 (ROD GAS HÖJ SKE)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1393"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>Mode 3 (SKE HÖJ GAS ROD)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1398"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>Mode 4 (SKE GAS HÖJ ROD)</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Kanalordning&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Den ordning på kanaler som används för en ny modell.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="666"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation>Alternativ för etikettval</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="673"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation>Etikettmatchning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="701"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation>Stora bilder (2 kolumner)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="706"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation>Små bilder (3 kolumner)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="711"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation>Endast namn (2 kolumner)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="716"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation>Endast namn (1 kolumn)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation>Layot för modellhantering</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation>Matcha favoriter</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation>Flerval</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation>Enskilt val</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation>Matcha alla</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation>Matcha någon</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation>Måste matcha</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation>Alternativt matcha</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1259"/>
-        <source>Invert LCD</source>
-        <translation>Invertera LCD</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2046"/>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
         <source>0s</source>
         <translation>0s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2051"/>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
         <source>0.5s</source>
         <translation>0.5s</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1922"/>
-        <source>R E T A</source>
-        <translation>R H G S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1927"/>
-        <source>R E A T</source>
-        <translation>R H S G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1932"/>
-        <source>R T E A</source>
-        <translation>R G H S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1937"/>
-        <source>R T A E</source>
-        <translation>R G S H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1942"/>
-        <source>R A E T</source>
-        <translation>R S H G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1947"/>
-        <source>R A T E</source>
-        <translation>R S G H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1952"/>
-        <source>E R T A</source>
-        <translation>H R G S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1957"/>
-        <source>E R A T</source>
-        <translation>H R S G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1962"/>
-        <source>E T R A</source>
-        <translation>H G R S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1967"/>
-        <source>E T A R</source>
-        <translation>H G S R</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1972"/>
-        <source>E A R T</source>
-        <translation>H S R G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1977"/>
-        <source>E A T R</source>
-        <translation>H S G R</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1982"/>
-        <source>T R E A</source>
-        <translation>G R H S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1987"/>
-        <source>T R A E</source>
-        <translation>G R S H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1992"/>
-        <source>T E R A</source>
-        <translation>G H R S</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1997"/>
-        <source>T E A R</source>
-        <translation>G H S R</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2002"/>
-        <source>T A R E</source>
-        <translation>G S R H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2007"/>
-        <source>T A E R</source>
-        <translation>G S H R</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2012"/>
-        <source>A R E T</source>
-        <translation>S R H G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2017"/>
-        <source>A R T E</source>
-        <translation>S R G H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2022"/>
-        <source>A E R T</source>
-        <translation>S H R G</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2027"/>
-        <source>A E T R</source>
-        <translation>S H G R</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2032"/>
-        <source>A T R E</source>
-        <translation>S G R H</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2037"/>
-        <source>A T E R</source>
-        <translation>S G H R</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2113"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
         <source>Trainer Poweroff Warning</source>
         <translation>Lärarläge varning vid avstängning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2256"/>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
         <source>Power ON/OFF Haptic</source>
         <translation>Vibration vid radio Av/På</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2728"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
         <source>Power Auto Off</source>
         <translation>Automatisk avstängning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2735"/>
-        <source>If not zero transmitter will shut down if it has been left without inputs for the specified number of minutes.</source>
-        <translation>Om inte noll, kommer radion stängas av automatiskt efter angivet antal minuter efter senaste interaktion med radion.</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2106"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>Talfördröjning för brytare</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2393"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation>Spela startljud</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1690"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation>PPM-enheter</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1880"/>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="782"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>Blinkande ljus vid alarm</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="754"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>Inverterad spak</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>Justera RTC</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2652"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translation>Min</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2659"/>
-        <location filename="../generaledit/generalsetup.ui" line="2688"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translation>v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2681"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translation>Max</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>Batterimätarens mätområde</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>Automatisk justering av radions klocka om GPS-enhet är ansluten till telemetri.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="680"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation>Ljusstyrka för Bakgrundsljus av</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation>Om du aktiverar FAI kommer endast RSSI och RxBt-sensorerna att fungera. Detta går inte att ändra från radion.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation>RSSI-varning vid avstängning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1461"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation>Varning för EEPROM minnesbrist</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1738"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation>USB-läge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1426"/>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation>Fråga vid anslutning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1431"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation>Joystick (HID)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1436"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation>USB masslagring</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1441"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation>Seriell USB (CDC)</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2197"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>Hattläge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="827"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation>ID för ägarregistrering</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation>Fördröjning vid uppstart</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2643"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation>Uttagsläge</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2080"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2085"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation>Lärare</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1753"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation>GMS</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2304"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation>Fördröjning vid avstängning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -6314,12 +6206,12 @@ Mode 4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation>Knappbelysning</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2453"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -6330,19 +6222,19 @@ Detta är det gränsvärde vid vilket batterivarningen ljuder.
 Acceptabla värden är 3 - 12 volt</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation>Snabbval av modell</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation>Aktivera detta för att snabbt byta modell på modellvalssidan. Ett långt knapptryck kan sedan användas för att öppna modellredigeringsmenyn.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2056"/>
-        <location filename="../generaledit/generalsetup.ui" line="2335"/>
-        <location filename="../generaledit/generalsetup.cpp" line="279"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation></translation>
     </message>
@@ -6350,137 +6242,137 @@ Acceptabla värden är 3 - 12 volt</translation>
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="368"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation>Av</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="368"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation>Knappar</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="368"/>
-        <source>Sticks</source>
-        <translation>Spakar</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="368"/>
-        <source>Keys + Sticks</source>
-        <translation>Knappar + Spakar</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="368"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation>På</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation>Engelska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation>Danska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation>Holländska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation>Franska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation>Italienska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation>Tyska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation>Tjeckiska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="399"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation>Slovakiska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="400"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation>Spanska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation>Polska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="397"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation>Portugisiska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="398"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation>Ryska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="401"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation>Svenska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation>Ungerska</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation>Ukrainska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="474"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="474"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation>Inm.hjul A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="474"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation>Inm.hjul B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="474"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation>Inm.hjul C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="474"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation>Inm.hjul D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="474"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation>Inm.hjul E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="587"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6489,42 +6381,42 @@ att fungera. Detta går inte att ändra från radion.
 Är du säker?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="605"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="605"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation>Inverterad</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="605"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation>Vertikal inverterad, Horisontell normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="605"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation>Vertikal inverterad, Horisontell alternativ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="605"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation>Normal, Redigera inverterad</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation>Kinesiska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation>Japanska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation>Hebreiska</translation>
     </message>
@@ -6621,7 +6513,17 @@ att fungera. Detta går inte att ändra från radion.
         <translation>Offset för strömstyrka</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="373"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished">Invertera</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation>Varning: Byte av den interna modulen kan göra modellernas interna modulprotokoll ogiltiga!</translation>
     </message>
@@ -8904,6 +8806,11 @@ Vill du spara ändringarna?</translation>
         <translation>Vikt</translation>
     </message>
     <message>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../modeledit/mixerdialog.ui" line="296"/>
         <source>2 Beeps</source>
         <translation>2 pip</translation>
@@ -9029,11 +8936,6 @@ Vill du spara ändringarna?</translation>
         <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>Inkludera DR/Expo</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="278"/>
-        <source>Flight modes</source>
-        <translation>Flyglägen</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="506"/>
@@ -9267,7 +9169,7 @@ p, li { white-space: pre-wrap; }
         <translation>GAS</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1617"/>
+        <location filename="../firmwares/modeldata.cpp" line="1620"/>
         <source>OFF</source>
         <translation>AV</translation>
     </message>
@@ -9277,89 +9179,94 @@ p, li { white-space: pre-wrap; }
         <translation>Gaskälla</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1621"/>
+        <location filename="../firmwares/modeldata.cpp" line="1624"/>
         <source>Slave/Jack</source>
         <translation>Elev/Uttag</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1623"/>
+        <location filename="../firmwares/modeldata.cpp" line="1626"/>
         <source>Master/SBUS Module</source>
         <translation>Lärare/SBUS-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1625"/>
+        <location filename="../firmwares/modeldata.cpp" line="1628"/>
         <source>Master/CPPM Module</source>
         <translation>Lärare/CPPM-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1619"/>
+        <location filename="../firmwares/modeldata.cpp" line="1622"/>
         <source>Master/Jack</source>
         <translation>Lärare/Uttag</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1627"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished">GAS</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1630"/>
         <source>Master/Serial</source>
         <translation>Lärare/Seriell</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1629"/>
+        <location filename="../firmwares/modeldata.cpp" line="1632"/>
         <source>Master/Bluetooth</source>
         <translation>Lärare/Bluetooth</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1631"/>
+        <location filename="../firmwares/modeldata.cpp" line="1634"/>
         <source>Slave/Bluetooth</source>
         <translation>Elev/Bluetooth</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1633"/>
+        <location filename="../firmwares/modeldata.cpp" line="1636"/>
         <source>Master/Multi</source>
         <translation>Lärare/Multi</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1720"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation>INGEN</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1722"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation>SKIFTA</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1749"/>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
         <source>SW</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1751"/>
-        <location filename="../firmwares/modeldata.cpp" line="1887"/>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
         <source>Off</source>
         <translation>Av</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1762"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
         <source>---</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1764"/>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
         <source>Group </source>
         <translation>Grupp </translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1889"/>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
         <source>On</source>
         <translation>På</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1747"/>
-        <location filename="../firmwares/modeldata.cpp" line="1891"/>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation>Återställ</translation>
     </message>
@@ -9377,17 +9284,17 @@ p, li { white-space: pre-wrap; }
         <translation>Heli</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="87"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>Input</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="103"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>Specialfunktioner</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="107"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
@@ -9402,38 +9309,33 @@ p, li { white-space: pre-wrap; }
         <translation>Grundinställningar</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="90"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translation>Mixar</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="100"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>Logiska brytare</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="97"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translation>Kurvor</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="84"/>
-        <source>Flight Modes</source>
-        <translation>Flyglägen</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="94"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>Output</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="112"/>
-        <location filename="../modeledit/modeledit.cpp" line="116"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation>Anpassade skärmar</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="120"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation>Aktiverade funktioner</translation>
     </message>
@@ -9487,8 +9389,8 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation>Flyglägen</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -11424,12 +11326,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation>VARNING</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="248"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation>&lt;p&gt;Import av JumperTX data till OpenTX 2.3 är &lt;b&gt;stödjs inte kan vara mycket riskfyllt.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Det är tyvärr inte möjligt att skilja JumperTX-data från riktiga FrSky X10-data, och &lt;b&gt;du bör endast fortsätta här om  filen du öppnat kommer från en äkta FrSky X10&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Vill du verkligen fortsätta?&lt;/p&gt;</translation>
     </message>
@@ -11734,12 +11636,17 @@ a
 r</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="227"/>
-        <source>FM%1</source>
-        <translation></translation>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
+        <translation type="unfinished">FL</translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="236"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation></translation>
     </message>
@@ -11747,7 +11654,7 @@ r</translation>
 <context>
     <name>RadioSwitchWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioswitchwidget.h" line="78"/>
+        <location filename="../simulation/widgets/radioswitchwidget.h" line="77"/>
         <source>Latch/unlatch the momentary switch.</source>
         <translation>Lås/lås upp den momentana brytaren.</translation>
     </message>
@@ -11766,149 +11673,173 @@ r</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="141"/>
-        <source>TrmR</source>
-        <translation>TrmR</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="141"/>
-        <source>TrmE</source>
-        <translation>TrmH</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="141"/>
-        <source>TrmT</source>
-        <translation>TrmG</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="141"/>
-        <source>TrmA</source>
-        <translation>TrmS</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="141"/>
-        <source>Trm5</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="141"/>
-        <source>Trm6</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="141"/>
-        <source>Trm7</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="141"/>
-        <source>Trm8</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="149"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="149"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation>Tid</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="152"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="152"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="167"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="173"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="189"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="192"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="215"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation>CYK%1</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="218"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="262"/>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
         <source>GR%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="382"/>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
         <source>Source</source>
         <translation>Källa</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="394"/>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="149"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="149"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation>Reserverad1</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="149"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation>Reserverad2</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="149"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation>Reserverad3</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="149"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation>Reserverad4</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="259"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation></translation>
     </message>
@@ -11941,174 +11872,222 @@ r</translation>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation>TrmH vänster</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation>TrmH höger</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation>TrmV ner</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation>TrmV upp</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="62"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="62"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
-        <location filename="../firmwares/rawswitch.cpp" line="127"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation>Av</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Rud-</source>
-        <translation>Rod-</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Rud+</source>
-        <translation>Rod+</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Ele-</source>
-        <translation>Hjd-</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Ele+</source>
-        <translation>Hjd+</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Thr-</source>
-        <translation>Gas-</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Thr+</source>
-        <translation>Gas+</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>Ail-</source>
-        <translation>Ske-</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>Ail+</source>
-        <translation>Ske+</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T5-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T5+</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T6-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T6+</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T7-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T7+</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="48"/>
-        <source>T8-</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="48"/>
-        <source>T8+</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
-        <location filename="../firmwares/rawswitch.cpp" line="124"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation>På</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="130"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation>En</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="142"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="210"/>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
         <source>Switch</source>
         <translation>Brytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="227"/>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="133"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="154"/>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="42"/>
+        <source>Trim Ele-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="42"/>
+        <source>Trim Ele+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="43"/>
+        <source>Trim Thr-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="43"/>
+        <source>Trim Thr+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="44"/>
+        <source>Trim Ail-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="44"/>
+        <source>Trim Ail+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="157"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation>Instr.</translation>
     </message>
@@ -12718,77 +12697,77 @@ Gasen reverseras om alternativet väljs. Tomgång ligger då uppåt. Trim och ga
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2166"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation>Profilinställningar</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2166"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation>Katalogstruktur för SD-kort inte specifierad eller ogiltig</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2184"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation>Rensa</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2191"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation>Rensa alla</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2238"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation>Rensa alla timers. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2226"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation>Rensa timern. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2181"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation>Kopiera</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2182"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation>Klipp ut</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2260"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation>Klipp ut timern. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2187"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation>Radera</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2268"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation>Radera timern. Är du säker?</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2186"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation>Lägg till</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2188"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation>Flytta upp</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2189"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation>Flytta ner</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2183"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation>Klistra in</translation>
     </message>
@@ -12809,204 +12788,204 @@ Gasen reverseras om alternativet väljs. Tomgång ligger då uppåt. Trim och ga
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="154"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation>skärmbild</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ MENY ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ SIDA ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ AVSLUTA ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ UPP ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation>&lt;pre&gt;[ NER ]&lt;/pre&gt;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation></translation>
     </message>
@@ -13143,8 +13122,8 @@ OBS! All befintlig EEPROM-data som är inkompatibel med vald radiotyp kan komms 
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
-        <translation>EdgeTX simulator</translation>
+        <source>EdgeTX Simulator</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
@@ -13532,75 +13511,80 @@ Förvalt värde är konfigurerat i den valda radioprofieln.</translation>
         <translation>Radiosimulator (%1)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="319"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation>Kunde inte bestämma datakälla för uppstart.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="324"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation>Kunde inte ladda data, möjligen fel format.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="325"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation>Fel vid dataladdning</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="383"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation>Ogiltig data för uppstart. Vänligen ange en korrekt fil/sökväg.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="384"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation>Fel vid uppstart av simulatorn</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="444"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation>Data kunde inte sparas: kunde inte öppnas för skrivning: &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation>Data kunde inte sparas: kunde inte hämta data från simulatorn.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="475"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation>Ett oväntat fel inträffade när radions data skulle sparas till fil &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="476"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation>Fel vid skrivning av data</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="736"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation>Ingen joystick kan hittas, joystick inkativerad</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="834"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation>Firmware-fel: %1</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="839"/>
-        <source> - Flight Mode %1 (#%2)</source>
-        <translation> - Flygläge %1 (#%2)</translation>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SliderWidget</name>
     <message>
-        <location filename="../simulation/widgets/sliderwidget.h" line="38"/>
+        <location filename="../simulation/widgets/sliderwidget.h" line="37"/>
         <source>Right-double-click to reset to center.</source>
         <translation>Dubbel-högerklicka för att återställa till centrum.</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/sliderwidget.h" line="38"/>
+        <location filename="../simulation/widgets/sliderwidget.h" line="37"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation>&lt;p&gt;Värde (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
@@ -15745,22 +15729,22 @@ Tidsstämpel</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="919"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation>AV</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="921"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation>+= (Summera)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="923"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation>:= (Ersätt)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="932"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation>KN%1</translation>
     </message>
@@ -16934,32 +16918,32 @@ Bearbeta nu?</translation>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="50"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation>Information saknas</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="107"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation>Tema:</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="111"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation>Upphovsman:</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="115"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation>Information:</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="98"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation>Kan inte ladda %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="138"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation>Övre raden:</translation>
     </message>
@@ -16980,44 +16964,44 @@ Bearbeta nu?</translation>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation>Håll Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="403"/>
-        <source>Hold Vertical stick position.</source>
-        <translation>Håll vertikalt spakläge.</translation>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation>Fixera Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="408"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation>Förhindra vertikal ändring av spak.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation>Fixera X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="413"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation>Förhindra horisontell ändring av spak.</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
         <translation>Håll X</translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="418"/>
-        <source>Hold Horizontal stick position.</source>
-        <translation>Håll horisontellt spakläge.</translation>
     </message>
 </context>
 <context>
@@ -17458,7 +17442,7 @@ Vill du fortsätta?</translation>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1269"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
@@ -17467,7 +17451,7 @@ Model settings may be corrupted if you continue.</source>
 Modellinställningarna kan förstöras om du fortsätter.</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1272"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
         <source>Read Model Settings</source>
         <translation>Läs radioinställningar</translation>
     </message>

--- a/companion/src/translations/companion_zh_CN.ts
+++ b/companion/src/translations/companion_zh_CN.ts
@@ -4,30 +4,30 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translatorcomment>模型向导中副翼连线方式的设定</translatorcomment>
         <translation>没有副翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translatorcomment>模型向导中副翼连线方式的设定</translatorcomment>
         <translation>有副翼, 使用一个接收机通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translatorcomment>模型向导中副翼连线方式的设定</translatorcomment>
         <translation>有副翼, 使用两个接收机通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;第一个副翼通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>第二个副翼通道:</translation>
     </message>
@@ -35,27 +35,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>没有空气刹车</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>有空气刹车, 使用一个接收机通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>有空气刹车, 使用两个接收机通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;第一个空气刹车通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>第二个空气刹车通道:</translation>
     </message>
@@ -63,23 +63,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,70 +174,70 @@
         <translation>遥控器档案</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>档案名称</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>遥控器型号</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translatorcomment>遥控器档案中</translatorcomment>
         <translation>开机画面</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>其他设置</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>SD卡目录</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>制定档案目录，如果设定此目录，将代替默认备份目录</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>备份目录</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>如果设置将会代替程序一般设定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>如果设定将会覆盖一般备份允许选项</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>写入固件前允许自动备份</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>一般设定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>默认摇杆模式</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -268,622 +268,617 @@ Mode 4:
  </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translatorcomment>遥控器档案中</translatorcomment>
         <translation>MODE1 日本手 ↕升降↔方向   ↕油门↔副翼</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>MODE2 美国手 ↕油门↔方向   ↕升降↔副翼</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>MODE3 中国手 ↕升降↔副翼   ↕油门↔方向</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>MODE4 模式4   ↕油门↔副翼   ↕升降↔方向</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translatorcomment>遥控器档案中</translatorcomment>
         <translation>默认通道顺序</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;通道顺序&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;定义了新建模型时默认设置的通道顺序&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>方向 升降 油门 副翼  [R E T A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>方向 升降 副翼 油门  [R E A T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>方向 油门 升降 副翼  [R T E A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>方向 油门 副翼 升降  [R T A E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>方向 副翼 升降 油门  [R A E T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation>方向 副翼 油门 升降  [R A T E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>升降 方向 油门 副翼  [E R T A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>升降 方向 副翼 油门  [E R A T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>升降 油门 方向 副翼  [E T R A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>升降 油门 副翼 方向  [E T A R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>升降 副翼 方向 油门  [E A R T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>升降 副翼 油门 方向  [E A T R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>油门 方向 升降 副翼  [T R E A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>油门 方向 副翼 升降  [T R A E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>油门 升降 方向 副翼  [T E R A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>油门 升降 副翼 方向  [T E A R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>油门 副翼 方向 升降  [T A R E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>油门 副翼 升降 方向  [T A E R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>副翼 方向 升降 油门  [A R E T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>副翼 方向 油门 升降  [A R T E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>副翼 升降 方向 油门  [A E R T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>副翼 升降 油门 方向  [A E T R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>副翼 油门 方向 升降  [A T R E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>副翼 油门 升降 方向  [A T E R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>清除图片</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translatorcomment>遥控器档案中</translatorcomment>
         <translation>选择图片</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>选择目录</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>程序首选项</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>开机画面图片库</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Google Earch 可执行文件</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>自定义开机画面</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>自动备份目录</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>只显示自定义开机画面</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>显示自定义和系统开机画面</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>选择可执行文件</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>模拟器设置</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>校准</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>蓝色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>绿色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>红色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>橙色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>黄色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>只截图到剪贴板中</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>使用游戏杆</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>游戏杆</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>模拟器背光颜色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>模拟器音量调节</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>我的遥控器</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>选择你的快照目录</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>找不到游戏杆</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>空白:在遥控器档案中找不到遥控器设定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>允许:不明日期的遥控器设定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>允许:遥控器设定保存到 %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translatorcomment>对话框标题栏</translatorcomment>
         <translation>选择你的图片库文件夹</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translatorcomment>对话框标题栏</translatorcomment>
         <translation>选择你的模型和设定备份文件夹</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translatorcomment>对话框标题栏</translatorcomment>
         <translation>选择 Google Earth 可执行文件</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translatorcomment>对话框标题栏</translatorcomment>
         <translation>选择模拟SD卡目录结构的电脑文件夹</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>打开图片并载入</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>图片 (%1)</translation>
     </message>
@@ -891,30 +886,30 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">写入文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,33 +947,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -989,255 +984,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">左摇杆水平方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished">左摇杆垂直方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished">右摇杆上下方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">右摇杆水平方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">飞行  [Flight]</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished">有中位旋钮</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2位弹簧开关</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished">2位开关</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished">3位开关</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">运算方式  [Function]</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">标准LCD  [Standard]</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">小</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">两侧</translation>
     </message>
@@ -1245,17 +1250,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished">负范围</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished">中值</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished">正范围</translation>
     </message>
@@ -1263,132 +1268,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished">舵机中位 [Subtrim]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished">舵机反向 [Dir]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">曲线       [Curve]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished">PPM中位脉宽</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished">线性微调 [Linear]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished">通道%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished">正向  [→]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished">反向  [←]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished">复制</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished">粘贴</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1431,57 +1436,57 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">无法写入文件 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1497,12 +1502,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1510,173 +1515,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished">启用时蜂鸣 [Warning]</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished">错误</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished">程序首选项</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished">模拟器现在还不支持此版固件</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1718,23 +1733,23 @@ Do you want to import settings from a file?</source>
         <translation>打印到文件</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translatorcomment>Compare 模型对比对话框</translatorcomment>
         <translation>打印文档</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translatorcomment>Compare 模型对比对话框</translatorcomment>
         <translation>选择PDF输出文件</translation>
@@ -1761,7 +1776,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translatorcomment>ConclusionPage 模型配置页面最后确认按钮中使用</translatorcomment>
         <translation>好的, 我明白。</translation>
@@ -1770,19 +1785,19 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translatorcomment>CopyProcess</translatorcomment>
         <translation>写入错误</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translatorcomment>CopyProcess</translatorcomment>
         <translation>无法写入 %1 (原因: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translatorcomment>CopyProcess</translatorcomment>
         <translation>无法打开 %1 (原因: %2)</translation>
@@ -1791,22 +1806,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished">标准LCD  [Standard]</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished">%1 点</translation>
     </message>
@@ -1889,32 +1904,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">直线</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">非对称指数曲线</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">左右中心对称</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">左右镜像对称</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1922,7 +1937,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,22 +1945,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished">差动曲线 [Diff]</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished">指数曲线 [Expo]</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished">其他曲线 [Func]</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1953,113 +1968,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished">加</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">编辑</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished">复制</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished">粘贴</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2067,343 +2082,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished">锁定通道值 %1     [Override]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished">教练开关 方向       [Trainer RUD]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished">教练开关 升降       [Trainer ELE]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished">教练开关 油门       [Trainer THR]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished">教练开关 副翼       [Trainer AIL]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished">操纵杆位变微调      [Instant Trim]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished">播放蜂鸣            [Play Sound]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished">振动  [Haptic]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished">重设</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>关闭音频功放</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished">播放一次但开机时不播放  [!1x]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished">播放一次  [1x]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished">1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished">%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished">设为</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished">开启 Vario 声音     [Vario]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished">播放声音文件        [Play Track]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished">播放同时振动        [Play Both]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished">播放数值            [Play Value]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished">SD Log 记录         [SD Logs]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished">音量                [Volume]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished">背光                [Backlight]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished">截屏                [Screenshot]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished">背景音乐播放        [Bg Music]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished">背景音乐暂停        [Bg Music Pause]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished">内置高频头对频</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished">外置高频头对频</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished">飞行  [Flight]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished">回传设置 Tele</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished">禁用</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2411,128 +2446,128 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>启动开关</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished">使用游戏杆</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished">复制</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished">粘贴</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2540,22 +2575,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished">数字</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">条状图</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished">脚本</translation>
     </message>
@@ -2563,47 +2598,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">飞行模式  [Modes]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2660,82 +2695,82 @@ Do you want to import settings from a file?</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>打开固件文件</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished">固件: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished">图片: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished">档案图片</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>不能从固件文件 %1 中载入内嵌图片 .</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>打开图片文件以载入</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>图片 (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>不能打开图片文件 %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>不能打开遥控器文档中图片 %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>不能从开机图片库中载入图片 %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>图片已经保存到 %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>图片刷新错误</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>无法从文件 %1 中刷新图片</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>文件保存错误</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>无法写入文件 %1</translation>
     </message>
@@ -2743,22 +2778,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2766,53 +2801,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished">启动开关</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"> 无法输出到这个主板!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished">源 %1 无法输出到这个主板!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX只允许最大%1点曲线 </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX只允许最大%1点曲线 </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished">OpenTX在这个主板上不支持此项功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished">OpenTX 不接受此遥控器协议</translation>
     </message>
@@ -2820,52 +2855,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished">启用</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2944,102 +2979,83 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished">下载中: </translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation type="unfinished">下载失败:%1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished">可能导致这样的原因:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished">- Eeprom 来自 OpenTX 的新版本</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished">- Eeprom 不是来自 OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished">- Eeprom 不是来自 ErSky9X</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished">- Eeprom 文件大小非法</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished">- Eeprom 文件系统非法</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished">- Eeprom 来自未知的主板</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished">- Eeprom 来自错误的主板</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished">- 不支持 Eeprom 备份</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished">- 抱歉，无法找出确定原因</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished">警告：</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished">- 你的遥控器可能使用了错误的固件，
  eeprom 大小为4096但仅前半部分的2048被使用</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3048,12 +3064,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3061,12 +3077,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3074,12 +3090,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;指定第1个升降副翼舵机通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>&lt;br&gt;指定第2个升降副翼舵机通道:</translation>
     </message>
@@ -3087,42 +3103,42 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">打开文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">写入文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3130,23 +3146,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">启用</translation>
     </message>
@@ -3154,129 +3170,109 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translatorcomment>Inputs对话框</translatorcomment>
-        <translation>飞行模式   [Modes]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>输入名称   [Input]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translatorcomment>Inputs对话框</translatorcomment>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translatorcomment>Inputs对话框</translatorcomment>
-        <translation>混控的输入源.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>比例       [Weight]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>启用开关   [Switch]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translatorcomment>Inputs对话框</translatorcomment>
-        <translation>启用开关 
-不选择则默认一直启用.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>摇杆作用于 [Side]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>负侧 [NEG]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>正侧 [POS]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>两侧 [ALL]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>缩放       [Scale]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>微调       [Trim]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>曲线       [Curve]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>作用于输入源的曲线.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>输入来源   [Source]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>此条名称   [Line]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>偏移       [Offset]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translatorcomment>Inputs对话框</translatorcomment>
         <translation>混控的输入源</translation>
@@ -3288,22 +3284,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation>编辑 %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3311,22 +3307,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>油门通道  [Throttle]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>偏航通道  [Yaw]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>仰俯通道  [Pitch]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>滚转通道  [Roll]:</translation>
     </message>
@@ -3334,262 +3330,262 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished">关闭</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished">开始通道  [CH]</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3597,367 +3593,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished">不允许锁定通道值功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished">可选择启用 FAI 模式 (没有回传)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished">一直启用 FAI 模式 (没有回传)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished">移除 D8 FrSky 协议支持,因为在20151月1日后在欧洲销售的遥控器中使用此协议是不合法的</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">禁用直升机菜单和CCPM混控菜单</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">禁用GV[Global variables]功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished">使用 另一个 SQT5 font</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished">使用旋钮进行菜单导航</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished">FrSky Taranis X9D+</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished">FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">振动模块已经安装</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished">FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished">遥控器关机前确认</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished">Horus 摇杆已安装 (霍尔传感器)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished">只用与 DEV pcb 版本</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished">允许直升机菜单和斜盘混控支持</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished">GV  [Global variables]</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished">在模型配置菜单通过移动摇杆自动设置源</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished">在模型配置菜单通过拨动开关自动设置源</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished">无图形选择框和滑杆</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished">电池图标</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished">不使用粗体高亮活动项目</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished">允许通过同时按上下键重设数值</translation>
     </message>
@@ -3965,28 +4005,28 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translatorcomment>FlapsPage</translatorcomment>
         <translation>没有襟翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>有襟翼, 使用一个接收机通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>有襟翼, 使用两个接收机通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;第一个襟翼通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>第二个襟翼通道:</translation>
     </message>
@@ -3995,7 +4035,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>将模型和设置写入到遥控器</translation>
     </message>
@@ -4060,51 +4100,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>写入到遥控器</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>当前档案: %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>选择遥控器备份文件</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>此文档包含错误的遥控器校准数据.设置没有修改</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>此文档包含错误的遥控器设置数据.设置没有修改</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>无法写入文件 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>写入文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>这个遥控器固件属于其他产品，检查文件和配置!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>这个遥控器固件已经过期, 请升级!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>无法检查模型和设置兼容性! 仍然继续么?</translation>
     </message>
@@ -4182,103 +4222,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>写入到遥控器</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>打开固件文件</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 可能是非法的固件文件</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>固件文件非法.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>固件中没有开机画面.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>档案图片 %1 无效.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>打开图片文件用作遥控器开机画面</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>图片 (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>图片无法从 %1 中加载</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>图片库中的图片无法被加载</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>无法找到开机画面图片</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>无法保存定制固件</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>写入固件到遥控器</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>固件检查失败</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>无法检查遥控器中的固件</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>新的固件于当前安装的固件不兼容!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>转换失败</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>无法转换此固件中的模型和设置, 将使用原始数据</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>恢复失败</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>无法将模型和设置恢复到遥控器. 模型和设置数据可以在 %1 中找到</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>烧录完成</translation>
     </message>
@@ -4286,52 +4326,52 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>未找到可执行文件 %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>写入中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>读取中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>验证中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>例如: OpenTX for 9X 主板 或 OpenTX for 9XR 主板</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>例如: OpenTX for M128 / 9X 主板 或 带有M128芯片的OpenTX for 9XR 主板</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>例如: OpenTX for Gruvin9X 主板</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4340,7 +4380,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 请检查高级烧录选项设置正确的cpu型号.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4349,7 +4389,7 @@ Please select an appropriate firmware type to program it.</source>
 请选择合适的用来编程它的固件类型.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4358,22 +4398,22 @@ You are currently using:
  %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>你的遥控器似乎没有连接到到USB端口，或没有安装驱动程序!!!.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>烧录完成 (退出码 = %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>烧录完成但包含错误</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>熔丝位: Low=%1 High=%2 Ext=%3</translation>
     </message>
@@ -4381,7 +4421,7 @@ You are currently using:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
@@ -4436,225 +4476,240 @@ You are currently using:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation type="unfinished">设为</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>全局变量[GV] %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>屏幕弹窗提示</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished">不使用微调</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished">使用单独的微调值</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished">使用 FM%1 的微调值</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished">使用 FM%1 的微调值 + 单独的微调偏移值</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">使用单独的取值</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished">复制</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished">粘贴</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>清除</translation>
     </message>
@@ -4662,19 +4717,18 @@ You are currently using:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translatorcomment>用于FM设定</translatorcomment>
-        <translation>飞行模式[FM] %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translatorcomment>FlightModePanel</translatorcomment>
         <translation>(%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translatorcomment>FlightModePanel</translatorcomment>
         <translation>(默认)</translation>
@@ -4683,17 +4737,17 @@ You are currently using:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>有副翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>无副翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>副翼:</translation>
     </message>
@@ -4701,17 +4755,17 @@ You are currently using:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4719,13 +4773,13 @@ You are currently using:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished">正向  [→]</translation>
     </message>
@@ -4743,17 +4797,18 @@ You are currently using:
         <translation>可自定义开关</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished">开始通道  [CH]</translation>
     </message>
@@ -4763,7 +4818,12 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4771,8 +4831,13 @@ You are currently using:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4917,13 +4982,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;只有当你知道自己在做什么时才进行操作.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>重设遥控器熔丝位</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>从遥控器中读取熔丝位</translation>
     </message>
@@ -4931,44 +4996,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished">使用单独的取值</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation type="unfinished">使用FM%1值</translation>
     </message>
 </context>
 <context>
@@ -4996,62 +5051,62 @@ These will be relevant for all models in the same EEPROM.</source>
 对相同的EEPROM, 对所有模型这些设置都是相同的.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translatorcomment>General Edit????</translatorcomment>
         <translation>设定</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translatorcomment>General Edit</translatorcomment>
         <translation>全局功能</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translatorcomment>General Edit</translatorcomment>
         <translation>教练功能</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translatorcomment>General Edit????</translatorcomment>
         <translation>硬件</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translatorcomment>General Edit</translatorcomment>
         <translation>校准</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>此文档包含错误的数据. 未读取遥控器校准数据</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>此文档包含错误的数据. 未读取开关/旋钮配置</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>此文档包含错误的数据. 未读取硬件相关参数</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>你想要存储校准数据到 %1 档案&lt;br&gt;覆盖当前已经存在的校准数据么?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>校准数据和硬件参数已经存储.</translation>
     </message>
@@ -5090,8 +5145,8 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">飞行模式 FM</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5127,185 +5182,208 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished">硬件</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">回传设置 Tele</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">教练功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">SBUS 教练功能  [SBUS Trainer]</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">除错 [Debug]</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished">微调</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished">导航键</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished">可切换</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished">全局</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -5322,206 +5400,204 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation>只读解锁  [Readonly Unlock]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>依照UTC调整时间        [From UTC]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>语音语言         [Voice Language]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>国家代码           [Country Code]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>反向摇杆          [Stick Reverse]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>FAI 模式               [FAI Mode]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>如果安装有GPS回传则自动调整遥控器时钟.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>自动调整时钟</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>最大上升率时Vario音调       [Max]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>喇叭音量                 [Volume]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>背光开关                 [Switch]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>声音模式             [Sound Mode]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>颜色 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>颜色 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>喇叭音调 (仅喇叭)         [Pitch]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>如果值非0, 任何按键将会开启背光, 并在所设定秒数后关闭.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation> 秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>背光颜色                  [Color]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>蜂鸣器</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>喇叭</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>蜂鸣器和语音</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>喇叭和语音</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>蜂鸣器音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>WAV播放音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Vario音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>背景音乐音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation> 毫秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>背光自动关闭时间       [Duration]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>告警时背光闪烁            [Alarm]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>升降率为0时Vario音调       [Zero]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>升降率0时Vario重复率     [Repeat]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5532,7 +5608,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5547,37 +5623,37 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;取值范围 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>背光亮度             [Brightness]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>旋转编码器导航           [RotEnc]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>美国</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>日本</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>欧洲</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5618,252 +5694,112 @@ MODE4 模式4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>MODE1 日本手↕升降↔方向   ↕油门↔副翼</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>MODE2 美国手↕油门↔方向   ↕升降↔副翼</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>MODE3 中国手↕升降↔副翼   ↕油门↔方向</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>MODE4 模式4 ↕油门↔副翼   ↕升降↔方向</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;通道顺序&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;定义了当新的混控创建时默认的通道顺序.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation>方向 升降 油门 副翼  [R E T A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation>方向 升降 副翼 油门  [R E A T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation>方向 油门 升降 副翼  [R T E A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation>方向 油门 副翼 升降  [R T A E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation>方向 副翼 升降 油门  [R A E T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation>方向 副翼 油门 升降  [R A T E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation>升降 方向 油门 副翼  [E R T A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation>升降 方向 副翼 油门  [E R A T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation>升降 油门 方向 副翼  [E T R A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation>升降 油门 副翼 方向  [E T A R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation>升降 副翼 方向 油门  [E A R T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation>升降 副翼 油门 方向  [E A T R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation>油门 方向 升降 副翼  [T R E A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation>油门 方向 副翼 升降  [T R A E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation>油门 升降 方向 副翼  [T E R A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation>油门 升降 副翼 方向  [T E A R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation>油门 副翼 方向 升降  [T A R E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation>油门 副翼 升降 方向  [T A E R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation>副翼 方向 升降 油门  [A R E T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation>副翼 方向 油门 升降  [A R T E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation>副翼 升降 方向 油门  [A E R T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation>副翼 升降 油门 方向  [A E T R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation>副翼 油门 方向 升降  [A T R E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation>副翼 油门 升降 方向  [A T E R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5874,334 +5810,367 @@ Acceptable values are 3v..12v</source>
 允许值是3V - 12V</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished">教练功能</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>按键帽模式</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>摇杆模式                [MODE]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>公制  [Metric]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>英制  [Imperial]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>默认通道顺序[Default Ch Order]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>GPS坐标格式  [GPS Coordinates]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>最小</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>忘记关机定时器    [Inactivity]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>显示开机画面   [Splash Screen]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>显示屏对比度        [Contrast]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>遥控器电池图标范围     [Range]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>振动强度     [Haptic Strength]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>LCD显示屏类型  [LCD Disp Type]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>当静音时 开机告警  [Sound Off]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>遥控器电量警告   [Battery Low]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>振动时长       [Haptic Length]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>MAVLink 波特率     [Baud Rate]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>禁用  [Quiet]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>只有告警  [Alarm]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>忽略按键  [NoKey]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>开启  [All]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>标准LCD  [Standard]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>光王LCD  [Optrex]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">0s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">0.5s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6216,72 +6185,72 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>极短</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>较短</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>正常</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>较长</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>极长</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>开关拨过中档时播音延迟 [Delay]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>单位制                 [Units]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>振动             [Haptic Mode]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>蜂鸣时长         [Beep Length]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>蜂鸣音             [Beep Mode]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6292,13 +6261,15 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>只有告警  [Alarm]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished">1s</translation>
     </message>
@@ -6306,179 +6277,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished">按键  [Keys]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished">摇杆  [Sticks]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished">按键和摇杆  [Keys + Sticks]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished">启用</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished">英语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished">荷兰语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished">法语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished">意大利语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished">德语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished">捷克语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished">慢动作  [Slow]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished">西班牙语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished">波兰语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished">葡萄牙语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished">瑞典语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished">匈牙利语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished">旋转编码器A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">旋转编码器B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">旋转编码器C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">旋转编码器D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">旋转编码器E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6486,18 +6457,18 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translatorcomment>Gyropage</translatorcomment>
         <translation>无陀螺仪</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>有陀螺仪, 通过开关控制感度</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>有陀螺仪, 通过旋钮控制感度</translation>
     </message>
@@ -6505,118 +6476,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished">蓝牙 [Bluetooth]</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>音频停播时自动静音</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished">当前修正 [Offset]</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6697,22 +6678,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>油门通道  [Throttle]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>偏航通道  [Yaw]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>仰俯通道  [Pitch]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>滚转通道  [Roll]:</translation>
     </message>
@@ -6720,18 +6701,18 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished">无效的 EEPROM 文件 %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">写入文件错误 %1:
@@ -6741,160 +6722,160 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>上移</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>下移</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>清除所有输入</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished">折线</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>添加  (&amp;A)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>编辑  (&amp;E)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translatorcomment>InputPanel</translatorcomment>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>删除  (&amp;D)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>复制  (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>剪切  (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>粘贴  (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>克隆  (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished">输入</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6935,96 +6916,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7032,17 +7013,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished">反向  [←]</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished">或非</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7050,7 +7031,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
     </message>
@@ -7058,122 +7039,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished">正向  [→]</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished">数值1 ＞ 数值2           a&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished">数值1 ＜ 数值2           a&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished">|数值1| ＞ 数值2        |a|&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished">|数值1| ＜ 数值 2       |a|&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished">与运算                   AND</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished">或运算                   OR</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished">异或运算                 XOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished">数值1 ＝ 数值2           a=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished">数值1 !＝ 数值2          a!=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished">数值1 ＞ 数值2           a&gt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished">数值1 ＜ 数值2           a&lt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished">数值1 ≥ 数值2           a&gt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished">数值1 ≤ 数值2           a&lt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished">数值1变动   ≥ 数值2     d&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished">|数值1变动| ≥ 数值2     d&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished">数值1 ＝ 数值2           a=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished">数值1  ≈  数值2         a~x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished">定时开关                 Timer</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished">粘滞键                   Sticky</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished">边沿触发                 EDGE</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished">未知[Unknown]</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7181,117 +7162,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>运算方式  [Function]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>数值1  [V1]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>数值2  [V2]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>与开关  [AND Sw]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>持续时间  [Duration]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>延迟  [Delay]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">保持</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished">复制</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished">粘贴</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translatorcomment>LogicalSwitchPanel 边沿触发使用</translatorcomment>
         <translation>(立刻 [instant])</translation>
@@ -7346,52 +7332,52 @@ Are you sure ?</source>
         <translation>打开 Log 文件</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>回传 logs</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>改变绘制标题</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>新的绘制标题:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>改变坐标轴标签</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>新的坐标轴标题:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>改变图表的名称</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>新的图表名称:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7400,74 +7386,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 包含高度的列 &quot;GAlt&quot; 和包含速度的列 &quot;GSpd&quot; 是可选的</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>无法写入文件 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>光标 A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>光标 B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>时间偏移: %1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>升降速率: %1 m/s</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>选择你的 log 文件</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>可用项目</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>选择的 Log 文件共有 %2 条记录, 其中 %1 条记录无效</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>持续时间</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation> (L1)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation></translation>
     </message>
@@ -7475,738 +7461,738 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>文件已载入</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>新的主题将在重新打开程序后使用.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>打开模型和配置文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>同步SD卡</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>从遥控器中读取固件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>将固件写入遥控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>从遥控器中读取模型和配置</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>将模型和配置写入遥控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>保存遥控器备份到文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>读取遥控器固件并保存到文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>如果你觉得此程序有用, 请通过&lt;a href=&apos;%1&apos;&gt;捐赠&lt;/a&gt;支持</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>关于 Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translatorcomment>MainWindow</translatorcomment>
         <translation>新建配置文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>建立新的模型和设置文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>打开...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>保存模型和配置文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>另存为...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation type="unfinished">关闭</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>退出程序</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished">不能移除遥控器档案</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished">默认遥控器档案无法被移除.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>经典</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>经典 companion9x 图标主题</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation>Yerico图标主题</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>黄色圆润甜蜜图标主题</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>单色黑白</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>黑色图标的黑白主题</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>单色白色</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>白色图标的黑白主题</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>单色蓝色</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>蓝色图标的黑白主题</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>小</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>使用小的工具栏图标</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translatorcomment>MainWindow</translatorcomment>
         <translation>普通</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>使用普通大小的工具栏图标</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>大</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>使用大工具栏图标</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>超大</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>使用特大的工具栏图标</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>使用系统语言</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>显示程序的关于对话框</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>查看 Log 文件...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>打开和查看 Log 文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>设置...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>编辑设定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>比较模型...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>比较模型参数</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>编辑遥控器开机画面...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>编辑你的遥控器的开机画面</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>从遥控器中读取固件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>将固件写入遥控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>添加遥控器档案</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>将模型和配置写入遥控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>从遥控器中读取模型和配置</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>配置通讯...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>配置与遥控器通讯的软件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>将备份写入遥控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>将备份文件写入到遥控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>备份遥控器到文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>保存一个包含所有遥控器设置和模型数据的备份文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>同步SD卡</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>最近使用的文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>设置菜单语言</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>设置程序图标</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>设置图标大小</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>读/写</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>写入</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>已准备好</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8214,63 +8200,63 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished">你希望覆盖遥控器一般设定么？</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation type="unfinished">
@@ -8278,7 +8264,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation type="unfinished">
@@ -8286,384 +8272,384 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation type="unfinished">复制</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation type="unfinished">粘贴</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation type="unfinished">模型名称  [Model Name]</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation type="unfinished">模型向导</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>编辑模型 %1:</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>无法找到文件 %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>打开文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>打开文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>另存为</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished">加</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1已经修改.
 想要保存修改么?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>打开备份的模型和设置文件</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>无效的二进制备份文件 %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">编辑</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8671,143 +8657,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8815,12 +8806,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8833,50 +8824,67 @@ Do you want to save your changes?</source>
         <translation>对话框</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">0.00</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>延迟 [Delay]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>慢动作  [Slow]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>正向  [Up]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>负向  [Dn]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">精确度</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8901,186 +8909,132 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;如果慢动作值不为0, 混控的输出将按照指定的速度慢动作 -&amp;gt; 所设定数值为舵机从 -100% 运动到 +100%所需要时间.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>微调       [Trim]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>偏移       [Offset]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>比例       [Weight]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>名称       [Name]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translatorcomment>第一次出现 Mixer的主页条目概览中</translatorcomment>
         <translation>输入源     [Source]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>混控方式   [Multiplex]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>启用时蜂鸣 [Warning]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>此混控使用的曲线</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>使用 DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>飞行模式   [Modes]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>开启开关   [Switch]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>混控警告 
-当本条混控启用时发出蜂鸣.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translatorcomment>1声蜂鸣  [1]</translatorcomment>
         <translation>关闭     [OFF]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1声蜂鸣  [1]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2声蜂鸣  [2]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3声蜂鸣  [3]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translatorcomment>禁用微调 用在FM设定中</translatorcomment>
         <translation>不使用 [OFF]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translatorcomment>不使用 [OFF]</translatorcomment>
         <translation>使用    [On]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>混控的输入源</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>混控方式 
-
-规定了混控值如何混合 
-
-&quot;+&quot;表示本混控值将会与此通道中的上条2混控 值相加.
-
-&quot;*&quot;表示本混控值将会与此通道中的上条混控值相乘.
- 
-&quot;R&quot;表示本混控值将会取代此通道中的上条混控
-如果开关关闭此条混控将会被忽略.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>与前一行的输出值相加后输出       [Add]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>与前一行的输出值相乘后输出       [Multiply]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translatorcomment>与前一行的输出值相乘后输出       [Multiply]</translatorcomment>
         <translation>取代前一行的输出值               [Replace]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>曲线       [Curve]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>用来开启此条混控的开关 
-如果不设定开启开关则默认此条混控一直启用.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9088,22 +9042,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9111,136 +9065,136 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>向上移动此行</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>向下移动此行</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Dn</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>清除本页所有混控</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>无空白混控存储位置!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>添加  (&amp;A)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>编辑  (&amp;E)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>切换高亮  (&amp;T)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>删除  (&amp;D)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>复制 (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>剪切  (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>粘贴  (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>克隆  (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>清除混控?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>是否真的删除所有混控?</translation>
     </message>
@@ -9248,19 +9202,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished">设为油门杆   [Thr Source]</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation type="unfinished">油门</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9308,32 +9267,49 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished">正向  [→]</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9351,65 +9327,60 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>遥控器模拟器</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>设置 Setup</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>直升机 Heli</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>飞行模式 FM</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>输入 Inputs</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translatorcomment>!!!! mixes--&gt;mixer</translatorcomment>
         <translation>混控 Mixer</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>输出 Outputs</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translatorcomment>ModelEdit</translatorcomment>
         <translation>曲线 Curves</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>逻辑开关 Logical Sw</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>特殊功能 Special Func</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>回传设置 Tele</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9463,8 +9434,8 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">飞行模式 FM</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9500,590 +9471,600 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translatorcomment>指微调的步长</translatorcomment>
         <translation>先小后大  [Exp]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>很小  [Extra Fine]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>小  [Fine]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>中等  [Medium]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>大  [Coarse]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translatorcomment>Model Printer</translatorcomment>
         <translation>未知[Unknown]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished">使用游戏杆</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished">启用</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished">模式</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished">通道数  [Channels]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished">PPM 延迟  [Delay]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished">极性  [Polarity]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished">遥控器射频协议    [Protocol]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished">接收机设置[Reciever]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translatorcomment>Model Printer</translatorcomment>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished">飞行模式  [Modes]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished">开启  [All]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished">边沿触发                 EDGE</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished">粘滞键                   Sticky</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished">定时开关                 Timer</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished">持续时间  [Duration]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished">舵机上下限扩展
 [Extended Limits]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished">显示检查单
 [Checklist]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished">手动  [Manual]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished">用关机位置  [Auto]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished">失控保护方式 [Failsafe Mode]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished">不输出脉冲  [No Pulse]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished">未设置</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished">按键帽模式</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished">从不  [Never]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished">一直  [Always]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished">微调</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished">导航键</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished">可切换</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished">全局</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished">启用时蜂鸣 [Warning]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished">高度</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished">最大高度</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished">垂直速度</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished">A1  模拟值1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished">A2  模拟值2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished">A3  模拟值3</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished">A4  模拟值4</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished">FAS</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished">锂电总电压</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished">数字</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished">条状图</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished">脚本</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished">文件名</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation>不使用微调[Notrim]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation>偏移[Offse](%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation>不使用 DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>在所有飞行模式中禁用</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation>立刻执行[instant]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>自定义[Custom]</translation>
     </message>
@@ -10091,27 +10072,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>固定翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>多轴</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>直升机</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>模型名称:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>模型种类:</translation>
     </message>
@@ -10119,27 +10100,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished">模型编号        </translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10399,285 +10380,290 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished">负  [Negative]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished">教练功能  [Trainer Port]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished">内置高频头  [Internal RF]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished">外置高频头  [External RF]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished">附加高频头  [Extra RF]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished">高频头  [Radio System]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10685,58 +10671,58 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translatorcomment>自定义回传中使用</translatorcomment>
         <translation>设为</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>保持 [Hold]</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>不输出脉冲  [No Pulse]</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10744,456 +10730,456 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>输入</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>比例  [Weight]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation>纵向循环螺距  [Long]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation>横向循环螺距  [Lateral]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>总距  [Collective]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>飞行模式  [Modes]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>飞行模式  [Modes]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>启用开关  [Switch]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished">模型图片  [Medel Image]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished">油门</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished">开关位置告警  [Switch Positions]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished">旋钮位置告警  [Pot Positions]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished">Time  当前时间</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished">倒数报数</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">模式</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished">开始通道  [CH]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished">直升机</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">运算方式  [Function]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished">遥控器射频协议    [Protocol]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished">高度计</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished">Vario 传感器</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished">顶部横条</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished">电压传感器</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished">高度传感器</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>可自定义开关</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished">参数</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished">GF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>通道</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>名称  [Name]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished">输出 Outputs</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished">舵机中位 [Subtrim]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished">曲线       [Curve]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished">直线</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished">回传设置 Tele</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation>舵机下限  [Min]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation>舵机上限  [Max]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>全局变量  [Global Variables]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>输入</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>混控  [Mixers]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>多点曲线  [Curves]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>逻辑开关  [Logical Sw]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>特殊功能  [Special Func]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>单位  [Unit]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>RSSI 告警  [RF Quality Alarms]</translation>
     </message>
@@ -11201,7 +11187,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11209,22 +11195,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>油门通道  [Throttle]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>偏航通道  [Yaw]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>仰俯通道  [Pitch]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>滚转通道  [Roll]:</translation>
     </message>
@@ -11232,22 +11218,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11255,17 +11241,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>油门切断  [Throttle Cut]</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>油门计时器  [Throttle Timer]</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>飞行计时器  [Flight Timer]</translation>
     </message>
@@ -11273,40 +11259,40 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">打开文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">写入文件错误 %1:
@@ -11336,17 +11322,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>打印到文件</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>打印文档</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11373,12 +11359,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
@@ -11394,22 +11380,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11417,24 +11403,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11442,97 +11428,107 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished">功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished">新建配置文件</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11540,30 +11536,30 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">无法写入文件 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished">无法删除临时文件: %1</translation>
     </message>
@@ -11571,12 +11567,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11672,12 +11668,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11693,360 +11694,460 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation type="unfinished">TrmR  方向微调</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation type="unfinished">TrmE  升降微调</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation type="unfinished">TrmT  油门微调</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation type="unfinished">TrmA  副翼微调</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished">Batt  控电电压</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished">Time  当前时间</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished">MAX   最大</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished">CYC%1  循环螺距</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished">启用</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished">THs  油门激活</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished">TH%  油门比例</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished">THt  油门计时</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished">One  单次</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished">回传设置 Tele</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translatorcomment>RudderPage</translatorcomment>
         <translation>没有方向舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translatorcomment>RudderPage</translatorcomment>
         <translation>有方向舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;方向舵通道:</translation>
     </message>
@@ -12054,20 +12155,20 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">打开文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12075,319 +12176,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished">对象</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished">Alt  高度</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished">精确度</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished">比例</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished">自动偏移</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished">旋翼数</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished">系数</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished">过滤器</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished">运算</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished">加</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished">平均值</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished">乘以</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished">总计</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished">锂电单片电压</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished">消耗</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished">最低</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished">第%1片</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished">最高</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished">每片电压差</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished">原始值 (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished">小时</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished">分</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished">秒</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12619,87 +12735,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>计时器[Timer] %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished">复制</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished">粘贴</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12707,7 +12823,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>升降舵通道:</translation>
     </message>
@@ -12715,204 +12831,204 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12920,122 +13036,122 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished">可用档案:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished">可用的遥控器:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished">用于模拟器的遥控器档案 ID 或名称.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished">模拟的遥控器类型 (一般在遥控器档案中定义).</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished">警告: 无法初始化 SDL:
 %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished">错误:没有可用的模拟器库.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished">错误: 未找到遥控器档案或模拟器固件.
@@ -13046,7 +13162,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13195,74 +13311,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished">回传模拟器</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished">Debug 输出</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished">模拟器帮助</translation>
     </message>
@@ -13387,32 +13503,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished">所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13425,67 +13541,72 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished">Companion 模拟器</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished">无法打开游戏杆, 游戏杆功能禁用</translation>
     </message>
@@ -13512,17 +13633,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>开机图片库 - 第%1页/共%2页</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>图片库 %1 中的图片无效</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>在图片库中没有找到有效的图片, 请检查你的设置</translation>
     </message>
@@ -13530,7 +13651,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>通道 %1</translation>
     </message>
@@ -13538,7 +13659,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished">无法找到文件 %1!</translation>
     </message>
@@ -13547,9 +13668,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13574,19 +13695,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13595,47 +13716,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13643,141 +13764,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13785,17 +13906,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>方向舵通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>升降舵通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>只剩一个通道可用!&lt;br&gt;可能你需要不使用向导来配置模型.</translation>
     </message>
@@ -13803,22 +13924,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>升降舵和方向舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>只有升降舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>V尾</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>尾翼类型:</translation>
     </message>
@@ -14151,7 +14272,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">回传屏幕 %1</translation>
     </message>
@@ -14159,28 +14280,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>低告警</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>紧急告警</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (不支持)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">表单</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished">RxBt  接收机电压</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VSpd  垂直速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Hdg  航向角</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GSpd  GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">Curr  电流</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt  高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">表单</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished">Cells  锂电电压</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished">Fule Qty  油量</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished">GALT  GPS高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished">VFAS  FAS传感器电压</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished">A4  模拟值4</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished">ASpd  空速</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">Tmp1  温度1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished">RxBt  接收机电压</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished">伏 / 比值          </translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ  Z轴加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX  X轴加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">Tmp2  温度2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished">Rpm</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished">A1  模拟值1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY  Y轴加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VSpd  垂直速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished">A2  模拟值2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished">A3  模拟值3</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Fule  燃油</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI  信号强度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Hdg  航向角</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">Curr  电流</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt  高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished">Date  日期</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GSpd  GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">表单</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Fule  燃油</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished">Rpm</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">Tmp2  温度2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VSpd  垂直速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Hdg  航向角</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished">Date  日期</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished">A2  模拟值2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX  X轴加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished">Batt  控电电压</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished">GALT  GPS高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished">A1  模拟值1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI  信号强度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished">VFAS  FAS传感器电压</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">Tmp1  温度1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt  高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ  Z轴加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">Curr  电流</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GSpd  GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY  Y轴加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14297,72 +15351,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished">复制</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished">粘贴</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished">删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14385,425 +15439,151 @@ Too many errors, giving up.</source>
         <translation>模拟</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished">25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation>重播 SD Log 文件</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished">1/5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished">5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation>现在没有载入任何 log 文件</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation>载入</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation>行数
 时间戳</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation>RxBt  接收机电压</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation>伏 / 比值          </translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation>VFAS  FAS传感器电压</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation>V</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation>RSSI  信号强度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation>Curr  电流</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation>Cells  锂电电压</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation>A1  模拟值1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation>A2  模拟值2</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation>ASpd  空速</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation>A3  模拟值3</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation>GALT  GPS高度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation>A4  模拟值4</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation>GSpd  GPS速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation>Tmp1  温度1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation>Hdg  航向角</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation>Tmp2  温度2</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation>Date  日期</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation>Rpm</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>Fule  燃油</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation>AccX  X轴加速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation>Fule Qty  油量</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation>AccY  Y轴加速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation>VSpd  垂直速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation>AccZ  Z轴加速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation>Alt  高度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation>Log 文件</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation>LOG文件 (*.csv)</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
         <translation>错误   无效的文件</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>使用油门通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>不使用油门通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;油门通道:</translation>
     </message>
@@ -14829,138 +15609,138 @@ hh:mm:ss</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished">计时器[Timer] %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished">静音  [Silent]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">蜂鸣  [Beeps]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">语音  [Voice]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">振动  [Haptic]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished">5s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished">10s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished">20s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished">30s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">关机不记忆  [Not persistent]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">关机记忆 随Flight重设  [Flight]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished">飞行  [Flight]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">关机记忆 手动重设  [manual reset]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">启用</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished">开始通道  [CH]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished">THs  油门激活</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished">TH%  油门比例</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished">THt  油门计时</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14968,22 +15748,22 @@ hh:mm:ss</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+=  (相加)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:=   (取代)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished">通道%1</translation>
     </message>
@@ -14991,27 +15771,27 @@ hh:mm:ss</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">模式</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished">系数</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished">校准</translation>
     </message>
@@ -15022,6 +15802,210 @@ hh:mm:ss</source>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
         <translation>教练功能模拟</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -15048,47 +16032,47 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15101,22 +16085,42 @@ hh:mm:ss</source>
         <translation type="unfinished">固件类型</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15124,285 +16128,317 @@ hh:mm:ss</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished">未知</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15418,63 +16454,90 @@ hh:mm:ss</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15567,32 +16630,32 @@ hh:mm:ss</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15605,22 +16668,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15633,22 +16696,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15672,17 +16735,17 @@ hh:mm:ss</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15690,37 +16753,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15836,32 +16899,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15869,32 +16932,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished">顶部横条</translation>
     </message>
@@ -15902,12 +16965,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>第一个V尾通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>第二个V尾通道:</translation>
     </message>
@@ -15915,55 +16978,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation>固定 Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation>固定 X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>标准机翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>飞翼 / 三角翼</translation>
     </message>
@@ -15971,22 +17034,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15994,273 +17057,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>模型向导</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>模型种类</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>输入模型名称和模型种类.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>油门</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>你的模型装有马达或引擎么?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>机翼类型</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>你的模型是是标准机翼, 还是飞翼/三角翼?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>副翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>你的模型有副翼么?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>襟翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>你的模型有襟翼么?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>空气刹车</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>你的模型有空气刹车么?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>飞翼 / 三角翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>指定升降副翼通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>方向舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>你的模型有方向舵么?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>尾翼类型</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>选择你的飞机装置何种尾翼类型.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>尾翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>选择尾翼通道.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>V尾</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>选择升降舵通道.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>倾斜盘</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>你的直升机使用何种十字盘?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>锁尾陀螺仪</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>你的直升机装有感度可调的锁尾陀螺么?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>旋翼类型</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>你的直升机有副翼么?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>直升机</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>选择你的直升机的控制通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>多轴</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>选择你的多旋翼的控制通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>模型选项</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>飞机通电后, 请人工检查每个舵面的运动方向, 如果舵面运动方向错误请将此舵机设置成反向. 第一次通电前请卸下螺旋桨. &lt;br&gt;经常把不用的的模型配置删除是好习惯!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>请输入模型名字和模型种类.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>选择电调或油门舵机插在哪个通道上.&lt;br&gt;&lt;br&gt;Spektrum接收机:通道1, Futaba接收机: 通道3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>大多数固定翼的控制舵面分别安装在机翼和尾翼上. 飞翼或三角翼只有一个机翼. 一般固定翼的主机翼上的舵面控制飞机绕纵轴的滚转, 这些舵面叫做副翼.&lt;br&gt;飞翼机翼后缘的舵面控制飞机绕纵轴的滚转和绕横轴的仰俯. 这些舵面叫做升降副翼. </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>模型使用一个或两个通道来控制副翼.&lt;br&gt;如果使用一个通道, 则需要使用Y线来控制两个副翼舵机.&lt;br&gt;&lt;br&gt;副翼通道 - Spektrum接收机: 通道2, Futaba接收机: 通道1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>此向导假定你使用开关来控制襟翼. 如果你使用旋钮控制襟翼, 你可以在向导完成后手动更改配置.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>空气刹车在高级滑翔机中用来降低空速, 它们很少见于普通固定翼中.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>模型使用2个通道控制升降副翼 &lt;br&gt;选择这两个通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>选择方向舵通道.&lt;br&gt;&lt;br&gt;Spektrum接收机: 通道4, Futaba接收机: 通道4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>选择你的飞机的尾翼类型.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>选择方向舵或升降舵通道.&lt;br&gt;&lt;br&gt;方向舵: Spektrum接收机:通道4, Futaba接收机: 通道4&lt;br&gt;升降舵: Spektrum接收机: 通道3, Futaba接收机: 通道2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>选择升降舵通道.&lt;br&gt;&lt;br&gt;Spektrum接收机: 通道3, Futaba接收机: 通道2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation>TBD.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>选择你的多旋翼的控制通道.&lt;br&gt;&lt;br&gt;油门 - Spektrum: 通道1, Futaba: 通道3&lt;br&gt;偏航 - Spektrum: 通道4, Futaba: 通道4&lt;br&gt;仰俯 - Spektrum: 通道3, Futaba: 通道2&lt;br&gt;滚转  - Spektrum: 通道2, Futaba: 通道1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>当前页面没有帮助信息.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>模型向导帮助</translation>
     </message>
@@ -16268,37 +17331,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>固定翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>多轴</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>直升机</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>模型名称:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>模型种类:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>选项: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>通道 %1: </translation>
     </message>
@@ -16306,46 +17369,46 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">打开文件错误 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16353,16 +17416,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16371,10 +17437,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16481,18 +17562,18 @@ v4.1版电路板应为m2560</translation>
         <translation>使用高级控制项</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>DFU-UTIL 配置</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>SAM-BA 配置</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>选择位置</translation>
     </message>
@@ -16530,7 +17611,7 @@ v4.1版电路板应为m2560</translation>
         <translation type="unfinished">开始通道  [CH]</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
@@ -16540,59 +17621,59 @@ v4.1版电路板应为m2560</translation>
         <translation>确定</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished">找不到游戏杆</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>找不到游戏杆.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_zh_CN.ts
+++ b/companion/src/translations/companion_zh_CN.ts
@@ -5368,22 +5368,22 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1003"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">MODE1 日本手 ↕升降↔方向   ↕油门↔副翼</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1005"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">MODE2 美国手 ↕油门↔方向   ↕升降↔副翼</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1007"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">MODE3 中国手 ↕升降↔副翼   ↕油门↔方向</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1009"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">MODE4 模式4   ↕油门↔副翼   ↕升降↔方向</translation>
     </message>
 </context>
 <context>
@@ -9684,7 +9684,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">飞行模式  [Modes]</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="486"/>

--- a/companion/src/translations/companion_zh_TW.ts
+++ b/companion/src/translations/companion_zh_TW.ts
@@ -5368,17 +5368,17 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1003"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">MODE1 日本手 ↕升降↔方向   ↕油門↔副翼</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1005"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">MODE2 美國手 ↕油門↔方向 ↕升降↔副翼</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1007"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">MODE3 中國手 ↕升降↔副翼 ↕油門↔方向</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="1009"/>
@@ -9684,7 +9684,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">飛行模式  [Modes]</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="486"/>

--- a/companion/src/translations/companion_zh_TW.ts
+++ b/companion/src/translations/companion_zh_TW.ts
@@ -4,30 +4,30 @@
 <context>
     <name>AileronsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="435"/>
+        <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
         <translatorcomment>模型嚮導中副翼連線方式的設定</translatorcomment>
         <translation>没有副翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="436"/>
+        <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
         <translatorcomment>模型嚮導中副翼連線方式的設定</translatorcomment>
         <translation>有副翼，使用一個接收機通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="437"/>
+        <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
         <translatorcomment>模型嚮導中副翼連線方式的設定</translatorcomment>
         <translation>有副翼，使用兩個接收機通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="449"/>
+        <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
         <translation>&lt;br&gt;第一個副翼通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="451"/>
+        <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
         <translation>第二個副翼通道:</translation>
     </message>
@@ -35,27 +35,27 @@
 <context>
     <name>AirbrakesPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="564"/>
+        <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
         <translation>沒有空氣剎車</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="565"/>
+        <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
         <translation>有空氣剎車，使用一個通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="566"/>
+        <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
         <translation>有空氣剎車，使用兩個通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="578"/>
+        <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
         <translation>&lt;br&gt;第一個空氣剎車通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="580"/>
+        <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
         <translation>第二個空氣剎車通道:</translation>
     </message>
@@ -63,23 +63,23 @@
 <context>
     <name>AppData</name>
     <message>
-        <location filename="../storage/appdata.cpp" line="857"/>
+        <location filename="../storage/appdata.cpp" line="858"/>
         <source>Application Settings have been saved to
  %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="860"/>
+        <location filename="../storage/appdata.cpp" line="861"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="862"/>
+        <location filename="../storage/appdata.cpp" line="863"/>
         <source>because the file could not be saved (check access permissions).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.cpp" line="864"/>
+        <location filename="../storage/appdata.cpp" line="865"/>
         <source>for unknown reasons.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,70 +174,70 @@
         <translation>遙控器檔案</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="676"/>
+        <location filename="../apppreferencesdialog.ui" line="722"/>
         <source>Profile Name</source>
         <translation>檔案名稱</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="86"/>
+        <location filename="../apppreferencesdialog.ui" line="349"/>
         <source>Radio Type</source>
         <translation>遙控器型號</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="370"/>
+        <location filename="../apppreferencesdialog.ui" line="212"/>
         <source>Splash Screen</source>
         <translatorcomment>遙控器檔案中</translatorcomment>
         <translation>開機畫面</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="644"/>
+        <location filename="../apppreferencesdialog.ui" line="371"/>
         <source>Other Settings</source>
         <translation>其他設置</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="278"/>
+        <location filename="../apppreferencesdialog.ui" line="655"/>
         <source>SD Structure path</source>
         <translation>SD卡目錄</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="454"/>
-        <location filename="../apppreferencesdialog.ui" line="722"/>
+        <location filename="../apppreferencesdialog.ui" line="296"/>
+        <location filename="../apppreferencesdialog.ui" line="671"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
         <translation>制定檔案目錄，如果設定此目錄，將代替默認備份目錄</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="725"/>
+        <location filename="../apppreferencesdialog.ui" line="674"/>
         <source>Backup folder</source>
         <translation>備份目錄</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="706"/>
+        <location filename="../apppreferencesdialog.ui" line="119"/>
         <source>If set it will override the application general setting</source>
         <translation>如果設置將會代替程序一般設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="593"/>
+        <location filename="../apppreferencesdialog.ui" line="603"/>
         <source>if set, will override general backup enable</source>
         <translation>如果設定將會覆蓋一般備份允許選項</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="596"/>
-        <location filename="../apppreferencesdialog.ui" line="1025"/>
+        <location filename="../apppreferencesdialog.ui" line="606"/>
+        <location filename="../apppreferencesdialog.ui" line="1012"/>
         <source>Enable automatic backup before writing firmware</source>
         <translation>寫入韌體前允許自動備份</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>General Settings</source>
         <translation>一般設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="580"/>
+        <location filename="../apppreferencesdialog.ui" line="635"/>
         <source>Default Stick Mode</source>
         <translation>默認搖桿模式</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="496"/>
+        <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Mode selection:
 
 Mode 1:
@@ -268,622 +268,617 @@ Mode 4:
  </translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="521"/>
+        <location filename="../apppreferencesdialog.ui" line="558"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translatorcomment>遥控器档案中</translatorcomment>
         <translation>MODE1 日本手 ↕升降↔方向   ↕油門↔副翼</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="526"/>
+        <location filename="../apppreferencesdialog.ui" line="563"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>MODE2 美國手 ↕油門↔方向 ↕升降↔副翼</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="531"/>
+        <location filename="../apppreferencesdialog.ui" line="568"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>MODE3 中國手 ↕升降↔副翼 ↕油門↔方向</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="536"/>
+        <location filename="../apppreferencesdialog.ui" line="573"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>MODE4 模式4 ↕油門↔副翼 ↕升降↔方向</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="317"/>
+        <location filename="../apppreferencesdialog.ui" line="687"/>
         <source>Default Channel Order</source>
         <translatorcomment>遙控器檔案中</translatorcomment>
         <translation>默認通道順序</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="128"/>
+        <location filename="../apppreferencesdialog.ui" line="397"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;通道順序&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;定義了新建模型時默認設置的通道順序&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="609"/>
+        <location filename="../apppreferencesdialog.ui" line="619"/>
         <source>Language</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="657"/>
+        <location filename="../apppreferencesdialog.ui" line="112"/>
         <source>Prompt to write firmware to radio after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="135"/>
+        <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>R E T A</source>
         <translation>方向 升降 油門 副翼  [R E T A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="140"/>
+        <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>R E A T</source>
         <translation>方向 升降 副翼 油門  [R E A T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="145"/>
+        <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>R T E A</source>
         <translation>方向 油門 升降 副翼  [R T E A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="150"/>
+        <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>R T A E</source>
         <translation>方向 油門 副翼 升降  [R T A E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="155"/>
+        <location filename="../apppreferencesdialog.ui" line="424"/>
         <source>R A E T</source>
         <translation>方向 副翼 升降 油門  [R A E T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="160"/>
+        <location filename="../apppreferencesdialog.ui" line="429"/>
         <source>R A T E</source>
         <translation>方向 副翼 油門 升降  [R A T E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="165"/>
+        <location filename="../apppreferencesdialog.ui" line="434"/>
         <source>E R T A</source>
         <translation>升降 方向 油門 副翼  [E R T A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="170"/>
+        <location filename="../apppreferencesdialog.ui" line="439"/>
         <source>E R A T</source>
         <translation>升降 方向 副翼 油門  [E R A T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="175"/>
+        <location filename="../apppreferencesdialog.ui" line="444"/>
         <source>E T R A</source>
         <translation>升降 油門 方向 副翼  [E T R A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="180"/>
+        <location filename="../apppreferencesdialog.ui" line="449"/>
         <source>E T A R</source>
         <translation>升降 油門 副翼 方向  [E T A R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="185"/>
+        <location filename="../apppreferencesdialog.ui" line="454"/>
         <source>E A R T</source>
         <translation>升降 副翼 方向 油門  [E A R T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="190"/>
+        <location filename="../apppreferencesdialog.ui" line="459"/>
         <source>E A T R</source>
         <translation>升降 副翼 油門 方向  [E A T R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="195"/>
+        <location filename="../apppreferencesdialog.ui" line="464"/>
         <source>T R E A</source>
         <translation>油門 方向 升降 副翼  [T R E A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="200"/>
+        <location filename="../apppreferencesdialog.ui" line="469"/>
         <source>T R A E</source>
         <translation>油門 方向 副翼 升降  [T R A E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="205"/>
+        <location filename="../apppreferencesdialog.ui" line="474"/>
         <source>T E R A</source>
         <translation>油門 升降 方向 副翼  [T E R A]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="210"/>
+        <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>T E A R</source>
         <translation>油門 升降 副翼 方向  [T E A R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="215"/>
+        <location filename="../apppreferencesdialog.ui" line="484"/>
         <source>T A R E</source>
         <translation>油門 副翼 方向 升降  [T A R E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="220"/>
+        <location filename="../apppreferencesdialog.ui" line="489"/>
         <source>T A E R</source>
         <translation>油門 副翼 升降 方向  [T A E R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="225"/>
+        <location filename="../apppreferencesdialog.ui" line="494"/>
         <source>A R E T</source>
         <translation>副翼 方向 升降 油門  [A R E T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="230"/>
+        <location filename="../apppreferencesdialog.ui" line="499"/>
         <source>A R T E</source>
         <translation>副翼 方向 油門 升降  [A R T E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="235"/>
+        <location filename="../apppreferencesdialog.ui" line="504"/>
         <source>A E R T</source>
         <translation>副翼 升降 方向 油門  [A E R T]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="240"/>
+        <location filename="../apppreferencesdialog.ui" line="509"/>
         <source>A E T R</source>
         <translation>副翼 升降 油門 方向  [A E T R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="245"/>
+        <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>A T R E</source>
         <translation>副翼 油門 方向 升降  [A T R E]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="250"/>
+        <location filename="../apppreferencesdialog.ui" line="519"/>
         <source>A T E R</source>
         <translation>副翼 油門 升降 方向  [A T E R]</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="732"/>
+        <location filename="../apppreferencesdialog.ui" line="316"/>
         <source>External Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1111"/>
+        <location filename="../apppreferencesdialog.ui" line="1098"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1139"/>
+        <location filename="../apppreferencesdialog.ui" line="1126"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1146"/>
+        <location filename="../apppreferencesdialog.ui" line="1133"/>
         <source>Move selected Radio Profile to the top of the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1397"/>
+        <location filename="../apppreferencesdialog.ui" line="1384"/>
         <source>Simulator controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1410"/>
+        <location filename="../apppreferencesdialog.ui" line="1397"/>
         <source>Save switch/pot positions on simulator exit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1417"/>
+        <location filename="../apppreferencesdialog.ui" line="1404"/>
         <source>Clear saved positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1424"/>
+        <location filename="../apppreferencesdialog.ui" line="1411"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1432"/>
+        <location filename="../apppreferencesdialog.ui" line="1419"/>
         <source>Update Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1440"/>
+        <location filename="../apppreferencesdialog.ui" line="1427"/>
         <source>Check frequency</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1463"/>
+        <location filename="../apppreferencesdialog.ui" line="1450"/>
         <source>Reset to Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1472"/>
+        <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1478"/>
+        <location filename="../apppreferencesdialog.ui" line="1465"/>
         <source>Download</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1495"/>
+        <location filename="../apppreferencesdialog.ui" line="1482"/>
         <source>Create sub-folders in Download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1512"/>
+        <location filename="../apppreferencesdialog.ui" line="1499"/>
         <source>Decompress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1519"/>
+        <location filename="../apppreferencesdialog.ui" line="1506"/>
         <source>Use Radio Profile SD Structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1566"/>
+        <location filename="../apppreferencesdialog.ui" line="1553"/>
         <source>Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1579"/>
+        <location filename="../apppreferencesdialog.ui" line="1566"/>
         <source>Delete downloads</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1586"/>
+        <location filename="../apppreferencesdialog.ui" line="1573"/>
         <source>Delete decompressions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1606"/>
+        <location filename="../apppreferencesdialog.ui" line="1593"/>
         <source>Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="999"/>
+        <location filename="../apppreferencesdialog.ui" line="986"/>
         <source>Action on New Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1235"/>
+        <location filename="../apppreferencesdialog.ui" line="1222"/>
         <source>Screenshot capture folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="431"/>
+        <location filename="../apppreferencesdialog.ui" line="273"/>
         <source>Clear Image</source>
         <translation>清除圖片</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="387"/>
+        <location filename="../apppreferencesdialog.ui" line="229"/>
         <source>Select Image</source>
         <translatorcomment>遙控器檔案中</translatorcomment>
         <translation>選擇圖片</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="265"/>
-        <location filename="../apppreferencesdialog.ui" line="457"/>
-        <location filename="../apppreferencesdialog.ui" line="886"/>
-        <location filename="../apppreferencesdialog.ui" line="984"/>
-        <location filename="../apppreferencesdialog.ui" line="1130"/>
-        <location filename="../apppreferencesdialog.ui" line="1284"/>
-        <location filename="../apppreferencesdialog.ui" line="1539"/>
-        <location filename="../apppreferencesdialog.ui" line="1549"/>
-        <location filename="../apppreferencesdialog.ui" line="1556"/>
+        <location filename="../apppreferencesdialog.ui" line="299"/>
+        <location filename="../apppreferencesdialog.ui" line="642"/>
+        <location filename="../apppreferencesdialog.ui" line="873"/>
+        <location filename="../apppreferencesdialog.ui" line="971"/>
+        <location filename="../apppreferencesdialog.ui" line="1117"/>
+        <location filename="../apppreferencesdialog.ui" line="1271"/>
+        <location filename="../apppreferencesdialog.ui" line="1526"/>
+        <location filename="../apppreferencesdialog.ui" line="1536"/>
+        <location filename="../apppreferencesdialog.ui" line="1543"/>
         <source>Select Folder</source>
         <translation>選擇目錄</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="743"/>
+        <location filename="../apppreferencesdialog.ui" line="730"/>
         <source>Application Settings</source>
         <translation>程序首選項</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1066"/>
+        <location filename="../apppreferencesdialog.ui" line="1053"/>
         <source>most recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1094"/>
+        <location filename="../apppreferencesdialog.ui" line="1081"/>
         <source>Startup Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="760"/>
+        <location filename="../apppreferencesdialog.ui" line="747"/>
         <source>Remember</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="929"/>
+        <location filename="../apppreferencesdialog.ui" line="916"/>
         <source>Output Logs Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1108"/>
+        <location filename="../apppreferencesdialog.ui" line="1095"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="848"/>
+        <location filename="../apppreferencesdialog.ui" line="835"/>
         <source>Debug Output Logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="810"/>
+        <location filename="../apppreferencesdialog.ui" line="797"/>
         <source>Application (Companion/Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="817"/>
+        <location filename="../apppreferencesdialog.ui" line="804"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="820"/>
+        <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Radio Firmware (in Simulator)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1081"/>
+        <location filename="../apppreferencesdialog.ui" line="1068"/>
         <source>Splash Screen Library</source>
         <translation>開機畫面圖片庫</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="835"/>
+        <location filename="../apppreferencesdialog.ui" line="822"/>
         <source>Google Earth Executable</source>
         <translation>Google Earch 可執行文件</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1012"/>
+        <location filename="../apppreferencesdialog.ui" line="999"/>
         <source>User Splash Screens</source>
         <translation>自定義開機畫面</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="864"/>
+        <location filename="../apppreferencesdialog.ui" line="851"/>
         <source>Automatic Backup Folder</source>
         <translation>自動備份目錄</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="953"/>
+        <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Only show user splash images</source>
         <translation>只顯示自定義開機畫面</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="958"/>
+        <location filename="../apppreferencesdialog.ui" line="945"/>
         <source>Show user and companion splash images</source>
         <translation>顯示自定義和系統開機畫面</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="796"/>
+        <location filename="../apppreferencesdialog.ui" line="783"/>
         <source>Select Executable</source>
         <translation>選擇可執行文件</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="442"/>
+        <location filename="../apppreferencesdialog.cpp" line="455"/>
         <source>Release channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1176"/>
+        <location filename="../apppreferencesdialog.ui" line="1163"/>
         <source>Simulator Settings</source>
         <translation>模擬器設置</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1277"/>
+        <location filename="../apppreferencesdialog.ui" line="1264"/>
         <source>Calibrate</source>
         <translation>校準</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1249"/>
+        <location filename="../apppreferencesdialog.ui" line="1236"/>
         <source>Blue</source>
         <translation>藍色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="64"/>
-        <location filename="../apppreferencesdialog.ui" line="1573"/>
-        <location filename="../apppreferencesdialog.cpp" line="470"/>
+        <location filename="../apppreferencesdialog.ui" line="83"/>
+        <location filename="../apppreferencesdialog.ui" line="1560"/>
+        <location filename="../apppreferencesdialog.cpp" line="483"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="258"/>
+        <location filename="../apppreferencesdialog.ui" line="330"/>
         <source>Default Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="699"/>
-        <source>Append version number to firmware file name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../apppreferencesdialog.ui" line="304"/>
+        <location filename="../apppreferencesdialog.ui" line="323"/>
         <source>Prompt to run SD Sync after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="807"/>
+        <location filename="../apppreferencesdialog.ui" line="794"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="936"/>
+        <location filename="../apppreferencesdialog.ui" line="923"/>
         <source>Show splash screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1032"/>
+        <location filename="../apppreferencesdialog.ui" line="1019"/>
         <source>Prompt for radio profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="774"/>
+        <location filename="../apppreferencesdialog.ui" line="761"/>
         <source>Prompt to run installer after update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="767"/>
-        <location filename="../apppreferencesdialog.ui" line="1488"/>
+        <location filename="../apppreferencesdialog.ui" line="754"/>
+        <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1254"/>
+        <location filename="../apppreferencesdialog.ui" line="1241"/>
         <source>Green</source>
         <translation>綠色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1259"/>
+        <location filename="../apppreferencesdialog.ui" line="1246"/>
         <source>Red</source>
         <translation>紅色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1264"/>
+        <location filename="../apppreferencesdialog.ui" line="1251"/>
         <source>Orange</source>
         <translation>橙色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1269"/>
+        <location filename="../apppreferencesdialog.ui" line="1256"/>
         <source>Yellow</source>
         <translation>黄色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1300"/>
+        <location filename="../apppreferencesdialog.ui" line="1287"/>
         <source>Only capture to clipboard</source>
         <translation>只截圖到剪貼板中</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1313"/>
+        <location filename="../apppreferencesdialog.ui" line="1300"/>
         <source>Enable</source>
         <translation>使用遊戲桿</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1339"/>
+        <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>Joystick</source>
         <translation>遊戲桿</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1365"/>
+        <location filename="../apppreferencesdialog.ui" line="1352"/>
         <source>Simulator BackLight</source>
         <translation>模擬器背光顏色</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.ui" line="1352"/>
+        <location filename="../apppreferencesdialog.ui" line="1339"/>
         <source>Simulator Volume Gain</source>
         <translation>模擬器音量調節</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="170"/>
+        <location filename="../apppreferencesdialog.cpp" line="175"/>
         <source>My Radio</source>
         <translation>我的遙控器</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="180"/>
+        <location filename="../apppreferencesdialog.cpp" line="185"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="214"/>
+        <location filename="../apppreferencesdialog.cpp" line="219"/>
         <source>Select your snapshot folder</source>
         <translation>選擇你的快照目錄</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="113"/>
+        <location filename="../apppreferencesdialog.cpp" line="119"/>
         <source>Update Settings: Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="118"/>
+        <location filename="../apppreferencesdialog.cpp" line="124"/>
         <source>Update Settings: Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="123"/>
+        <location filename="../apppreferencesdialog.cpp" line="129"/>
         <source>Update Settings: Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="129"/>
+        <location filename="../apppreferencesdialog.cpp" line="135"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="279"/>
-        <location filename="../apppreferencesdialog.cpp" line="600"/>
+        <location filename="../apppreferencesdialog.cpp" line="284"/>
+        <location filename="../apppreferencesdialog.cpp" line="613"/>
         <source>No joysticks found</source>
         <translation>找不到遊戲桿</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="329"/>
+        <location filename="../apppreferencesdialog.cpp" line="342"/>
         <source>EMPTY: No radio settings stored in profile</source>
         <translation>空白:在遙控器檔案中找不到遙控器設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="334"/>
+        <location filename="../apppreferencesdialog.cpp" line="347"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
         <translation>允許:不明日期的遙控器設定</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="336"/>
+        <location filename="../apppreferencesdialog.cpp" line="349"/>
         <source>AVAILABLE: Radio settings stored %1</source>
         <translation>允許:遙控器設定保存到 %1</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="356"/>
+        <location filename="../apppreferencesdialog.cpp" line="369"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="360"/>
+        <location filename="../apppreferencesdialog.cpp" line="373"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="400"/>
+        <location filename="../apppreferencesdialog.cpp" line="413"/>
         <source>Select your download folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="407"/>
+        <location filename="../apppreferencesdialog.cpp" line="420"/>
         <source>Select your decompress folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="414"/>
+        <location filename="../apppreferencesdialog.cpp" line="427"/>
         <source>Select your update destination folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="439"/>
+        <location filename="../apppreferencesdialog.cpp" line="452"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="531"/>
+        <location filename="../apppreferencesdialog.cpp" line="544"/>
         <source>Select your library folder</source>
         <translatorcomment>對話框標題欄</translatorcomment>
         <translation>選擇你的圖片庫文件夾</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="555"/>
-        <location filename="../apppreferencesdialog.cpp" line="565"/>
+        <location filename="../apppreferencesdialog.cpp" line="568"/>
+        <location filename="../apppreferencesdialog.cpp" line="578"/>
         <source>Select your Models and Settings backup folder</source>
         <translatorcomment>對話框標題欄</translatorcomment>
         <translation>選擇你的模型和設定備份文件夾</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="575"/>
+        <location filename="../apppreferencesdialog.cpp" line="588"/>
         <source>Select a folder for application logs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="583"/>
+        <location filename="../apppreferencesdialog.cpp" line="596"/>
         <source>Select Google Earth executable</source>
         <translatorcomment>對話框標題欄</translatorcomment>
         <translation>選擇 Google Earth 可執行文件</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="634"/>
+        <location filename="../apppreferencesdialog.cpp" line="647"/>
         <source>Select the folder replicating your SD structure</source>
         <translatorcomment>對話框標題欄</translatorcomment>
         <translation>選擇模擬SD卡目錄結構的電腦文件夾</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Open Image to load</source>
         <translation>打開圖片並載入</translation>
     </message>
     <message>
-        <location filename="../apppreferencesdialog.cpp" line="665"/>
+        <location filename="../apppreferencesdialog.cpp" line="679"/>
         <source>Images (%1)</source>
         <translation>圖片 (%1)</translation>
     </message>
@@ -891,30 +886,30 @@ Mode 4:
 <context>
     <name>BinEepromFormat</name>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="42"/>
+        <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="65"/>
+        <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="76"/>
+        <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="83"/>
+        <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">寫入文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/bineeprom.cpp" line="108"/>
+        <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -952,33 +947,33 @@ Mode 4:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="799"/>
-        <location filename="../firmwares/boardjson.cpp" line="805"/>
-        <location filename="../firmwares/boardjson.cpp" line="814"/>
-        <location filename="../firmwares/boardjson.cpp" line="824"/>
+        <location filename="../firmwares/boardjson.cpp" line="875"/>
+        <location filename="../firmwares/boardjson.cpp" line="881"/>
+        <location filename="../firmwares/boardjson.cpp" line="890"/>
+        <location filename="../firmwares/boardjson.cpp" line="900"/>
         <source>Load Board Hardware Definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="800"/>
+        <location filename="../firmwares/boardjson.cpp" line="876"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="806"/>
+        <location filename="../firmwares/boardjson.cpp" line="882"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="815"/>
+        <location filename="../firmwares/boardjson.cpp" line="891"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boardjson.cpp" line="825"/>
+        <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Board: %1
 Error: %2 is not a valid json formatted file.
 Error code: %3
@@ -989,255 +984,265 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="348"/>
+        <location filename="../firmwares/boards.cpp" line="404"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">左搖桿水平方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="349"/>
+        <location filename="../firmwares/boards.cpp" line="405"/>
         <source>Left Vertical</source>
         <translation type="unfinished">左搖桿垂直方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="350"/>
+        <location filename="../firmwares/boards.cpp" line="406"/>
         <source>Right Vertical</source>
         <translation type="unfinished">右搖桿上下方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="351"/>
+        <location filename="../firmwares/boards.cpp" line="407"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">右搖桿水平方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="352"/>
+        <location filename="../firmwares/boards.cpp" line="408"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="353"/>
+        <location filename="../firmwares/boards.cpp" line="409"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="369"/>
+        <location filename="../firmwares/boards.cpp" line="425"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="370"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="371"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="372"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="381"/>
-        <location filename="../firmwares/boards.cpp" line="383"/>
+        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="439"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="382"/>
-        <location filename="../firmwares/boards.cpp" line="384"/>
+        <location filename="../firmwares/boards.cpp" line="438"/>
+        <location filename="../firmwares/boards.cpp" line="440"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="389"/>
-        <location filename="../firmwares/boards.cpp" line="398"/>
-        <location filename="../firmwares/boards.cpp" line="428"/>
-        <location filename="../firmwares/boards.cpp" line="438"/>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
-        <location filename="../firmwares/boards.cpp" line="465"/>
+        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="502"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="397"/>
-        <location filename="../firmwares/boards.cpp" line="436"/>
+        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="492"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="399"/>
-        <location filename="../firmwares/boards.cpp" line="429"/>
-        <location filename="../firmwares/boards.cpp" line="439"/>
-        <location filename="../firmwares/boards.cpp" line="447"/>
-        <location filename="../firmwares/boards.cpp" line="459"/>
-        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="485"/>
+        <location filename="../firmwares/boards.cpp" line="495"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="400"/>
-        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="401"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="437"/>
+        <location filename="../firmwares/boards.cpp" line="493"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="743"/>
+        <location filename="../firmwares/boards.cpp" line="891"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="745"/>
+        <location filename="../firmwares/boards.cpp" line="893"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="747"/>
+        <location filename="../firmwares/boards.cpp" line="895"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="749"/>
+        <location filename="../firmwares/boards.cpp" line="897"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="751"/>
+        <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="390"/>
-        <location filename="../firmwares/boards.cpp" line="394"/>
-        <location filename="../firmwares/boards.cpp" line="405"/>
-        <location filename="../firmwares/boards.cpp" line="410"/>
-        <location filename="../firmwares/boards.cpp" line="416"/>
-        <location filename="../firmwares/boards.cpp" line="420"/>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <location filename="../firmwares/boards.cpp" line="433"/>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="463"/>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Flight</source>
+        <translation type="unfinished">飛行  [Flight]</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1095"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <location filename="../firmwares/boards.cpp" line="466"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="481"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="519"/>
         <source>P1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="395"/>
-        <location filename="../firmwares/boards.cpp" line="406"/>
-        <location filename="../firmwares/boards.cpp" line="411"/>
-        <location filename="../firmwares/boards.cpp" line="421"/>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <location filename="../firmwares/boards.cpp" line="434"/>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="464"/>
+        <location filename="../firmwares/boards.cpp" line="451"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="482"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="500"/>
+        <location filename="../firmwares/boards.cpp" line="508"/>
+        <location filename="../firmwares/boards.cpp" line="520"/>
         <source>P2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="396"/>
-        <location filename="../firmwares/boards.cpp" line="412"/>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <location filename="../firmwares/boards.cpp" line="435"/>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="452"/>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="491"/>
+        <location filename="../firmwares/boards.cpp" line="501"/>
+        <location filename="../firmwares/boards.cpp" line="509"/>
         <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="377"/>
-        <location filename="../firmwares/boards.cpp" line="379"/>
+        <location filename="../firmwares/boards.cpp" line="433"/>
+        <location filename="../firmwares/boards.cpp" line="435"/>
         <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="378"/>
-        <location filename="../firmwares/boards.cpp" line="380"/>
+        <location filename="../firmwares/boards.cpp" line="434"/>
+        <location filename="../firmwares/boards.cpp" line="436"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="510"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="570"/>
-        <location filename="../firmwares/boards.cpp" line="707"/>
-        <location filename="../firmwares/boards.cpp" line="737"/>
+        <location filename="../firmwares/boards.cpp" line="642"/>
+        <location filename="../firmwares/boards.cpp" line="855"/>
+        <location filename="../firmwares/boards.cpp" line="885"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="739"/>
+        <location filename="../firmwares/boards.cpp" line="887"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="741"/>
+        <location filename="../firmwares/boards.cpp" line="889"/>
         <source>Pot with detent</source>
         <translation type="unfinished">有中位旋鈕</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="572"/>
+        <location filename="../firmwares/boards.cpp" line="644"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2段彈簧開關</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="574"/>
+        <location filename="../firmwares/boards.cpp" line="646"/>
         <source>2 Positions</source>
         <translation type="unfinished">2段開關</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="576"/>
+        <location filename="../firmwares/boards.cpp" line="648"/>
         <source>3 Positions</source>
         <translation type="unfinished">3段開關</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="578"/>
+        <location filename="../firmwares/boards.cpp" line="650"/>
         <source>Function</source>
         <translation type="unfinished">運算方式  [Function]</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="709"/>
+        <location filename="../firmwares/boards.cpp" line="857"/>
         <source>Standard</source>
         <translation type="unfinished">標準LCD  [Standard]</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="711"/>
+        <location filename="../firmwares/boards.cpp" line="859"/>
         <source>Small</source>
         <translation type="unfinished">小</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="713"/>
+        <location filename="../firmwares/boards.cpp" line="861"/>
         <source>Both</source>
         <translation type="unfinished">兩側</translation>
     </message>
@@ -1245,17 +1250,17 @@ Error description: %4</source>
 <context>
     <name>CalibrationPanel</name>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
         <translation type="unfinished">負範圍</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
         <translation type="unfinished">中值</translation>
     </message>
     <message>
-        <location filename="../generaledit/calibration.cpp" line="32"/>
+        <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
         <translation type="unfinished">正範圍</translation>
     </message>
@@ -1263,132 +1268,132 @@ Error description: %4</source>
 <context>
     <name>ChannelsPanel</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="110"/>
+        <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
         <translation type="unfinished">舵機中位 [Subtrim]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="112"/>
+        <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
         <translation type="unfinished">舵機反向 [Dir]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
         <translation type="unfinished">曲線       [Curve]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="114"/>
+        <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="116"/>
+        <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
         <translation type="unfinished">PPM中位脈寬</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="118"/>
+        <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
         <translation type="unfinished">線性微調 [Linear]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="126"/>
+        <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
         <translation type="unfinished">通道%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="130"/>
+        <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>---</source>
         <translation type="unfinished">正向  [→]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="156"/>
+        <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
         <translation type="unfinished">反向  [←]</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="351"/>
+        <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="373"/>
+        <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="387"/>
+        <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
         <translation type="unfinished">複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="388"/>
+        <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="389"/>
+        <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
         <translation type="unfinished">貼上</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="390"/>
+        <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="392"/>
+        <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="393"/>
+        <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="394"/>
+        <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="395"/>
+        <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="397"/>
+        <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="448"/>
+        <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/channels.cpp" line="459"/>
+        <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1431,57 +1436,57 @@ Error description: %4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="65"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="76"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="83"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="85"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">無法寫入文件 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="102"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="110"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/checklistdialog.cpp" line="123"/>
+        <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1497,12 +1502,12 @@ Error description: %4</source>
 <context>
     <name>ColorCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="441"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="443"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1510,173 +1515,183 @@ Error description: %4</source>
 <context>
     <name>Companion</name>
     <message>
-        <location filename="../constants.h" line="61"/>
+        <location filename="../constants.h" line="63"/>
         <source>Information</source>
         <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="62"/>
+        <location filename="../constants.h" line="64"/>
         <source>Warning</source>
         <translation type="unfinished">啟用時蜂鳴 [Warning]</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="63"/>
+        <location filename="../constants.h" line="65"/>
         <source>Error</source>
         <translation type="unfinished">錯誤</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="81"/>
+        <location filename="../constants.h" line="66"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="67"/>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
         <translation type="unfinished">程序首選項</translation>
     </message>
     <message>
-        <location filename="../constants.h" line="65"/>
+        <location filename="../constants.h" line="69"/>
         <source>files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="59"/>
+        <location filename="../constants.h" line="61"/>
         <source>EdgeTX Companion</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="60"/>
+        <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="66"/>
+        <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="294"/>
+        <location filename="../helpers.cpp" line="284"/>
         <source>Select or create a file for exported Settings:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="304"/>
+        <location filename="../helpers.cpp" line="294"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="339"/>
+        <location filename="../helpers.cpp" line="360"/>
         <source>Simulator for this firmware is not yet available</source>
         <translation type="unfinished">模擬器現在還不支持此版韌體</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="366"/>
+        <location filename="../helpers.cpp" line="387"/>
         <source>Uknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="367"/>
+        <location filename="../helpers.cpp" line="388"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="377"/>
+        <location filename="../helpers.cpp" line="398"/>
         <source>Error occurred while starting simulator.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="30"/>
+        <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="38"/>
+        <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="45"/>
+        <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="61"/>
+        <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="76"/>
+        <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="77"/>
+        <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="80"/>
+        <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="82"/>
+        <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="101"/>
+        <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="122"/>
+        <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="123"/>
+        <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="124"/>
+        <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="125"/>
+        <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="126"/>
+        <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="127"/>
+        <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="175"/>
+        <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="180"/>
+        <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../companion.cpp" line="187"/>
+        <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/appdata.h" line="58"/>
+        <location filename="../storage/appdata.h" line="59"/>
         <source>settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1718,23 +1733,23 @@ Do you want to import settings from a file?</source>
         <translation>列印到文件</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="118"/>
+        <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="128"/>
+        <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="160"/>
+        <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
         <translatorcomment>Compare 模型對比對話框</translatorcomment>
         <translation>列印到文檔</translation>
     </message>
     <message>
-        <location filename="../comparedialog.cpp" line="169"/>
+        <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
         <translatorcomment>Compare 模型對比對話框</translatorcomment>
         <translation>選擇PDF輸出文件</translation>
@@ -1761,7 +1776,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>ConclusionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="982"/>
+        <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
         <translatorcomment>ConclusionPage 模型配置頁面最後確認按鈕中使用</translatorcomment>
         <translation>好的, 我知道。</translation>
@@ -1770,19 +1785,19 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CopyProcess</name>
     <message>
-        <location filename="../process_copy.cpp" line="71"/>
+        <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
         <translatorcomment>CopyProcess</translatorcomment>
         <translation>寫入錯誤</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="79"/>
+        <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
         <translatorcomment>CopyProcess</translatorcomment>
         <translation>無法寫入 %1 (原因: %2)</translation>
     </message>
     <message>
-        <location filename="../process_copy.cpp" line="84"/>
+        <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
         <translatorcomment>CopyProcess</translatorcomment>
         <translation>無法打開 %1 (原因: %2)</translation>
@@ -1791,22 +1806,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveData</name>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="62"/>
+        <location filename="../firmwares/curvedata.cpp" line="63"/>
         <source>CV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="75"/>
+        <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
         <translation type="unfinished">標準LCD  [Standard]</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="77"/>
+        <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/curvedata.cpp" line="127"/>
+        <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
         <translation type="unfinished">%1 點</translation>
     </message>
@@ -1889,32 +1904,32 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="185"/>
+        <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
         <translation type="unfinished">直線</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="186"/>
+        <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
         <translation type="unfinished">非對稱指數曲線</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="187"/>
+        <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
         <translation type="unfinished">左右中心對稱</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="188"/>
+        <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
         <translation type="unfinished">左右鏡像對稱</translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="419"/>
+        <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../shared/curvedialog.cpp" line="429"/>
+        <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1922,7 +1937,7 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveImageWidget</name>
     <message>
-        <location filename="../shared/curveimagewidget.cpp" line="31"/>
+        <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1930,22 +1945,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurveReference</name>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
         <translation type="unfinished">差動曲線 [Diff]</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
         <translation type="unfinished">指數曲線 [Expo]</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
         <translation type="unfinished">其他曲線 [Func]</translation>
     </message>
     <message>
-        <location filename="../firmwares/curvereference.cpp" line="87"/>
+        <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1953,113 +1968,113 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CurvesPanel</name>
     <message>
-        <location filename="../modeledit/curves.cpp" line="35"/>
+        <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="48"/>
+        <location filename="../modeledit/curves.cpp" line="49"/>
         <source>CV%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="52"/>
-        <location filename="../modeledit/curves.cpp" line="63"/>
+        <location filename="../modeledit/curves.cpp" line="53"/>
+        <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="75"/>
+        <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="79"/>
+        <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="83"/>
+        <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="96"/>
+        <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="179"/>
+        <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
         <translation type="unfinished">加</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="180"/>
+        <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
         <translation type="unfinished">編輯</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="182"/>
+        <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
         <translation type="unfinished">複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="183"/>
+        <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="184"/>
+        <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
         <translation type="unfinished">貼上</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="185"/>
+        <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="187"/>
+        <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="188"/>
+        <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="189"/>
+        <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="190"/>
+        <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="192"/>
+        <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="232"/>
+        <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="245"/>
+        <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="269"/>
+        <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/curves.cpp" line="277"/>
+        <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2067,343 +2082,363 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionData</name>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>GF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="53"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="54"/>
         <source>SF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="65"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
         <translation type="unfinished">鎖定通道值 %1     [Override]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="69"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
         <translation type="unfinished">教練開關 方向       [Trainer RUD]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="71"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
         <translation type="unfinished">教練開關 升降       [Trainer ELE]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="73"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
         <translation type="unfinished">教練開關 油門       [Trainer THR]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="75"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
         <translation type="unfinished">教練開關 副翼       [Trainer AIL]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="77"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="79"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
         <translation type="unfinished">操縱杆位變微調      [Instant Trim]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="81"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
         <translation type="unfinished">播放蜂鳴            [Play Sound]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="83"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
         <translation type="unfinished">震動  [Haptic]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="85"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
         <translation type="unfinished">重設</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="87"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="97"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="113"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="115"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="117"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="123"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="125"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="127"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="129"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
         <translation>關閉音頻功放</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="131"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
         <source>RGB leds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
+        <source>LCD to Video</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
+        <source>Push Custom Switch %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
         <translation type="unfinished">播放一次但開機時不播放  [!1x]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="220"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
         <translation type="unfinished">播放一次  [1x]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
-        <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
         <translation type="unfinished">1x</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
         <translation type="unfinished">%1s</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="343"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="371"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="373"/>
-        <source>Source</source>
+        <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
+        <source>Source (%)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="375"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
+        <source>Source (value)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="377"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="403"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="89"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
         <translation type="unfinished">開啟 Vario 聲音    [Vario]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="67"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="91"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
         <translation type="unfinished">播放聲音文件        [Play Track]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="93"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
         <translation type="unfinished">播放同時振動        [Play Both]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="95"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
         <translation type="unfinished">播放數值            [Play Value]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="99"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
         <translation type="unfinished">SD Log 記錄        [SD Logs]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="101"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
         <translation type="unfinished">音量                [Volume]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="103"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
         <translation type="unfinished">背光                [Backlight]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="105"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
         <translation type="unfinished">截屏                [Screenshot]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="107"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
         <translation type="unfinished">背景音樂播放        [Bg Music]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="109"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
         <translation type="unfinished">背景音樂暫停        [Bg Music Pause]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="111"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="119"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
         <translation type="unfinished">內置高頻頭對頻</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="121"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
         <translation type="unfinished">外置高頻頭對頻</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="290"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
         <translation type="unfinished">飛行  [Flight]</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="293"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
         <translation type="unfinished">回傳設置 Tele</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="147"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
         <translation type="unfinished">禁用</translation>
     </message>
     <message>
-        <location filename="../firmwares/customfunctiondata.cpp" line="29"/>
+        <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2411,128 +2446,128 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomFunctionsPanel</name>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>啟動開關</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>功能</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>参数</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="115"/>
+        <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
         <translation type="unfinished">使用遊戲桿</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="122"/>
+        <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="126"/>
+        <location filename="../modeledit/customfunctions.cpp" line="128"/>
         <source>SF%1</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>SF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="128"/>
+        <location filename="../modeledit/customfunctions.cpp" line="130"/>
         <source>GF%1</source>
         <translatorcomment>CustomFunctionPanel</translatorcomment>
         <translation>GF%1</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="166"/>
+        <location filename="../modeledit/customfunctions.cpp" line="168"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="253"/>
+        <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="280"/>
+        <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="611"/>
+        <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="634"/>
+        <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="647"/>
+        <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
         <translation type="unfinished">複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="648"/>
+        <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="649"/>
+        <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
         <translation type="unfinished">貼上</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="650"/>
+        <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="652"/>
+        <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="653"/>
+        <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="654"/>
+        <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="655"/>
+        <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="657"/>
+        <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="720"/>
+        <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/customfunctions.cpp" line="731"/>
+        <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2540,22 +2575,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreen</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="96"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
         <translation type="unfinished">數字</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
         <translation type="unfinished">條狀圖</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="100"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
         <translation type="unfinished">腳本</translation>
     </message>
@@ -2563,47 +2598,47 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CustomScreenPanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="233"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="237"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="262"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="324"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="327"/>
-        <source>Flight mode</source>
-        <translation type="unfinished">飛行模式  [Modes]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="330"/>
-        <source>Sliders</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
-        <source>Trims</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
-        <source>Mirror</source>
+        <source>%1 mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
+        <source>Sliders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
+        <source>Trims</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
+        <source>Mirror</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2660,82 +2695,82 @@ Do you want to import settings from a file?</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="209"/>
+        <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
         <translation>打開韌體文件</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="95"/>
+        <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
         <translation type="unfinished">韌體: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="100"/>
+        <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
         <translation type="unfinished">圖片: %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="105"/>
+        <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
         <translation type="unfinished">檔案圖片</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="212"/>
+        <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
         <translation>不能從韌體文件 %1 中載入內嵌圖片 .</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
         <translation>打開圖片文件以載入</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="228"/>
+        <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
         <translation>圖片 (%1)</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="232"/>
+        <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
         <translation>不能打開圖片文件 %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="247"/>
+        <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
         <translation>不能打開遙控器文檔中圖片 %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="261"/>
+        <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
         <translation>不能從開機圖片庫中載入圖片 %1.</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="270"/>
+        <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
         <translation>圖片已經保存到 %1</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
         <translation>圖片刷新錯誤</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="272"/>
+        <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
         <translation>無法從文件 %1 中刷新圖片</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
         <translation>文件保存錯誤</translation>
     </message>
     <message>
-        <location filename="../customizesplashdialog.cpp" line="276"/>
+        <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
         <translation>無法寫入文件 %1</translation>
     </message>
@@ -2743,22 +2778,22 @@ Do you want to import settings from a file?</source>
 <context>
     <name>CyclicPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="795"/>
+        <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
         <translation>90</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="797"/>
+        <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
         <translation>120</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="798"/>
+        <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
         <translation>120x</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="799"/>
+        <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
         <translation>140</translation>
     </message>
@@ -2766,53 +2801,53 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataField</name>
     <message>
-        <location filename="../firmwares/eepromimportexport.h" line="776"/>
+        <location filename="../firmwares/eepromimportexport.h" line="777"/>
         <source>Conversion error on field %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="496"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="623"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source>Switch </source>
         <translation type="unfinished">啟動開關</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="497"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="624"/>
         <source> cannot be exported on this board!</source>
         <translation type="unfinished"> 無法輸出到這個主板!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="659"/>
         <source>Source %1 cannot be exported on this board!</source>
         <translation type="unfinished">源 %1 無法輸出到這個主板!</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1416"/>
         <source>OpenTX only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX只允許最大%1點曲線 </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1266"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1423"/>
         <source>OpenTx only accepts %1 points in all curves</source>
         <translation type="unfinished">OpenTX只允許最大%1點曲線 </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1579"/>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1583"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1736"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="1740"/>
         <source>OpenTX on this board doesn&apos;t accept this function</source>
         <translation type="unfinished">OpenTX在這個主板上不支持此項功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2320"/>
+        <location filename="../firmwares/opentx/opentxeeprom.cpp" line="2479"/>
         <source>OpenTX doesn&apos;t accept this radio protocol</source>
         <translation type="unfinished">OpenTX 不接受此遙控器協議</translation>
     </message>
@@ -2820,52 +2855,52 @@ Do you want to import settings from a file?</source>
 <context>
     <name>DataHelpers</name>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="26"/>
+        <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="27"/>
+        <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="28"/>
+        <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="29"/>
+        <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
         <translation type="unfinished">啟用</translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="30"/>
+        <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="31"/>
+        <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="32"/>
+        <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="33"/>
+        <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="34"/>
+        <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/datahelpers.cpp" line="35"/>
+        <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2944,102 +2979,83 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="266"/>
+        <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/debugoutput.cpp" line="292"/>
+        <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>DownloadDialog</name>
-    <message>
-        <location filename="../updates/downloaddialog.ui" line="14"/>
-        <source>Downloading: </source>
-        <translation type="unfinished">下載中: </translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="51"/>
-        <source>Unable to open the download file %1 for writing.
-Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/downloaddialog.cpp" line="97"/>
-        <source>Download failed: %1.</source>
-        <translation type="unfinished">下載失敗:%1.</translation>
-    </message>
-</context>
-<context>
     <name>EEPROMInterface</name>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="75"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="76"/>
         <source>Possible causes for this:</source>
         <translation type="unfinished">可能導致這樣的原因:</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="77"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
         <source>- Eeprom is from a newer version of OpenTX</source>
         <translation type="unfinished">- Eeprom 來自 OpenTX 的新版本</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="78"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
         <source>- Eeprom is not from OpenTX</source>
         <translation type="unfinished">- Eeprom 不是來自 OpenTX</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="79"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
         <source>- Eeprom is not from ErSky9X</source>
         <translation type="unfinished">- Eeprom 不是來自 ErSky9X</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="80"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
         <source>- Eeprom size is invalid</source>
         <translation type="unfinished">- Eeprom 文件大小錯誤</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="81"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
         <source>- Eeprom file system is invalid</source>
         <translation type="unfinished">- Eeprom 文件系统錯誤</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="82"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
         <source>- Eeprom is from a unknown board</source>
         <translation type="unfinished">- Eeprom 來自未知的主板</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="83"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
         <source>- Eeprom is from the wrong board</source>
         <translation type="unfinished">- Eeprom 來自錯誤的主板</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="84"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="85"/>
         <source>- Eeprom backup not supported</source>
         <translation type="unfinished">- 不支持 Eeprom 備份</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="86"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="87"/>
         <source>- Something that couldn&apos;t be guessed, sorry</source>
         <translation type="unfinished">- 抱歉，無法找出確定原因</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="89"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
         <source>Warning:</source>
         <translation type="unfinished">警告：</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="90"/>
-        <location filename="../firmwares/eeprominterface.cpp" line="109"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="91"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="110"/>
         <source>- Your radio probably uses a wrong firmware,
  eeprom size is 4096 but only the first 2048 are used</source>
         <translation type="unfinished">- 你的遙控器可能使用了錯誤的韌體，
  eeprom 大小為4096但僅前半部分的2048被使用</translation>
     </message>
     <message>
-        <location filename="../firmwares/eeprominterface.cpp" line="112"/>
+        <location filename="../firmwares/eeprominterface.cpp" line="113"/>
         <source>- Your eeprom is from an old version of OpenTX, upgrading!
  To keep your original file as a backup, please choose File -&gt; Save As specifying a different name.</source>
         <translation type="unfinished"></translation>
@@ -3048,12 +3064,12 @@ Error: %2</source>
 <context>
     <name>EdgeTXInterface</name>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="157"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="171"/>
+        <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3061,12 +3077,12 @@ Error: %2</source>
 <context>
     <name>EepeFormat</name>
     <message>
-        <location filename="../storage/eepe.cpp" line="31"/>
+        <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/eepe.cpp" line="47"/>
+        <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3074,12 +3090,12 @@ Error: %2</source>
 <context>
     <name>ElevonsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="633"/>
+        <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
         <translation>&lt;br&gt;指定第1個升降副翼舵機通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="635"/>
+        <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
         <translation>&lt;br&gt;指定第2個升降副翼舵機通道:</translation>
     </message>
@@ -3087,42 +3103,42 @@ Error: %2</source>
 <context>
     <name>EtxFormat</name>
     <message>
-        <location filename="../storage/etx.cpp" line="31"/>
+        <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">打開文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="42"/>
+        <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="57"/>
+        <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="73"/>
+        <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">寫入文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="78"/>
+        <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="83"/>
+        <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/etx.cpp" line="110"/>
+        <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3130,23 +3146,23 @@ Error: %2</source>
 <context>
     <name>ExpoData</name>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="28"/>
+        <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="29"/>
+        <location filename="../firmwares/input_data.cpp" line="30"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="42"/>
-        <location filename="../firmwares/input_data.cpp" line="47"/>
+        <location filename="../firmwares/input_data.cpp" line="43"/>
+        <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/input_data.cpp" line="45"/>
+        <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
         <translation type="unfinished">啟用</translation>
     </message>
@@ -3154,129 +3170,109 @@ Error: %2</source>
 <context>
     <name>ExpoDialog</name>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="132"/>
-        <source>Flight modes</source>
-        <translatorcomment>Inputs對話框</translatorcomment>
-        <translation>飛行模式   [Modes]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="209"/>
+        <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>輸入名稱   [Input]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="57"/>
-        <location filename="../modeledit/expodialog.ui" line="155"/>
-        <location filename="../modeledit/expodialog.ui" line="443"/>
-        <source>GV</source>
-        <translatorcomment>Inputs對話框</translatorcomment>
-        <translation>GV</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="216"/>
-        <source>Source for the mixer.</source>
-        <translatorcomment>Inputs對話框</translatorcomment>
-        <translation>混控的輸入源.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="146"/>
+        <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>比例       [Weight]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="125"/>
+        <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>啟用開關   [Switch]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="187"/>
-        <source>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</source>
-        <translatorcomment>Inputs對話框</translatorcomment>
-        <translation>啟用開關 
-不選擇則默認一直啟用.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/expodialog.ui" line="139"/>
+        <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>搖桿作用於 [Side]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="37"/>
+        <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>負側 [NEG]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="42"/>
+        <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>正侧 [POS]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="47"/>
+        <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>兩側 [ALL]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="245"/>
+        <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="424"/>
+        <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>縮放       [Scale]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="472"/>
+        <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="481"/>
+        <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>微調       [Trim]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="118"/>
+        <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>曲線       [Curve]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="436"/>
+        <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>作用於輸入源的曲線.</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="202"/>
+        <location filename="../modeledit/expodialog.ui" line="38"/>
+        <location filename="../modeledit/expodialog.ui" line="147"/>
+        <location filename="../modeledit/expodialog.ui" line="373"/>
+        <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>輸入來源   [Source]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="488"/>
+        <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>此條名稱   [Line]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="195"/>
+        <location filename="../modeledit/expodialog.ui" line="86"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>偏移       [Offset]</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.ui" line="67"/>
+        <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
         <translatorcomment>Inputs對話框</translatorcomment>
         <translation>混控的輸入源</translation>
@@ -3288,22 +3284,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
         <translation>編輯 %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="88"/>
+        <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="244"/>
+        <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="245"/>
+        <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/expodialog.cpp" line="246"/>
+        <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3311,22 +3307,22 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FblPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="852"/>
+        <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
         <translation>油門通道  [Throttle]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="854"/>
+        <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
         <translation>偏航通道  [Yaw]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="856"/>
+        <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
         <translation>仰俯通道  [Pitch]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="858"/>
+        <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
         <translation>滾轉通道  [Roll]:</translation>
     </message>
@@ -3334,262 +3330,262 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</source
 <context>
     <name>FileSyncDialog</name>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="50"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="64"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="126"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="150"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="160"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="166"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="168"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="172"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="175"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="182"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="187"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="194"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="198"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="202"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="204"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="209"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="215"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="228"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="230"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="242"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="271"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="246"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="261"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
         <translation type="unfinished">關閉</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="278"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="280"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="282"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="323"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
         <source> MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="335"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="336"/>
         <source> KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="426"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
         <translation type="unfinished">開始通道  [CH]</translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="437"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="489"/>
-        <location filename="../dialogs/filesyncdialog.cpp" line="491"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="493"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="511"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
+        <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3597,367 +3593,411 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>Firmware</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1149"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1166"/>
         <source>No OverrideCH functions available</source>
         <translation type="unfinished">不允許鎖定通道值功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1145"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
         <translation type="unfinished">可選擇啟用 FAI 模式 (沒有回傳)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1146"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
         <source>FAI MODE (no telemetry) always enabled</source>
         <translation type="unfinished">一直啟用 FAI 模式 (沒有回傳)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1162"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1179"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
         <translation type="unfinished">移除 D8 FrSky 協議支持,因為在20151月1日後在歐洲銷售的遙控器中使用此協議是不合法的</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1188"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1227"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1345"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1355"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1377"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1387"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1397"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1247"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1380"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1390"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1410"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1420"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1430"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1440"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1450"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1471"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1490"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1500"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1519"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1530"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1540"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1558"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">禁用直升機菜單和CCPM混控菜單</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1189"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1228"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1346"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1356"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1248"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1381"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1391"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1401"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1411"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1431"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1451"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1462"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1491"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1501"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1510"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1520"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1541"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1559"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">禁用GV[Global variables]功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1190"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1347"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1379"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1389"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1399"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1382"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1392"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1402"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1412"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1422"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="1432"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1442"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1452"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1463"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1493"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1492"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1502"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1511"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1521"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1542"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1560"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1199"/>
         <source>Use alternative SQT5 font</source>
         <translation type="unfinished">使用 另一個 SQT5 font</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1204"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1221"/>
         <source>Pots use in menus navigation</source>
         <translation type="unfinished">使用旋鈕進行菜單導航</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1322"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1350"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished">FrSky Taranis X9D+</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1163"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1180"/>
         <source>Enable non certified firmwares</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1165"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1182"/>
         <source>Enable AFHDS3 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1315"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1323"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1351"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1329"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1357"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1314"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1342"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished">FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1344"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">振動模塊已經安裝</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1335"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1363"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished">FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1364"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished">遙控器關機前確認</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1337"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1365"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished">Horus 搖桿已安裝 (霍爾傳感器)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1302"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1330"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1305"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1296"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1324"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1289"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1317"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1256"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1284"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1291"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1269"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1297"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1272"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1300"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished">只用與 DEV pcb 版本</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1385"/>
-        <source>Jumper T-Pro v2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1395"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1400"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1433"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1461"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1353"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1388"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1375"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1398"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1406"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1237"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1244"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1251"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1409"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1416"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1482"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1241"/>
         <source>Support for bluetooth module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1459"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1528"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1469"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1538"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1489"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1556"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1423"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1494"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1441"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1476"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1561"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1421"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1371"/>
+        <source>HelloRadioSky V16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1408"/>
+        <source>Jumper T-Pro V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1418"/>
+        <source>Jumper T-Pro S</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1439"/>
+        <source>Jumper T12 MAX</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1446"/>
+        <source>Jumper T14</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1453"/>
+        <source>Jumper T15</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1474"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1428"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1481"/>
+        <source>Jumper T20 V2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1488"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1438"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1498"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1448"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1508"/>
+        <source>Radiomaster MT12</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1517"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1456"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1525"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1479"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1548"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1483"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
         <source>Support internal GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1485"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1259"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1552"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1414"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1467"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1235"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1263"/>
         <source>FlySky NV14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1245"/>
         <source>BETAFPV LiteRadio3 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1343"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1378"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1202"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1219"/>
         <source>Enable HELI menu and cyclic mix support</source>
         <translation type="unfinished">允許直升機菜單和斜盤混控支持</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1164"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1181"/>
         <source>Enable AFHDS2A support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1203"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1220"/>
         <source>Global variables</source>
         <translation type="unfinished">GV  [Global variables]</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1205"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1222"/>
         <source>In model setup menus automatically set source by moving the control</source>
         <translation type="unfinished">在模型配置菜單通過移動搖桿自動設置源</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1206"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1223"/>
         <source>In model setup menus automatically set switch by moving the control</source>
         <translation type="unfinished">在模型配置菜單通過撥動開關自動設置源</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1207"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1224"/>
         <source>No graphical check boxes and sliders</source>
         <translation type="unfinished">無圖形選擇框和滑桿</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1208"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1225"/>
         <source>Battery graph</source>
         <translation type="unfinished">電池圖標</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1209"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1226"/>
         <source>Don&apos;t use bold font for highlighting active items</source>
         <translation type="unfinished">不使用粗體高亮活動項目</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1242"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1255"/>
+        <source>Fatfish F16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1270"/>
         <source>FlySky EL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1249"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1277"/>
         <source>FlySky PL18</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1308"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1336"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1283"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1311"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1258"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1271"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1286"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1299"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1212"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="1229"/>
         <source>Enable resetting values by pressing up and down at the same time</source>
         <translation type="unfinished">允許通過同時按上下鍵重設數值</translation>
     </message>
@@ -3965,28 +4005,28 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlapsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="500"/>
+        <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
         <translatorcomment>FlapsPage</translatorcomment>
         <translation>没有襟翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="501"/>
+        <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
         <translation>有襟翼, 使用一個單通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="502"/>
+        <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
         <translation>有襟翼, 使用兩個通道控制</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="514"/>
+        <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
         <translation>&lt;br&gt;第一個襟翼通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="516"/>
+        <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
         <translation>第二個襟翼通道:</translation>
     </message>
@@ -3995,7 +4035,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <name>FlashEEpromDialog</name>
     <message>
         <location filename="../flasheepromdialog.ui" line="26"/>
-        <location filename="../flasheepromdialog.cpp" line="253"/>
+        <location filename="../flasheepromdialog.cpp" line="254"/>
         <source>Write Models and Settings to Radio</source>
         <translation>將模型和設置寫入到遙控器</translation>
     </message>
@@ -4060,51 +4100,51 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>寫入到遙控器</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="37"/>
+        <location filename="../flasheepromdialog.cpp" line="38"/>
         <source>Current profile: %1</source>
         <translation>當前檔案: %1</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="104"/>
+        <location filename="../flasheepromdialog.cpp" line="105"/>
         <source>Choose Radio Backup file</source>
         <translation>選擇遙控器備份文件</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="165"/>
+        <location filename="../flasheepromdialog.cpp" line="166"/>
         <source>Wrong radio calibration data in profile, Settings not patched</source>
         <translation>此文檔包含錯誤的遙控器校準數據.設置沒有修改</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="210"/>
+        <location filename="../flasheepromdialog.cpp" line="211"/>
         <source>Wrong radio setting data in profile, Settings not patched</source>
         <translation>此文檔包含錯誤的遙控器設置數據.設置沒有修改</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="239"/>
+        <location filename="../flasheepromdialog.cpp" line="240"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>無法寫入文件 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="245"/>
+        <location filename="../flasheepromdialog.cpp" line="246"/>
         <source>Error writing file %1:
 %2.</source>
         <translation>寫入文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="284"/>
+        <location filename="../flasheepromdialog.cpp" line="285"/>
         <source>The radio firmware belongs to another product family, check file and preferences!</source>
         <translation>這個遙控器韌體屬於其他產品，檢查文件和配置!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="288"/>
+        <location filename="../flasheepromdialog.cpp" line="289"/>
         <source>The radio firmware is outdated, please upgrade!</source>
         <translation>這個遙控器韌體已經過期, 請升級!</translation>
     </message>
     <message>
-        <location filename="../flasheepromdialog.cpp" line="293"/>
+        <location filename="../flasheepromdialog.cpp" line="294"/>
         <source>Cannot check Models and Settings compatibility! Continue anyway?</source>
         <translation>無法檢查模型和設置兼容性! 仍然繼續麼?</translation>
     </message>
@@ -4182,103 +4222,103 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>寫入到遙控器</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="140"/>
+        <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
         <translation>打開韌體文件</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="144"/>
+        <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
         <translation>%1 可能是非法的韌體文件</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="154"/>
+        <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
         <translation>韌體文件非法.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="157"/>
+        <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
         <translation>韌體中沒有開機畫面.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="171"/>
+        <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
         <translation>檔案圖片 %1 无效.</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
         <translation>打開圖片文件用作遙控器開機畫面</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="186"/>
+        <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
         <translation>圖片 (%1)</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="191"/>
+        <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
         <translation>圖片無法從 %1 中加載</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="209"/>
+        <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
         <translation>圖片庫中的圖片無法被加載</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="234"/>
+        <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
         <translation>無法找到開機畫面圖片</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="247"/>
+        <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
         <translation>無法保存定制韌體</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="273"/>
+        <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
         <translation>寫入韌體到遙控器</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
         <translation>韌體檢查失敗</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="280"/>
+        <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
         <translation>無法檢查遙控器中的韌體</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="288"/>
+        <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
         <translation>新的韌體於當前安裝的韌體不兼容!</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Conversion failed</source>
         <translation>轉換失敗</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="320"/>
+        <location filename="../flashfirmwaredialog.cpp" line="321"/>
         <source>Cannot convert Models and Settings for use with this firmware, original data will be used</source>
         <translation>無法轉換此韌體中的模型和設置, 將使用原始數據</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Restore failed</source>
         <translation>恢復失敗</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="324"/>
+        <location filename="../flashfirmwaredialog.cpp" line="325"/>
         <source>Could not restore Models and Settings to Radio. The models and settings data file can be found at: %1</source>
         <translation>無法將模型和設置恢復到遙控器. 模型和設置數據可以在 %1 中找到</translation>
     </message>
     <message>
-        <location filename="../flashfirmwaredialog.cpp" line="328"/>
+        <location filename="../flashfirmwaredialog.cpp" line="329"/>
         <source>Flashing done</source>
         <translation>燒錄完成</translation>
     </message>
@@ -4286,52 +4326,52 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
 <context>
     <name>FlashProcess</name>
     <message>
-        <location filename="../process_flash.cpp" line="69"/>
+        <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>未找到可執行文件 %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="214"/>
+        <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>寫入中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="219"/>
+        <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>讀取中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="223"/>
+        <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>驗證中...</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="261"/>
+        <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
         <translatorcomment>FlashProcess</translatorcomment>
         <translation>未知</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="268"/>
+        <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
         <translation>例如: OpenTX for 9X 主板 或 OpenTX for 9XR 主板</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="273"/>
+        <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
         <translation>例如: OpenTX for M128 / 9X 主板 或 帶有M128芯片的OpenTX for 9XR 主板</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="284"/>
+        <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
         <translation>例如: OpenTX for Gruvin9X 主板</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="292"/>
+        <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
@@ -4340,7 +4380,7 @@ Please check advanced burn options to set the correct cpu type.</source>
 請檢查高級燒錄選項設置正確的cpu型號.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
@@ -4349,7 +4389,7 @@ Please select an appropriate firmware type to program it.</source>
 請選擇合適的用來編程它的固件類型.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="296"/>
+        <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
@@ -4358,22 +4398,22 @@ You are currently using:
  %1</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="300"/>
+        <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
         <translation>你的遙控器似乎沒有連接到到USB端口，或沒有安裝驅動程序!!!.</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="311"/>
+        <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
         <translation>燒錄完成 (退出碼 = %1)</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="317"/>
+        <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
         <translation>燒錄完成但包含錯誤</translation>
     </message>
     <message>
-        <location filename="../process_flash.cpp" line="330"/>
+        <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
         <translation>熔絲位: Low=%1 High=%2 Ext=%3</translation>
     </message>
@@ -4381,7 +4421,7 @@ You are currently using:
 <context>
     <name>FlexSwitchesItemModel</name>
     <message>
-        <location filename="../datamodels/compounditemmodels.cpp" line="592"/>
+        <location filename="../datamodels/compounditemmodels.cpp" line="630"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
@@ -4436,225 +4476,240 @@ You are currently using:
 <context>
     <name>FlightModeData</name>
     <message>
-        <location filename="../firmwares/flightmodedata.cpp" line="45"/>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/flightmodedata.cpp" line="46"/>
+        <source>DM</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FlightModePanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="151"/>
+        <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="183"/>
+        <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="189"/>
+        <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="194"/>
+        <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
         <translation type="unfinished">设为</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="223"/>
-        <source>GVAR%1</source>
-        <translation>全局變量[GV] %1</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="215"/>
+        <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
         <translation>屏幕彈窗提示</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="39"/>
-        <location filename="../modeledit/flightmodes.cpp" line="226"/>
+        <location filename="../modeledit/flightmodes.cpp" line="41"/>
+        <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="112"/>
+        <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
         <translation type="unfinished">不使用微調</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="113"/>
+        <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="117"/>
+        <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
         <translation type="unfinished">使用單獨的微調值</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="120"/>
-        <source>Use Trim from Flight mode %1</source>
-        <translation type="unfinished">使用 FM%1 的微調值</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="122"/>
-        <source>Use Trim from Flight mode %1 + Own Trim as an offset</source>
-        <translation type="unfinished">使用 FM%1 的微調值 + 單獨的微調偏移值</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="199"/>
+        <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="203"/>
+        <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="207"/>
+        <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="211"/>
+        <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="388"/>
+        <location filename="../modeledit/flightmodes.cpp" line="402"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="389"/>
+        <location filename="../modeledit/flightmodes.cpp" line="403"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="498"/>
-        <source>Warning: Global variable links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="123"/>
+        <source>Use Trim from %1 Mode %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="607"/>
-        <source>Warning: Rotary encoder links back to itself. Flight Mode 0 value used.</source>
+        <location filename="../modeledit/flightmodes.cpp" line="125"/>
+        <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="681"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1062"/>
+        <location filename="../modeledit/flightmodes.cpp" line="227"/>
+        <source>GV%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="356"/>
+        <source>Own value</source>
+        <translation type="unfinished">使用單獨的取值</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="359"/>
+        <source>%1 Mode %2 value</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="512"/>
+        <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="621"/>
+        <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="695"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
         <translation type="unfinished">複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="682"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1063"/>
+        <location filename="../modeledit/flightmodes.cpp" line="696"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="683"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1064"/>
+        <location filename="../modeledit/flightmodes.cpp" line="697"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
         <translation type="unfinished">貼上</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="686"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1067"/>
+        <location filename="../modeledit/flightmodes.cpp" line="700"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="687"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1068"/>
+        <location filename="../modeledit/flightmodes.cpp" line="701"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="688"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1069"/>
+        <location filename="../modeledit/flightmodes.cpp" line="702"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="689"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1070"/>
+        <location filename="../modeledit/flightmodes.cpp" line="703"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="691"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1072"/>
+        <location filename="../modeledit/flightmodes.cpp" line="705"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="726"/>
-        <source>Clear Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="740"/>
+        <source>Clear %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="763"/>
-        <source>Clear all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="777"/>
+        <source>Clear all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="798"/>
-        <source>Cut Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="812"/>
+        <source>Cut %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="806"/>
-        <source>Delete Flight Mode. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="820"/>
+        <source>Delete %1 Mode. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1162"/>
-        <source>Clear Global Variable across all Flight Modes. Are you sure?</source>
+        <location filename="../modeledit/flightmodes.cpp" line="1176"/>
+        <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1173"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1200"/>
+        <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1211"/>
+        <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1263"/>
+        <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1341"/>
+        <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1186"/>
-        <source>Clear all Global Variables for all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1197"/>
-        <source>Clear all Global Variables for this Flight Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1249"/>
-        <source>Cut Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1253"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1266"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1327"/>
-        <source>Paste to selected Global Variable across all Flight Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/flightmodes.cpp" line="684"/>
-        <location filename="../modeledit/flightmodes.cpp" line="1065"/>
+        <location filename="../modeledit/flightmodes.cpp" line="698"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
         <translation>清除</translation>
     </message>
@@ -4662,19 +4717,18 @@ You are currently using:
 <context>
     <name>FlightModesPanel</name>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1432"/>
-        <source>Flight Mode %1</source>
-        <translatorcomment>用於FM設定</translatorcomment>
-        <translation>飛行模式[FM] %1</translation>
+        <location filename="../modeledit/flightmodes.cpp" line="1462"/>
+        <source>%1 Mode %2</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1435"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1465"/>
         <source> (%1)</source>
         <translatorcomment>FlightModePanel</translatorcomment>
         <translation>(%1)</translation>
     </message>
     <message>
-        <location filename="../modeledit/flightmodes.cpp" line="1438"/>
+        <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
         <translatorcomment>FlightModePanel</translatorcomment>
         <translation>(默認)</translation>
@@ -4683,17 +4737,17 @@ You are currently using:
 <context>
     <name>FlybarSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="377"/>
+        <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
         <translation>有副翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="379"/>
+        <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
         <translation>無副翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="382"/>
+        <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
         <translation>副翼:</translation>
     </message>
@@ -4701,17 +4755,17 @@ You are currently using:
 <context>
     <name>FrSkyAlarmData</name>
     <message>
-        <location filename="../firmwares/telem_data.h" line="43"/>
+        <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="47"/>
+        <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4719,13 +4773,13 @@ You are currently using:
 <context>
     <name>FrSkyChannelData</name>
     <message>
-        <location filename="../firmwares/telem_data.cpp" line="44"/>
-        <location filename="../firmwares/telem_data.h" line="75"/>
+        <location filename="../firmwares/telem_data.cpp" line="45"/>
+        <location filename="../firmwares/telem_data.h" line="76"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/telem_data.h" line="73"/>
+        <location filename="../firmwares/telem_data.h" line="74"/>
         <source>---</source>
         <translation type="unfinished">正向  [→]</translation>
     </message>
@@ -4743,17 +4797,18 @@ You are currently using:
         <translation>可自定義開關</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="76"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
         <translation type="unfinished">開始通道  [CH]</translation>
     </message>
@@ -4763,7 +4818,12 @@ You are currently using:
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup_function_switches.ui" line="103"/>
+        <location filename="../modeledit/setup_function_switches.ui" line="128"/>
+        <source>Switch Groups</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4771,8 +4831,13 @@ You are currently using:
 <context>
     <name>FunctionSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1266"/>
+        <location filename="../modeledit/setup.cpp" line="1297"/>
         <source>SW%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/setup.cpp" line="1341"/>
+        <source>Group %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4917,13 +4982,13 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;只有当你知道自己在做什么时才进行操作.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="42"/>
-        <location filename="../fusesdialog.cpp" line="48"/>
+        <location filename="../fusesdialog.cpp" line="43"/>
+        <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
         <translation>重設遙控器熔絲位</translation>
     </message>
     <message>
-        <location filename="../fusesdialog.cpp" line="54"/>
+        <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
         <translation>從遙控器中讀取熔絲位</translation>
     </message>
@@ -4931,44 +4996,34 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GVarData</name>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="31"/>
+        <location filename="../firmwares/gvardata.cpp" line="32"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="33"/>
+        <location filename="../firmwares/gvardata.cpp" line="34"/>
         <source>?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="41"/>
+        <location filename="../firmwares/gvardata.cpp" line="42"/>
         <source>0._</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="43"/>
+        <location filename="../firmwares/gvardata.cpp" line="44"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="45"/>
+        <location filename="../firmwares/gvardata.cpp" line="46"/>
         <source>?.?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/gvardata.cpp" line="51"/>
+        <location filename="../firmwares/gvardata.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="230"/>
-        <source>Own value</source>
-        <translation type="unfinished">使用單獨的取值</translation>
-    </message>
-    <message>
-        <location filename="../helpers.cpp" line="233"/>
-        <source>Flight mode %1 value</source>
-        <translation type="unfinished">使用FM%1值</translation>
     </message>
 </context>
 <context>
@@ -4996,62 +5051,62 @@ These will be relevant for all models in the same EEPROM.</source>
 對相同的EEPROM, 對所有模型這些設置都是相同的.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="67"/>
+        <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
         <translatorcomment>General Edit????</translatorcomment>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="68"/>
+        <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
         <translatorcomment>General Edit</translatorcomment>
         <translation>全局功能</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="69"/>
+        <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
         <translatorcomment>General Edit</translatorcomment>
         <translation>教練功能</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="71"/>
+        <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
         <translatorcomment>General Edit????</translatorcomment>
         <translation>硬件</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="72"/>
+        <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
         <translatorcomment>General Edit</translatorcomment>
         <translation>校準</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="73"/>
+        <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="171"/>
+        <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
         <translation>此文檔包含錯誤的數據. 未讀取遙控器校準數據</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="197"/>
+        <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
         <translation>此文檔包含錯誤的數據. 未讀取開關/旋鈕配置</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="238"/>
+        <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
         <translation>此文檔包含錯誤的數據. 未讀取硬件相關參數</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="261"/>
+        <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
         <translation>你想要存儲校準數據到 %1 檔案&lt;br&gt;覆蓋當前已經存在的校準數據麼?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generaledit.cpp" line="315"/>
+        <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
         <translation>校準數據和硬件參數已經存儲.</translation>
     </message>
@@ -5090,8 +5145,8 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">飛行模式 FM</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
@@ -5127,185 +5182,208 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="425"/>
+        <location filename="../firmwares/generalsettings.cpp" line="410"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="427"/>
+        <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Hardware</source>
         <translation type="unfinished">硬件</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="428"/>
+        <location filename="../firmwares/generalsettings.cpp" line="413"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="443"/>
+        <location filename="../firmwares/generalsettings.cpp" line="428"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="447"/>
+        <location filename="../firmwares/generalsettings.cpp" line="433"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="476"/>
+        <location filename="../firmwares/generalsettings.cpp" line="462"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="480"/>
+        <location filename="../firmwares/generalsettings.cpp" line="467"/>
+        <location filename="../firmwares/generalsettings.cpp" line="479"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="468"/>
+        <location filename="../firmwares/generalsettings.cpp" line="480"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="507"/>
+        <location filename="../firmwares/generalsettings.cpp" line="497"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="562"/>
+        <location filename="../firmwares/generalsettings.cpp" line="551"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="564"/>
+        <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="566"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="569"/>
+        <location filename="../firmwares/generalsettings.cpp" line="558"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="582"/>
-        <location filename="../firmwares/generalsettings.cpp" line="598"/>
+        <location filename="../firmwares/generalsettings.cpp" line="571"/>
+        <location filename="../firmwares/generalsettings.cpp" line="587"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="585"/>
+        <location filename="../firmwares/generalsettings.cpp" line="574"/>
         <source>Telemetry</source>
         <translation type="unfinished">回傳設置 Tele</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="587"/>
+        <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Trainer</source>
         <translation type="unfinished">教練功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="600"/>
+        <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="602"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="604"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">SBUS 教練功能  [SBUS Trainer]</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="606"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="608"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="610"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="612"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>Debug</source>
         <translation type="unfinished">除錯 [Debug]</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="614"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="616"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="649"/>
+        <location filename="../firmwares/generalsettings.cpp" line="638"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="748"/>
+        <location filename="../firmwares/generalsettings.cpp" line="737"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="750"/>
+        <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="795"/>
+        <location filename="../firmwares/generalsettings.cpp" line="784"/>
         <source>Trims only</source>
         <translation type="unfinished">微調</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="797"/>
+        <location filename="../firmwares/generalsettings.cpp" line="786"/>
         <source>Keys only</source>
         <translation type="unfinished">導航鍵</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="799"/>
+        <location filename="../firmwares/generalsettings.cpp" line="788"/>
         <source>Switchable</source>
         <translation type="unfinished">可切換</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="801"/>
+        <location filename="../firmwares/generalsettings.cpp" line="790"/>
         <source>Global</source>
         <translation type="unfinished">全局</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1003"/>
+        <source>Mode 1 (RUD ELE THR AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1005"/>
+        <source>Mode 2 (RUD THR ELE AIL)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1007"/>
+        <source>Mode 3 (AIL ELE THR RUD)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/generalsettings.cpp" line="1009"/>
+        <source>Mode 4 (AIL THR ELE RUD)</source>
+        <translation type="unfinished">MODE4 模式4 ↕油門↔副翼 ↕升降↔方向</translation>
     </message>
 </context>
 <context>
@@ -5322,206 +5400,204 @@ These will be relevant for all models in the same EEPROM.</source>
         <translation>只讀解鎖  [Readonly Unlock]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="47"/>
+        <location filename="../generaledit/generalsetup.ui" line="44"/>
         <source>SC</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="109"/>
+        <location filename="../generaledit/generalsetup.ui" line="100"/>
         <source>SE</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="404"/>
+        <location filename="../generaledit/generalsetup.ui" line="374"/>
         <source>SA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="420"/>
+        <location filename="../generaledit/generalsetup.ui" line="387"/>
         <source>SF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="436"/>
+        <location filename="../generaledit/generalsetup.ui" line="400"/>
         <source>SH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="452"/>
+        <location filename="../generaledit/generalsetup.ui" line="413"/>
         <source>SD</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="468"/>
+        <location filename="../generaledit/generalsetup.ui" line="426"/>
         <source>SB</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="533"/>
+        <location filename="../generaledit/generalsetup.ui" line="485"/>
         <source>SG</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="758"/>
+        <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
         <translation>依照UTC調整時間        [From UTC]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="765"/>
+        <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
         <translation>語音語言         [Voice Language]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1022"/>
+        <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
         <translation>國家代碼           [Country Code]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="648"/>
+        <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
         <translation>反向搖桿          [Stick Reverse]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1098"/>
+        <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
         <translation>FAI 模式               [FAI Mode]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1069"/>
+        <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
         <translation>如果安裝有GPS回傳則自動調整遙控器時鐘.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1075"/>
+        <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
         <translation>自動調整時鐘</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="803"/>
+        <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
         <translation>最大上升率時Vario音調       [Max]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="953"/>
-        <location filename="../generaledit/generalsetup.ui" line="1105"/>
+        <location filename="../generaledit/generalsetup.ui" line="1039"/>
+        <location filename="../generaledit/generalsetup.ui" line="1175"/>
         <source> Hz</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="844"/>
+        <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
         <translation>喇叭音量                 [Volume]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1029"/>
+        <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
         <translation>背光開關                 [Switch]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1186"/>
+        <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
         <translation>聲音模式             [Sound Mode]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1143"/>
+        <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
         <translation>顏色 1</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1163"/>
+        <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
         <translation>顏色 2</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1172"/>
+        <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
         <translation>喇叭音調 (僅喇叭)         [Pitch]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1048"/>
+        <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
         <translation>如果值非0, 任何按鍵將會開啟背光, 並在所設定秒數後關閉.</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1051"/>
-        <location filename="../generaledit/generalsetup.ui" line="1631"/>
-        <location filename="../generaledit/generalsetup.ui" line="2437"/>
+        <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
         <translation> 秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1134"/>
+        <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
         <translation>背光顏色                  [Color]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="619"/>
+        <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
         <translation>蜂鳴器</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="624"/>
+        <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
         <translation>喇叭</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="629"/>
+        <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
         <translation>蜂鳴器和語音</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="634"/>
+        <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
         <translation>喇叭和語音</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="664"/>
+        <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
         <translation>蜂鳴器音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="687"/>
+        <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
         <translation>WAV播放音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="710"/>
+        <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
         <translation>Vario音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="733"/>
+        <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
         <translation>背景音樂音量</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="920"/>
-        <location filename="../generaledit/generalsetup.ui" line="1655"/>
+        <location filename="../generaledit/generalsetup.ui" line="757"/>
+        <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
         <translation> 毫秒</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1091"/>
+        <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
         <translation>背光自動關閉時間       [Duration]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="775"/>
+        <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
         <translation>警告時背光閃爍            [Alarm]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="939"/>
+        <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
         <translation>升降率為0時Vario音調       [Zero]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="796"/>
+        <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
         <translation>升降率0時Vario重複率     [Repeat]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1010"/>
+        <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
@@ -5532,7 +5608,7 @@ These will be relevant for all models in the same EEPROM.</source>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
-        <location filename="../generaledit/generalsetup.ui" line="1647"/>
+        <location filename="../generaledit/generalsetup.ui" line="2172"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -5547,37 +5623,37 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;取值范围 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="789"/>
+        <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
         <translation>背光亮度             [Brightness]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="946"/>
+        <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
         <translation>旋轉編碼器導航           [RotEnc]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="902"/>
+        <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
         <translation>美國</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="907"/>
+        <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
         <translation>日本</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="912"/>
+        <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
         <translation>歐洲</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="574"/>
+        <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2518"/>
+        <location filename="../generaledit/generalsetup.ui" line="1887"/>
         <source>Mode selection:
 
 Mode 1:
@@ -5618,252 +5694,112 @@ MODE4 模式4:
 </translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2543"/>
-        <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation>MODE1 日本手↕升降↔方向 ↕油門↔副翼</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2548"/>
-        <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation>MODE2 美國手↕油門↔方向 ↕升降↔副翼</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2553"/>
-        <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation>MODE3 中國手↕升降↔副翼 ↕油門↔方向</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="2558"/>
-        <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation>MODE4 模式4 ↕油門↔副翼 ↕升降↔方向</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1822"/>
+        <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;通道順序&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;定义了当新的混控创建时默认的通道顺序.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1124"/>
+        <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1366"/>
+        <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1312"/>
+        <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="560"/>
+        <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="567"/>
+        <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="595"/>
+        <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="600"/>
+        <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="605"/>
+        <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="610"/>
+        <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="810"/>
+        <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="851"/>
+        <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="871"/>
+        <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="878"/>
+        <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1210"/>
+        <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1218"/>
+        <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1223"/>
+        <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1237"/>
+        <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1246"/>
+        <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1251"/>
+        <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1829"/>
-        <source>R E T A</source>
-        <translation>方向 升降 油門 副翼  [R E T A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1834"/>
-        <source>R E A T</source>
-        <translation>方向 升降 副翼 油門  [R E A T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1839"/>
-        <source>R T E A</source>
-        <translation>方向 油門 升降 副翼  [R T E A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1844"/>
-        <source>R T A E</source>
-        <translation>方向 油門 副翼 升降  [R T A E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1849"/>
-        <source>R A E T</source>
-        <translation>方向 副翼 升降 油門  [R A E T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1854"/>
-        <source>R A T E</source>
-        <translation>方向 副翼 油門 升降  [R A T E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1859"/>
-        <source>E R T A</source>
-        <translation>升降 方向 油門 副翼  [E R T A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1864"/>
-        <source>E R A T</source>
-        <translation>升降 方向 副翼 油門  [E R A T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1869"/>
-        <source>E T R A</source>
-        <translation>升降 油門 方向 副翼  [E T R A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1874"/>
-        <source>E T A R</source>
-        <translation>升降 油門 副翼 方向  [E T A R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1879"/>
-        <source>E A R T</source>
-        <translation>升降 副翼 方向 油門  [E A R T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1884"/>
-        <source>E A T R</source>
-        <translation>升降 副翼 油門 方向  [E A T R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1889"/>
-        <source>T R E A</source>
-        <translation>油門 方向 升降 副翼  [T R E A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1894"/>
-        <source>T R A E</source>
-        <translation>油門 方向 副翼 升降  [T R A E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1899"/>
-        <source>T E R A</source>
-        <translation>油門 升降 方向 副翼  [T E R A]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1904"/>
-        <source>T E A R</source>
-        <translation>油門 升降 副翼 方向  [T E A R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1909"/>
-        <source>T A R E</source>
-        <translation>油門 副翼 方向 升降  [T A R E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1914"/>
-        <source>T A E R</source>
-        <translation>油門 副翼 升降 方向  [T A E R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1919"/>
-        <source>A R E T</source>
-        <translation>副翼 方向 升降 油門  [A R E T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1924"/>
-        <source>A R T E</source>
-        <translation>副翼 方向 油門 升降  [A R T E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1929"/>
-        <source>A E R T</source>
-        <translation>副翼 升降 方向 油門  [A E R T]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1934"/>
-        <source>A E T R</source>
-        <translation>副翼 升降 油門 方向  [A E T R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1939"/>
-        <source>A T R E</source>
-        <translation>副翼 油門 方向 升降  [A T R E]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1944"/>
-        <source>A T E R</source>
-        <translation>副翼 油門 升降 方向  [A T E R]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.ui" line="1983"/>
+        <location filename="../generaledit/generalsetup.ui" line="1701"/>
         <source>Battery warning voltage.
 This is the threshold where the battery warning sounds.
 
@@ -5874,334 +5810,367 @@ Acceptable values are 3v..12v</source>
 允許值是3V - 12V</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2042"/>
+        <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2049"/>
+        <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2359"/>
+        <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2592"/>
-        <location filename="../generaledit/generalsetup.ui" line="2596"/>
+        <location filename="../generaledit/generalsetup.ui" line="2041"/>
+        <location filename="../generaledit/generalsetup.ui" line="2045"/>
         <source>0.--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2601"/>
+        <location filename="../generaledit/generalsetup.ui" line="2050"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2606"/>
+        <location filename="../generaledit/generalsetup.ui" line="2055"/>
         <source>us</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1485"/>
+        <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1490"/>
+        <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
         <translation type="unfinished">教練功能</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1466"/>
+        <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1809"/>
+        <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1792"/>
+        <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1480"/>
-        <location filename="../generaledit/generalsetup.ui" line="1575"/>
+        <location filename="../generaledit/generalsetup.ui" line="1544"/>
+        <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1580"/>
+        <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1585"/>
+        <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1590"/>
+        <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1802"/>
+        <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
         <translation>按鍵帽模式</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1598"/>
+        <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
         <translation>摇杆模式                [MODE]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2374"/>
+        <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
         <translation>公制  [Metric]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2379"/>
+        <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
         <translation>英制  [Imperial]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2075"/>
+        <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
         <translation>默認通道順序[Default Ch Order]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2505"/>
+        <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
         <translation>GPS坐標格式  [GPS Coordinates]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2125"/>
+        <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>最小</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2132"/>
-        <location filename="../generaledit/generalsetup.ui" line="2161"/>
+        <location filename="../generaledit/generalsetup.ui" line="2386"/>
+        <location filename="../generaledit/generalsetup.ui" line="2415"/>
         <source>v</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>v</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2154"/>
+        <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>最大</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2352"/>
+        <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
         <translation>忘記關機定時器    [Inactivity]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1686"/>
+        <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
         <translation>顯示開機畫面   [Splash Screen]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2462"/>
+        <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
         <translation>顯示屏對比度        [Contrast]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1385"/>
+        <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
         <translation>遙控器電池圖標範圍     [Range]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2116"/>
+        <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
         <translation>振動強度     [Haptic Strength]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2578"/>
+        <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
         <translation>LCD顯示屏類型  [LCD Disp Type]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2399"/>
+        <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
         <translation>當靜音時 開機警告  [Sound Off]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2097"/>
+        <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
         <translation>遙控器電量警告   [Battery Low]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1423"/>
+        <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
         <translation>振動時長       [Haptic Length]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2062"/>
+        <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
         <translation>MAVLink 波特率     [Baud Rate]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1721"/>
-        <location filename="../generaledit/generalsetup.ui" line="2482"/>
+        <location filename="../generaledit/generalsetup.ui" line="1806"/>
+        <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>禁用  [Quiet]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2487"/>
+        <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>只有警告  [Alarm]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1731"/>
-        <location filename="../generaledit/generalsetup.ui" line="2492"/>
+        <location filename="../generaledit/generalsetup.ui" line="1816"/>
+        <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>忽略按鍵  [NoKey]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1736"/>
-        <location filename="../generaledit/generalsetup.ui" line="2497"/>
+        <location filename="../generaledit/generalsetup.ui" line="1821"/>
+        <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>開啟  [All]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1618"/>
+        <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
         <translation>標準LCD  [Standard]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1623"/>
+        <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>光王LCD  [Optrex]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2424"/>
+        <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1193"/>
+        <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="861"/>
+        <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2427"/>
+        <location filename="../generaledit/generalsetup.ui" line="1864"/>
+        <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2295"/>
+        <location filename="../generaledit/generalsetup.ui" line="1373"/>
         <source>---</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2300"/>
+        <location filename="../generaledit/generalsetup.ui" line="1212"/>
+        <location filename="../generaledit/generalsetup.ui" line="1629"/>
+        <source>0s</source>
+        <translation type="unfinished">0s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1217"/>
+        <location filename="../generaledit/generalsetup.ui" line="1634"/>
+        <source>0.5s</source>
+        <translation type="unfinished">0.5s</translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1227"/>
+        <location filename="../generaledit/generalsetup.ui" line="1378"/>
+        <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2305"/>
+        <location filename="../generaledit/generalsetup.ui" line="1232"/>
+        <location filename="../generaledit/generalsetup.ui" line="1383"/>
+        <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2310"/>
+        <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2315"/>
+        <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2320"/>
+        <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2325"/>
+        <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2330"/>
+        <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1512"/>
+        <location filename="../generaledit/generalsetup.ui" line="1418"/>
+        <source>Trainer Poweroff Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1915"/>
+        <source>Power ON/OFF Haptic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="2286"/>
         <source>4800 Baud</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1517"/>
+        <location filename="../generaledit/generalsetup.ui" line="2291"/>
         <source>9600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1522"/>
+        <location filename="../generaledit/generalsetup.ui" line="2296"/>
         <source>14400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1527"/>
+        <location filename="../generaledit/generalsetup.ui" line="2301"/>
         <source>19200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1532"/>
+        <location filename="../generaledit/generalsetup.ui" line="2306"/>
         <source>38400 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1537"/>
+        <location filename="../generaledit/generalsetup.ui" line="2311"/>
         <source>57600 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1542"/>
+        <location filename="../generaledit/generalsetup.ui" line="2316"/>
         <source>76800 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1547"/>
+        <location filename="../generaledit/generalsetup.ui" line="2321"/>
         <source>115200 Baud</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1331"/>
-        <location filename="../generaledit/generalsetup.ui" line="1442"/>
-        <location filename="../generaledit/generalsetup.ui" line="2203"/>
+        <location filename="../generaledit/generalsetup.ui" line="2519"/>
+        <source>Power Auto Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.ui" line="1281"/>
+        <location filename="../generaledit/generalsetup.ui" line="1513"/>
+        <location filename="../generaledit/generalsetup.ui" line="2217"/>
+        <location filename="../generaledit/generalsetup.ui" line="2496"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -6216,72 +6185,72 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1757"/>
-        <location filename="../generaledit/generalsetup.ui" line="2258"/>
+        <location filename="../generaledit/generalsetup.ui" line="1587"/>
+        <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>極短</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1762"/>
-        <location filename="../generaledit/generalsetup.ui" line="2263"/>
+        <location filename="../generaledit/generalsetup.ui" line="1592"/>
+        <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>較短</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1767"/>
-        <location filename="../generaledit/generalsetup.ui" line="2268"/>
+        <location filename="../generaledit/generalsetup.ui" line="1597"/>
+        <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
         <translation>正常</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1772"/>
-        <location filename="../generaledit/generalsetup.ui" line="2273"/>
+        <location filename="../generaledit/generalsetup.ui" line="1602"/>
+        <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>較長</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1777"/>
-        <location filename="../generaledit/generalsetup.ui" line="2278"/>
+        <location filename="../generaledit/generalsetup.ui" line="1607"/>
+        <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
         <translation>極長</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1471"/>
+        <location filename="../generaledit/generalsetup.ui" line="1835"/>
         <source>NMEA</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1958"/>
+        <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
         <translation>開關撥過中檔時播音延遲 [Delay]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1785"/>
+        <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
         <translation>單位制                 [Units]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1567"/>
+        <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>振動             [Haptic Mode]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="2238"/>
+        <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
         <translation>蜂鳴時長         [Beep Length]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1404"/>
+        <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
         <translation>蜂鳴音             [Beep Mode]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1711"/>
+        <location filename="../generaledit/generalsetup.ui" line="2107"/>
         <source>Beeper volume
 
 0 - Quiet.  No beeps at all.
@@ -6292,13 +6261,15 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.ui" line="1726"/>
+        <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
         <translatorcomment>GeneralEdit</translatorcomment>
         <translation>只有警告  [Alarm]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="277"/>
+        <location filename="../generaledit/generalsetup.ui" line="1222"/>
+        <location filename="../generaledit/generalsetup.ui" line="1639"/>
+        <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
         <translation type="unfinished">1s</translation>
     </message>
@@ -6306,179 +6277,179 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GeneralSetupPanel</name>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
         <translation type="unfinished">按鍵  [Keys]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Sticks</source>
-        <translation type="unfinished">摇杆  [Sticks]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
-        <source>Keys + Sticks</source>
-        <translation type="unfinished">按鍵和搖桿  [Keys + Sticks]</translation>
-    </message>
-    <message>
-        <location filename="../generaledit/generalsetup.cpp" line="362"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
         <translation type="unfinished">啟用</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="383"/>
+        <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
         <translation type="unfinished">英語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="382"/>
+        <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
         <translation type="unfinished">荷蘭語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="384"/>
+        <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
         <translation type="unfinished">法語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="388"/>
+        <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
         <translation type="unfinished">意大利語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="385"/>
+        <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
         <translation type="unfinished">德語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="380"/>
+        <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
         <translation type="unfinished">捷克語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="393"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
         <translation type="unfinished">慢動作  [Slow]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="394"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
         <translation type="unfinished">西班牙語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="390"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
         <translation type="unfinished">波蘭語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="391"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
         <translation type="unfinished">葡萄牙語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="392"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="395"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
         <translation type="unfinished">瑞典語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="387"/>
+        <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
         <translation type="unfinished">匈牙利語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="381"/>
+        <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="379"/>
+        <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="389"/>
+        <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="386"/>
+        <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="396"/>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="402"/>
+        <source>Keys + Controls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
         <translation type="unfinished">旋轉編碼器A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">旋轉編碼器B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">旋轉編碼器C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">旋轉編碼器D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="468"/>
+        <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">旋轉編碼器E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="561"/>
+        <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="579"/>
+        <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6486,18 +6457,18 @@ Are you sure ?</source>
 <context>
     <name>GyroPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="822"/>
+        <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
         <translatorcomment>Gyropage</translatorcomment>
         <translation>無陀螺儀</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="824"/>
+        <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
         <translation>有陀螺儀, 通過開關控制感度</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="825"/>
+        <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
         <translation>有陀螺儀, 通過旋鈕控制感度</translation>
     </message>
@@ -6505,118 +6476,128 @@ Are you sure ?</source>
 <context>
     <name>HardwarePanel</name>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="148"/>
+        <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="159"/>
+        <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="173"/>
+        <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="189"/>
+        <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="213"/>
+        <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
         <translation type="unfinished">藍牙 [Bluetooth]</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="222"/>
+        <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="276"/>
+        <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="289"/>
+        <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="301"/>
-        <location filename="../generaledit/hardware.cpp" line="320"/>
+        <location filename="../generaledit/hardware.cpp" line="302"/>
+        <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="330"/>
+        <location filename="../generaledit/hardware.cpp" line="331"/>
         <source>USB-VCP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="197"/>
+        <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="138"/>
+        <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="205"/>
+        <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
         <translation>音頻停播時自動靜音</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="234"/>
+        <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="235"/>
+        <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="244"/>
+        <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="258"/>
+        <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="275"/>
+        <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="292"/>
+        <location filename="../generaledit/hardware.cpp" line="293"/>
         <source>AUX1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="311"/>
+        <location filename="../generaledit/hardware.cpp" line="312"/>
         <source>AUX2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="342"/>
+        <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="350"/>
+        <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
         <translation type="unfinished">當前修正 [Offset]</translation>
     </message>
     <message>
-        <location filename="../generaledit/hardware.cpp" line="372"/>
+        <location filename="../generaledit/hardware.cpp" line="361"/>
+        <source>Screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="363"/>
+        <source>Invert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6697,22 +6678,22 @@ Are you sure ?</source>
 <context>
     <name>HeliPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="889"/>
+        <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
         <translation>油門通道  [Throttle]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="891"/>
+        <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
         <translation>偏航通道  [Yaw]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="893"/>
+        <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
         <translation>仰俯通道  [Pitch]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="895"/>
+        <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
         <translation>滾轉通道  [Roll]:</translation>
     </message>
@@ -6720,18 +6701,18 @@ Are you sure ?</source>
 <context>
     <name>HexEepromFormat</name>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="39"/>
+        <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
         <translation type="unfinished">無效的 EEPROM 文件 %1</translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="51"/>
+        <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/hexeeprom.cpp" line="57"/>
+        <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">寫入文件錯誤 %1:
@@ -6741,160 +6722,160 @@ Are you sure ?</source>
 <context>
     <name>InputsPanel</name>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="49"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
-        <location filename="../modeledit/inputs.cpp" line="421"/>
+        <location filename="../modeledit/inputs.cpp" line="50"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
         <translation>上移</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="51"/>
-        <location filename="../modeledit/inputs.cpp" line="415"/>
+        <location filename="../modeledit/inputs.cpp" line="52"/>
+        <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
         <translation>Ctrl+Up</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="52"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
-        <location filename="../modeledit/inputs.cpp" line="422"/>
+        <location filename="../modeledit/inputs.cpp" line="53"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
+        <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
         <translation>下移</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="54"/>
-        <location filename="../modeledit/inputs.cpp" line="416"/>
+        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Down</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="55"/>
+        <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
         <translation>清除所有輸入</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="161"/>
+        <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="247"/>
+        <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="259"/>
+        <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="405"/>
+        <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
         <translation type="unfinished">折線</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
         <translation>添加  (&amp;A)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="406"/>
+        <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
         <translation>編輯  (&amp;E)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="407"/>
+        <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
         <translatorcomment>InputPanel</translatorcomment>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
         <translation>删除  (&amp;D)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="409"/>
-        <location filename="../modeledit/inputs.cpp" line="420"/>
+        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
         <translation>複製  (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="410"/>
+        <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
         <translation>剪下  (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="411"/>
+        <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
         <translation>貼上  (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="412"/>
+        <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
         <translation>克隆  (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="413"/>
+        <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="418"/>
+        <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
         <translation type="unfinished">輸入</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="419"/>
+        <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="424"/>
+        <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="427"/>
+        <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="538"/>
+        <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="583"/>
+        <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/inputs.cpp" line="601"/>
+        <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6935,96 +6916,96 @@ Are you sure ?</source>
 <context>
     <name>LabelsStorageFormat</name>
     <message>
-        <location filename="../storage/labeled.cpp" line="66"/>
+        <location filename="../storage/labeled.cpp" line="67"/>
         <source>Cannot extract RADIO/radio.bin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="82"/>
+        <location filename="../storage/labeled.cpp" line="83"/>
         <source>Cannot extract RADIO/models.txt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="117"/>
+        <location filename="../storage/labeled.cpp" line="118"/>
         <source>Cannot extract %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="124"/>
+        <location filename="../storage/labeled.cpp" line="125"/>
         <source>Error loading models</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="145"/>
-        <location filename="../storage/labeled.cpp" line="319"/>
+        <location filename="../storage/labeled.cpp" line="146"/>
+        <location filename="../storage/labeled.cpp" line="320"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="182"/>
+        <location filename="../storage/labeled.cpp" line="183"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="184"/>
+        <location filename="../storage/labeled.cpp" line="185"/>
         <source>Found %1/RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="187"/>
+        <location filename="../storage/labeled.cpp" line="188"/>
         <source>Cannot find %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="189"/>
+        <location filename="../storage/labeled.cpp" line="190"/>
         <source>Found %1/MODELS/models.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="193"/>
+        <location filename="../storage/labeled.cpp" line="194"/>
         <source>Cannot find %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="195"/>
+        <location filename="../storage/labeled.cpp" line="196"/>
         <source>Found %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="200"/>
+        <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot extract RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="206"/>
-        <location filename="../storage/labeled.cpp" line="210"/>
+        <location filename="../storage/labeled.cpp" line="207"/>
+        <location filename="../storage/labeled.cpp" line="211"/>
         <source>Cannot load RADIO/radio.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="228"/>
-        <location filename="../storage/labeled.cpp" line="231"/>
+        <location filename="../storage/labeled.cpp" line="229"/>
+        <location filename="../storage/labeled.cpp" line="232"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="282"/>
+        <location filename="../storage/labeled.cpp" line="283"/>
         <source>Cannot extract </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="293"/>
-        <location filename="../storage/labeled.cpp" line="297"/>
+        <location filename="../storage/labeled.cpp" line="294"/>
+        <location filename="../storage/labeled.cpp" line="298"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="343"/>
+        <location filename="../storage/labeled.cpp" line="344"/>
         <source>Cannot list files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/labeled.cpp" line="354"/>
+        <location filename="../storage/labeled.cpp" line="355"/>
         <source>Error deleting files</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7032,17 +7013,17 @@ Are you sure ?</source>
 <context>
     <name>LimitData</name>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
         <translation type="unfinished">反向  [←]</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="50"/>
+        <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
         <translation type="unfinished">或非</translation>
     </message>
     <message>
-        <location filename="../firmwares/output_data.cpp" line="55"/>
+        <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7050,7 +7031,7 @@ Are you sure ?</source>
 <context>
     <name>LimitsGroup</name>
     <message>
-        <location filename="../modeledit/channels.cpp" line="51"/>
+        <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
         <translation type="unfinished">GV</translation>
     </message>
@@ -7058,122 +7039,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchData</name>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="66"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="67"/>
         <source>---</source>
         <translation type="unfinished">正向  [→]</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="68"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="69"/>
         <source>a&gt;x</source>
         <translation type="unfinished">數值1 ＞ 數值2           a&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="70"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="71"/>
         <source>a&lt;x</source>
         <translation type="unfinished">數值1 ＜ 數值2           a&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="72"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="73"/>
         <source>|a|&gt;x</source>
         <translation type="unfinished">|數值1| ＞ 數值2        |a|&gt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="74"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="75"/>
         <source>|a|&lt;x</source>
         <translation type="unfinished">|數值1| ＜ 數值 2       |a|&lt;x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="76"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
         <translation type="unfinished">與運算                   AND</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="78"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
         <translation type="unfinished">或運算                   OR</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="80"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
         <translation type="unfinished">異或運算                 XOR</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="82"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
         <source>a=b</source>
         <translation type="unfinished">數值1 ＝ 數值2           a=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="84"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="85"/>
         <source>a!=b</source>
         <translation type="unfinished">數值1 !＝ 數值2          a!=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="86"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="87"/>
         <source>a&gt;b</source>
         <translation type="unfinished">數值1 ＞ 數值2           a&gt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="88"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="89"/>
         <source>a&lt;b</source>
         <translation type="unfinished">數值1 ＜ 數值2           a&lt;b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="90"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="91"/>
         <source>a&gt;=b</source>
         <translation type="unfinished">數值1 ≥ 數值2           a&gt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="92"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="93"/>
         <source>a&lt;=b</source>
         <translation type="unfinished">數值1 ≤ 數值2           a&lt;=b</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="94"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="95"/>
         <source>d&gt;=x</source>
         <translation type="unfinished">數值1變動   ≥ 數值2     d&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="96"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="97"/>
         <source>|d|&gt;=x</source>
         <translation type="unfinished">|數值1變動| ≥ 數值2     d&gt;=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="98"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="99"/>
         <source>a=x</source>
         <translation type="unfinished">數值1 ＝ 數值2           a=x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="100"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="101"/>
         <source>a~x</source>
         <translation type="unfinished">數值1  ≈  數值2         a~x</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="102"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
         <translation type="unfinished">定時開關                 Timer</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="104"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
         <translation type="unfinished">粘滞键                   Sticky</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="106"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
         <translation type="unfinished">邊沿觸發                 EDGE</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="108"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
         <translation type="unfinished">未知[Unknown]</translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="114"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
         <source>L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/logicalswitchdata.cpp" line="119"/>
+        <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7181,117 +7162,122 @@ Are you sure ?</source>
 <context>
     <name>LogicalSwitchesPanel</name>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>運算方式  [Function]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>數值1  [V1]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>數值2  [V2]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="46"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
         <translation>與開關  [AND Sw]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>持續時間  [Duration]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="48"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
         <translatorcomment>LogicalSwitchPanel</translatorcomment>
         <translation>延遲  [Delay]</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="60"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="51"/>
+        <source>Persistent</source>
+        <translation type="unfinished">保持</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="409"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="504"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="527"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="540"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
         <translation type="unfinished">複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="541"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="542"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
         <translation type="unfinished">貼上</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="543"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="545"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="546"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="547"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="548"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="550"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="595"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="608"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/logicalswitches.cpp" line="113"/>
+        <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
         <translatorcomment>LogicalSwitchPanel 邊沿觸發使用</translatorcomment>
         <translation>(立刻 [instant])</translation>
@@ -7346,52 +7332,52 @@ Are you sure ?</source>
         <translation>打開 Log 文件</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="65"/>
+        <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
         <translation>回傳 logs</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="77"/>
+        <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
         <translation>改變繪製標題</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="144"/>
+        <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
         <translation>新的繪製標題:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
         <translation>改變坐標軸標籤</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="158"/>
+        <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
         <translation>新的坐標軸標題:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
         <translation>改變圖表的名稱</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="173"/>
+        <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
         <translation>新的圖表名稱:</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="267"/>
+        <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="268"/>
+        <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
@@ -7400,74 +7386,74 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 包含高度的列 &quot;GAlt&quot; 和包含速度的列 &quot;GSpd&quot; 是可選的</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="343"/>
+        <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>無法寫入文件 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="494"/>
+        <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
         <translation>光標 A: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="497"/>
+        <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
         <translation>光標 B: %1 m</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="509"/>
+        <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
         <translation>時間偏移: %1</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="510"/>
+        <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
         <translation>升降速率: %1 m/s</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="582"/>
+        <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
         <translation>選擇你的 log 文件</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="593"/>
+        <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
         <translation>可用項目</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="709"/>
+        <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
         <translation>選擇的 Log 文件共有 %2 條記錄, 其中 %1 條記錄無效</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="776"/>
+        <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="784"/>
+        <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
         <translation>持續時間</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1028"/>
+        <location filename="../logsdialog.cpp" line="1029"/>
         <source> (L1)</source>
         <translation> (L1)</translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1039"/>
+        <location filename="../logsdialog.cpp" line="1040"/>
         <source> (R1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1049"/>
+        <location filename="../logsdialog.cpp" line="1050"/>
         <source> (L2)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../logsdialog.cpp" line="1056"/>
+        <location filename="../logsdialog.cpp" line="1057"/>
         <source> (R2)</source>
         <translation></translation>
     </message>
@@ -7475,738 +7461,738 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../mainwindow.cpp" line="131"/>
-        <location filename="../mainwindow.cpp" line="367"/>
+        <location filename="../mainwindow.cpp" line="132"/>
+        <location filename="../mainwindow.cpp" line="368"/>
         <source>File loaded</source>
         <translation>文件已載入</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="284"/>
+        <location filename="../mainwindow.cpp" line="285"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
         <translation>新的主題將在重新打開程序後使用.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="378"/>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="379"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open Models and Settings file</source>
         <translation>打開模型和配置文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="385"/>
-        <location filename="../mainwindow.cpp" line="392"/>
+        <location filename="../mainwindow.cpp" line="386"/>
+        <location filename="../mainwindow.cpp" line="393"/>
         <source>File saved</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="501"/>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="502"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>Synchronize SD</source>
         <translation>同步SD卡</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="563"/>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="564"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read Firmware from Radio</source>
         <translation>從遙控器中讀取韌體</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write Firmware to Radio</source>
         <translation>將韌體寫入遙控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="573"/>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="574"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings from Radio</source>
         <translation>從遙控器中讀取模型和配置</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings to Radio</source>
         <translation>將模型和配置寫入遙控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="610"/>
+        <location filename="../mainwindow.cpp" line="611"/>
         <source>Save Radio Backup to File</source>
         <translation>保存遙控器備份到文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="873"/>
+        <location filename="../mainwindow.cpp" line="874"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="581"/>
+        <location filename="../mainwindow.cpp" line="582"/>
         <source>Models and Settings read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="438"/>
+        <location filename="../mainwindow.cpp" line="439"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="494"/>
+        <location filename="../mainwindow.cpp" line="495"/>
         <source>No local SD structure path configured!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="496"/>
+        <location filename="../mainwindow.cpp" line="497"/>
         <source>No Radio or SD card detected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="589"/>
-        <location filename="../mainwindow.cpp" line="606"/>
+        <location filename="../mainwindow.cpp" line="590"/>
+        <location filename="../mainwindow.cpp" line="607"/>
         <source>This function is not yet implemented</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="619"/>
+        <location filename="../mainwindow.cpp" line="620"/>
         <source>Read Radio Firmware to File</source>
         <translation>讀取遙控器韌體並保存到文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="659"/>
+        <location filename="../mainwindow.cpp" line="660"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
         <translation>如果你覺得此程序有用, 請通過&lt;a href=&apos;%1&apos;&gt;捐贈&lt;/a&gt;支持</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="675"/>
+        <location filename="../mainwindow.cpp" line="676"/>
         <source>About Companion</source>
         <translation>關於 Companion</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>New</source>
         <translatorcomment>MainWindow</translatorcomment>
         <translation>新建配置文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="816"/>
+        <location filename="../mainwindow.cpp" line="817"/>
         <source>Create a new Models and Settings file</source>
         <translation>建立新的模型和設置文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="817"/>
+        <location filename="../mainwindow.cpp" line="818"/>
         <source>Open...</source>
         <translation>打開...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
+        <location filename="../mainwindow.cpp" line="819"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="818"/>
         <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save Models and Settings file</source>
         <translation>保存模型和配置文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="819"/>
+        <location filename="../mainwindow.cpp" line="820"/>
         <source>Save As...</source>
         <translation>另存為...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close</source>
         <translation type="unfinished">關閉</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="820"/>
+        <location filename="../mainwindow.cpp" line="821"/>
         <source>Close Models and Settings file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="821"/>
+        <location filename="../mainwindow.cpp" line="822"/>
         <source>Exit the application</source>
         <translation>退出軟體</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1293"/>
+        <location filename="../mainwindow.cpp" line="1295"/>
         <source> - Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Companion :: Open files warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1302"/>
+        <location filename="../mainwindow.cpp" line="1304"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>Not possible to remove profile</source>
         <translation type="unfinished">不能移除遙控器檔案</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1310"/>
+        <location filename="../mainwindow.cpp" line="1312"/>
         <source>The default profile can not be removed.</source>
         <translation type="unfinished">默認遙控器檔案無法被移除.</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1315"/>
+        <location filename="../mainwindow.cpp" line="1317"/>
         <source>Confirm Delete Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1316"/>
+        <location filename="../mainwindow.cpp" line="1318"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>Classical</source>
         <translation>經典</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="958"/>
+        <location filename="../mainwindow.cpp" line="959"/>
         <source>The classic companion9x icon theme</source>
         <translation>經典 companion9x 圖標主題</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yerico</source>
         <translation>Yerico圖標主題</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="959"/>
+        <location filename="../mainwindow.cpp" line="960"/>
         <source>Yellow round honey sweet icon theme</source>
         <translation>黃色圓潤甜蜜圖標主題</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>Monochrome</source>
         <translation>單色黑白</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="960"/>
+        <location filename="../mainwindow.cpp" line="961"/>
         <source>A monochrome black icon theme</source>
         <translation>黑色圖標的黑白主題</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>MonoWhite</source>
         <translation>單色白色</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="962"/>
+        <location filename="../mainwindow.cpp" line="963"/>
         <source>A monochrome white icon theme</source>
         <translation>白色圖標的黑白主題</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>MonoBlue</source>
         <translation>單色藍色</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="503"/>
+        <location filename="../mainwindow.cpp" line="504"/>
         <source>Local Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="504"/>
+        <location filename="../mainwindow.cpp" line="505"/>
         <source>Radio Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>Writing models and settings to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="533"/>
+        <location filename="../mainwindow.cpp" line="534"/>
         <source>In progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="655"/>
+        <location filename="../mainwindow.cpp" line="656"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="657"/>
+        <location filename="../mainwindow.cpp" line="658"/>
         <source>The EdgeTX Companion project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="669"/>
+        <location filename="../mainwindow.cpp" line="670"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="671"/>
+        <location filename="../mainwindow.cpp" line="672"/>
         <source>Copyright</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="747"/>
+        <location filename="../mainwindow.cpp" line="748"/>
         <source>EdgeTX Companion %1 - Radio: %2 - Profile: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>About Companion...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>List of recently used files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="825"/>
+        <location filename="../mainwindow.cpp" line="826"/>
         <source>Create or Select Radio Profiles</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download components...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="828"/>
+        <location filename="../mainwindow.cpp" line="829"/>
         <source>Download EdgeTX components and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="829"/>
+        <location filename="../mainwindow.cpp" line="830"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Release notes...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="830"/>
+        <location filename="../mainwindow.cpp" line="831"/>
         <source>Show release notes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Create a new Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Copy Current Radio Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="845"/>
+        <location filename="../mainwindow.cpp" line="846"/>
         <source>Duplicate current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete Current Radio Profile...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="846"/>
+        <location filename="../mainwindow.cpp" line="847"/>
         <source>Delete the current Radio Settings Profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Export Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="848"/>
+        <location filename="../mainwindow.cpp" line="849"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Import Application Settings..</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="849"/>
+        <location filename="../mainwindow.cpp" line="850"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="851"/>
+        <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="852"/>
+        <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="853"/>
+        <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="854"/>
+        <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="862"/>
+        <location filename="../mainwindow.cpp" line="863"/>
         <source>Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="881"/>
+        <location filename="../mainwindow.cpp" line="882"/>
         <source>Ctrl+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="885"/>
+        <location filename="../mainwindow.cpp" line="886"/>
         <source>Ctrl+Alt+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="887"/>
+        <location filename="../mainwindow.cpp" line="888"/>
         <source>Ctrl+Alt+D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="888"/>
+        <location filename="../mainwindow.cpp" line="889"/>
         <source>Ctrl+Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="961"/>
+        <location filename="../mainwindow.cpp" line="962"/>
         <source>A monochrome blue icon theme</source>
         <translation>藍色圖標的黑白主題</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Small</source>
         <translation>小</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="968"/>
+        <location filename="../mainwindow.cpp" line="969"/>
         <source>Use small toolbar icons</source>
         <translation>使用小的工具欄圖標</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Normal</source>
         <translatorcomment>MainWindow</translatorcomment>
         <translation>普通</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="969"/>
+        <location filename="../mainwindow.cpp" line="970"/>
         <source>Use normal size toolbar icons</source>
         <translation>使用普通大小的工具欄圖標</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Big</source>
         <translation>大</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="970"/>
+        <location filename="../mainwindow.cpp" line="971"/>
         <source>Use big toolbar icons</source>
         <translation>使用大工具欄圖標</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Huge</source>
         <translation>超大</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="971"/>
+        <location filename="../mainwindow.cpp" line="972"/>
         <source>Use huge toolbar icons</source>
         <translation>使用特大的工具欄圖標</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>System language</source>
         <translation>使用系統語言</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>Cannot add profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1263"/>
+        <location filename="../mainwindow.cpp" line="1265"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1338"/>
+        <location filename="../mainwindow.cpp" line="1340"/>
         <source>Please save or close all modified files before importing settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1341"/>
+        <location filename="../mainwindow.cpp" line="1343"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1349"/>
+        <location filename="../mainwindow.cpp" line="1351"/>
         <source>Confirm Settings Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1354"/>
+        <location filename="../mainwindow.cpp" line="1356"/>
         <source>Select %1:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1359"/>
+        <location filename="../mainwindow.cpp" line="1361"/>
         <source>backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1361"/>
+        <location filename="../mainwindow.cpp" line="1363"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1371"/>
+        <location filename="../mainwindow.cpp" line="1373"/>
         <source>The settings could not be imported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1374"/>
+        <location filename="../mainwindow.cpp" line="1376"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1381"/>
+        <location filename="../mainwindow.cpp" line="1383"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="822"/>
+        <location filename="../mainwindow.cpp" line="823"/>
         <source>Show the application&apos;s About box</source>
         <translation>顯示軟體的關於對話框</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>View Log File...</source>
         <translation>查看 Log 文件...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="826"/>
+        <location filename="../mainwindow.cpp" line="827"/>
         <source>Open and view log file</source>
         <translation>打開和查看 Log 文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Settings...</source>
         <translation>設置...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="827"/>
+        <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Settings</source>
         <translation>編輯設定</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare Models...</source>
         <translation>比較模型...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="831"/>
+        <location filename="../mainwindow.cpp" line="832"/>
         <source>Compare models</source>
         <translation>比較模型參數</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit Radio Splash Image...</source>
         <translation>編輯遙控器開機畫面...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="832"/>
+        <location filename="../mainwindow.cpp" line="833"/>
         <source>Edit the splash image of your Radio</source>
         <translation>編輯你的遙控器的開機畫面</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="833"/>
+        <location filename="../mainwindow.cpp" line="834"/>
         <source>Read firmware from Radio</source>
         <translation>從遙控器中讀取韌體</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="834"/>
+        <location filename="../mainwindow.cpp" line="835"/>
         <source>Write firmware to Radio</source>
         <translation>將韌體寫入遙控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="844"/>
+        <location filename="../mainwindow.cpp" line="845"/>
         <source>Add Radio Profile</source>
         <translation>添加遙控器檔案</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="838"/>
+        <location filename="../mainwindow.cpp" line="839"/>
         <source>Write Models and Settings To Radio</source>
         <translation>將模型和配置寫入遙控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="839"/>
+        <location filename="../mainwindow.cpp" line="840"/>
         <source>Read Models and Settings From Radio</source>
         <translation>從遙控器中讀取模型和配置</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure Communications...</source>
         <translation>配置通訊...</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="840"/>
+        <location filename="../mainwindow.cpp" line="841"/>
         <source>Configure software for communicating with the Radio</source>
         <translation>配置與遙控器通訊的軟件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup to Radio</source>
         <translation>將備份寫入遙控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="841"/>
+        <location filename="../mainwindow.cpp" line="842"/>
         <source>Write Backup from file to Radio</source>
         <translation>將備份文件寫入到遙控器</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Backup Radio to File</source>
         <translation>備份遙控器到文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="842"/>
+        <location filename="../mainwindow.cpp" line="843"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
         <translation>保存一個包含所有遙控器設置和模型數據的備份文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="835"/>
+        <location filename="../mainwindow.cpp" line="836"/>
         <source>SD card synchronization</source>
         <translation>同步SD卡</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1095"/>
+        <location filename="../mainwindow.cpp" line="1096"/>
         <source>Use default system language.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1099"/>
+        <location filename="../mainwindow.cpp" line="1100"/>
         <source>Use %1 language (some translations may not be complete).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="824"/>
+        <location filename="../mainwindow.cpp" line="825"/>
         <source>Recent Files</source>
         <translation>最近使用的文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1091"/>
+        <location filename="../mainwindow.cpp" line="1092"/>
         <source>Set Menu Language</source>
         <translation>設置菜單語言</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="859"/>
+        <location filename="../mainwindow.cpp" line="860"/>
         <source>Set Icon Theme</source>
         <translation>設置程序圖標</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="860"/>
+        <location filename="../mainwindow.cpp" line="861"/>
         <source>Set Icon Size</source>
         <translation>設置圖標大小</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="857"/>
-        <location filename="../mainwindow.cpp" line="865"/>
+        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="866"/>
         <source>File</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="248"/>
-        <location filename="../mainwindow.cpp" line="255"/>
+        <location filename="../mainwindow.cpp" line="249"/>
+        <location filename="../mainwindow.cpp" line="256"/>
         <source>Checking for updates...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="856"/>
-        <location filename="../mainwindow.cpp" line="866"/>
+        <location filename="../mainwindow.cpp" line="857"/>
+        <location filename="../mainwindow.cpp" line="867"/>
         <source>Edit</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="858"/>
+        <location filename="../mainwindow.cpp" line="859"/>
         <source>Settings</source>
         <translation>設置</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="861"/>
+        <location filename="../mainwindow.cpp" line="862"/>
         <source>Read/Write</source>
         <translation>讀/寫</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="863"/>
-        <location filename="../mainwindow.cpp" line="868"/>
+        <location filename="../mainwindow.cpp" line="864"/>
+        <location filename="../mainwindow.cpp" line="869"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="867"/>
+        <location filename="../mainwindow.cpp" line="868"/>
         <source>Write</source>
         <translation>寫入</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1111"/>
+        <location filename="../mainwindow.cpp" line="1112"/>
         <source>Ready</source>
         <translation>已準備好</translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1164"/>
+        <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mainwindow.cpp" line="1192"/>
+        <location filename="../mainwindow.cpp" line="1193"/>
         <source>Alt+%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8214,63 +8200,63 @@ Do you wish to continue?</source>
 <context>
     <name>MdiChild</name>
     <message>
-        <location filename="../mdichild.cpp" line="383"/>
-        <location filename="../mdichild.cpp" line="386"/>
+        <location filename="../mdichild.cpp" line="384"/>
+        <location filename="../mdichild.cpp" line="387"/>
         <source>Delete</source>
         <translation type="unfinished">刪除</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="234"/>
+        <location filename="../mdichild.cpp" line="235"/>
         <source>Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1021"/>
+        <location filename="../mdichild.cpp" line="1022"/>
         <source>Do you want to overwrite radio general settings?</source>
         <translation type="unfinished">你希望覆蓋遙控器一般設定嗎？</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="214"/>
+        <location filename="../mdichild.cpp" line="215"/>
         <source>Alt+Shift+E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="215"/>
+        <location filename="../mdichild.cpp" line="216"/>
         <source>Ctrl+Alt+C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="216"/>
+        <location filename="../mdichild.cpp" line="217"/>
         <source>Ctrl+Alt+V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="217"/>
+        <location filename="../mdichild.cpp" line="218"/>
         <source>Alt+Shift+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="222"/>
+        <location filename="../mdichild.cpp" line="223"/>
         <source>Alt+A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="223"/>
+        <location filename="../mdichild.cpp" line="224"/>
         <source>Alt+R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="224"/>
+        <location filename="../mdichild.cpp" line="225"/>
         <source>Alt+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="232"/>
+        <location filename="../mdichild.cpp" line="233"/>
         <source>Alt+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="337"/>
+        <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation type="unfinished">
@@ -8278,7 +8264,7 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="338"/>
+        <location filename="../mdichild.cpp" line="339"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation type="unfinished">
@@ -8286,384 +8272,384 @@ Do you wish to continue?</source>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="339"/>
+        <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="382"/>
+        <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="356"/>
+        <location filename="../mdichild.cpp" line="357"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="358"/>
+        <location filename="../mdichild.cpp" line="359"/>
         <source>Copy</source>
         <translation type="unfinished">複製</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="360"/>
+        <location filename="../mdichild.cpp" line="361"/>
         <source>Paste</source>
         <translation type="unfinished">貼上</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="362"/>
-        <location filename="../mdichild.cpp" line="960"/>
+        <location filename="../mdichild.cpp" line="363"/>
+        <location filename="../mdichild.cpp" line="961"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="376"/>
+        <location filename="../mdichild.cpp" line="377"/>
         <source>Edit Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="377"/>
+        <location filename="../mdichild.cpp" line="378"/>
         <source>Copy Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="378"/>
+        <location filename="../mdichild.cpp" line="379"/>
         <source>Paste Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="379"/>
+        <location filename="../mdichild.cpp" line="380"/>
         <source>Simulate Radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="391"/>
+        <location filename="../mdichild.cpp" line="392"/>
         <source>Add Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="392"/>
+        <location filename="../mdichild.cpp" line="393"/>
         <source>Model</source>
         <translation type="unfinished">模型名稱  [Model Name]</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="395"/>
+        <location filename="../mdichild.cpp" line="396"/>
         <source>Restore from Backup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="396"/>
+        <location filename="../mdichild.cpp" line="397"/>
         <source>Model Wizard</source>
         <translation type="unfinished">模型嚮導</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="397"/>
+        <location filename="../mdichild.cpp" line="398"/>
         <source>Set as Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="398"/>
+        <location filename="../mdichild.cpp" line="399"/>
         <source>Print Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="399"/>
+        <location filename="../mdichild.cpp" line="400"/>
         <source>Simulate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="400"/>
+        <location filename="../mdichild.cpp" line="401"/>
         <source>Duplicate Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="402"/>
+        <location filename="../mdichild.cpp" line="403"/>
         <source>Show Radio Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="403"/>
+        <location filename="../mdichild.cpp" line="404"/>
         <source>Show Model Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="776"/>
+        <location filename="../mdichild.cpp" line="777"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="818"/>
+        <location filename="../mdichild.cpp" line="819"/>
         <source>Cannot add model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="938"/>
+        <location filename="../mdichild.cpp" line="939"/>
         <source>Cannot paste model, out of available model slots.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../mdichild.cpp" line="1124"/>
+        <location filename="../mdichild.cpp" line="1125"/>
         <source>Delete %n selected model(s)?</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1155"/>
+        <location filename="../mdichild.cpp" line="1156"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1202"/>
+        <location filename="../mdichild.cpp" line="1203"/>
         <source>Editing model %1: </source>
         <translation>編輯模型 %1:</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1324"/>
-        <location filename="../mdichild.cpp" line="1806"/>
+        <location filename="../mdichild.cpp" line="1326"/>
+        <location filename="../mdichild.cpp" line="1809"/>
         <source>Invalid file extension!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1422"/>
+        <location filename="../mdichild.cpp" line="1425"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1492"/>
+        <location filename="../mdichild.cpp" line="1495"/>
         <source>Do not show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1513"/>
+        <location filename="../mdichild.cpp" line="1516"/>
         <source>Models and settings written to radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1518"/>
+        <location filename="../mdichild.cpp" line="1521"/>
         <source>Error writing models and settings to radio!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1541"/>
+        <location filename="../mdichild.cpp" line="1544"/>
         <source>Unable to find file %1!</source>
         <translation>無法找到文件 %1!</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1550"/>
+        <location filename="../mdichild.cpp" line="1553"/>
         <source>Error opening file %1:
 %2.</source>
         <translation>打開文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1561"/>
+        <location filename="../mdichild.cpp" line="1564"/>
         <source>Error reading file %1:
 %2.</source>
         <translation>打開文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1320"/>
+        <location filename="../mdichild.cpp" line="1322"/>
         <source>Save As</source>
         <translation>另存為</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="226"/>
         <location filename="../mdichild.cpp" line="227"/>
+        <location filename="../mdichild.cpp" line="228"/>
         <source>Alt-L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="228"/>
+        <location filename="../mdichild.cpp" line="229"/>
         <source>Alt-R</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="229"/>
+        <location filename="../mdichild.cpp" line="230"/>
         <source>Alt-+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="230"/>
+        <location filename="../mdichild.cpp" line="231"/>
         <source>Alt--</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="241"/>
+        <location filename="../mdichild.cpp" line="242"/>
         <source>Ctrl+Alt+S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="256"/>
+        <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="364"/>
-        <location filename="../mdichild.cpp" line="394"/>
+        <location filename="../mdichild.cpp" line="365"/>
+        <location filename="../mdichild.cpp" line="395"/>
         <source>Export</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="380"/>
+        <location filename="../mdichild.cpp" line="381"/>
         <source>Radio Models Order</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="385"/>
+        <location filename="../mdichild.cpp" line="386"/>
         <source>Add</source>
         <translation type="unfinished">加</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="387"/>
+        <location filename="../mdichild.cpp" line="388"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="388"/>
+        <location filename="../mdichild.cpp" line="389"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="389"/>
+        <location filename="../mdichild.cpp" line="390"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="393"/>
+        <location filename="../mdichild.cpp" line="394"/>
         <source>Export Model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="404"/>
+        <location filename="../mdichild.cpp" line="405"/>
         <source>Show Labels Actions Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="708"/>
+        <location filename="../mdichild.cpp" line="709"/>
         <source>read only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="958"/>
+        <location filename="../mdichild.cpp" line="959"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="959"/>
+        <location filename="../mdichild.cpp" line="960"/>
         <source>Overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1030"/>
+        <location filename="../mdichild.cpp" line="1031"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1254"/>
+        <location filename="../mdichild.cpp" line="1256"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1368"/>
+        <location filename="../mdichild.cpp" line="1370"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
         <translation>%1已經修改.
 想要保存修改嗎?</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1424"/>
+        <location filename="../mdichild.cpp" line="1427"/>
         <source>Do you wish to continue with the conversion?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1429"/>
+        <location filename="../mdichild.cpp" line="1432"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1456"/>
+        <location filename="../mdichild.cpp" line="1459"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1463"/>
+        <location filename="../mdichild.cpp" line="1466"/>
         <source>Companion :: Conversion Result for %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1486"/>
+        <location filename="../mdichild.cpp" line="1489"/>
         <source>You are about to overwrite ALL models on the Radio.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1487"/>
+        <location filename="../mdichild.cpp" line="1490"/>
         <source>Do you want to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1507"/>
+        <location filename="../mdichild.cpp" line="1510"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1525"/>
+        <location filename="../mdichild.cpp" line="1528"/>
         <source>Cannot write temporary file!</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1535"/>
+        <location filename="../mdichild.cpp" line="1538"/>
         <source>Open backup Models and Settings file</source>
         <translation>打開備份的模型和設置文件</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1571"/>
+        <location filename="../mdichild.cpp" line="1574"/>
         <source>Invalid binary backup File %1</source>
         <translation>無效的二進製備份文件 %1</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1637"/>
+        <location filename="../mdichild.cpp" line="1640"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1649"/>
+        <location filename="../mdichild.cpp" line="1652"/>
         <source>Select a model template file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1691"/>
+        <location filename="../mdichild.cpp" line="1694"/>
         <source>Add a new model using</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1692"/>
+        <location filename="../mdichild.cpp" line="1695"/>
         <source>Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1693"/>
+        <location filename="../mdichild.cpp" line="1696"/>
         <source>Edit</source>
         <translation type="unfinished">編輯</translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1694"/>
+        <location filename="../mdichild.cpp" line="1697"/>
         <source>Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1695"/>
+        <location filename="../mdichild.cpp" line="1698"/>
         <source>Template</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1702"/>
+        <location filename="../mdichild.cpp" line="1705"/>
         <source>Failed to remove temporary model!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../mdichild.cpp" line="1800"/>
+        <location filename="../mdichild.cpp" line="1803"/>
         <source>Export model</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8671,143 +8657,148 @@ Do you want to save your changes?</source>
 <context>
     <name>MinizInterface</name>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="39"/>
+        <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="50"/>
+        <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="54"/>
-        <location filename="../storage/minizinterface.cpp" line="179"/>
+        <location filename="../storage/minizinterface.cpp" line="57"/>
+        <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="64"/>
+        <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="68"/>
+        <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="72"/>
+        <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="75"/>
+        <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="79"/>
+        <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="83"/>
+        <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="87"/>
+        <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="96"/>
+        <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="137"/>
+        <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="146"/>
+        <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="155"/>
+        <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="167"/>
+        <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="175"/>
+        <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="187"/>
+        <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="195"/>
+        <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="210"/>
+        <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="217"/>
+        <location filename="../storage/minizinterface.cpp" line="222"/>
+        <source>Decompression interrupted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="238"/>
+        <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="243"/>
+        <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="256"/>
+        <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="265"/>
+        <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="274"/>
+        <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/minizinterface.cpp" line="278"/>
+        <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8815,12 +8806,12 @@ Do you want to save your changes?</source>
 <context>
     <name>MixData</name>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="26"/>
+        <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/mixdata.cpp" line="27"/>
+        <location filename="../firmwares/mixdata.cpp" line="28"/>
         <source> (@%1)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8833,50 +8824,67 @@ Do you want to save your changes?</source>
         <translation>對話框</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="474"/>
+        <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="483"/>
-        <source>Slow up/dn prec</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="491"/>
+        <location filename="../modeledit/mixerdialog.ui" line="662"/>
+        <location filename="../modeledit/mixerdialog.ui" line="676"/>
         <source>0.0</source>
         <translation type="unfinished">0.0</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="496"/>
+        <location filename="../modeledit/mixerdialog.ui" line="667"/>
+        <location filename="../modeledit/mixerdialog.ui" line="681"/>
         <source>0.00</source>
         <translation type="unfinished">0.00</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="524"/>
+        <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
         <translation>延遲 [Delay]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="531"/>
+        <location filename="../modeledit/mixerdialog.ui" line="278"/>
+        <source>Modes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="296"/>
+        <source>2 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="301"/>
+        <source>3 Beeps</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
         <translation>慢動作  [Slow]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="538"/>
+        <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
         <translation>正向  [Up]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="548"/>
+        <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
         <translation>負向  [Dn]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="558"/>
-        <location filename="../modeledit/mixerdialog.ui" line="587"/>
-        <location filename="../modeledit/mixerdialog.ui" line="616"/>
-        <location filename="../modeledit/mixerdialog.ui" line="639"/>
+        <location filename="../modeledit/mixerdialog.ui" line="651"/>
+        <source>Precision</source>
+        <translation type="unfinished">精確度</translation>
+    </message>
+    <message>
+        <location filename="../modeledit/mixerdialog.ui" line="506"/>
+        <location filename="../modeledit/mixerdialog.ui" line="570"/>
+        <location filename="../modeledit/mixerdialog.ui" line="599"/>
+        <location filename="../modeledit/mixerdialog.ui" line="622"/>
         <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
@@ -8901,186 +8909,132 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;如果慢动作值不为0, 混控的输出将按照指定的速度慢动作 -&amp;gt; 所设定数值为舵机从 -100% 运动到 +100%所需要时间.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="429"/>
+        <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
         <translation>微調       [Trim]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="422"/>
+        <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
         <translation>偏移       [Offset]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="415"/>
+        <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
         <translation>比例       [Weight]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="251"/>
+        <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
         <translation>名稱       [Name]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="244"/>
+        <location filename="../modeledit/mixerdialog.ui" line="37"/>
+        <location filename="../modeledit/mixerdialog.ui" line="84"/>
+        <location filename="../modeledit/mixerdialog.ui" line="163"/>
+        <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
         <translatorcomment>第一次出現 Mixer的主頁條目概覽中</translatorcomment>
         <translation>輸入源     [Source]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="237"/>
+        <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
         <translation>混控方式   [Multiplex]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="223"/>
+        <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
         <translation>啟用時蜂鳴 [Warning]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="230"/>
+        <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
         <translation>此混控使用的曲線</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="216"/>
+        <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
         <translation>使用 DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="209"/>
-        <source>Flight modes</source>
-        <translation>飛行模式   [Modes]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="202"/>
+        <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
         <translation>開啟開關   [Switch]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="167"/>
-        <source>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</source>
-        <translation>混控警告
-當本條混控啟用時發出蜂鳴.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="172"/>
+        <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
         <translatorcomment>1聲蜂鳴  [1]</translatorcomment>
         <translation>關閉     [OFF]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="177"/>
+        <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
         <translation>1聲蜂鳴  [1]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="182"/>
-        <source>2 Beep</source>
-        <translation>2聲蜂鳴  [2]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="187"/>
-        <source>3 Beep</source>
-        <translation>3聲蜂鳴  [3]</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="154"/>
+        <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
         <translatorcomment>禁用微調 用在FM設定中</translatorcomment>
         <translation>不使用 [OFF]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="159"/>
+        <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
         <translatorcomment>不使用 [OFF]</translatorcomment>
         <translation>使用    [On]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="59"/>
-        <location filename="../modeledit/mixerdialog.ui" line="121"/>
-        <location filename="../modeledit/mixerdialog.ui" line="445"/>
-        <source>GV</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="43"/>
-        <location filename="../modeledit/mixerdialog.ui" line="66"/>
-        <location filename="../modeledit/mixerdialog.ui" line="128"/>
-        <location filename="../modeledit/mixerdialog.ui" line="452"/>
+        <location filename="../modeledit/mixerdialog.ui" line="44"/>
+        <location filename="../modeledit/mixerdialog.ui" line="91"/>
+        <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
         <translation>混控的輸入源</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="91"/>
-        <source>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</source>
-        <translation>混控方式 
-
-規定了混控值如何混合
-
-&quot;+&quot;表示本混控值將會與此通道中的上條2混控 值相加.
-
-&quot;*&quot;表示本混控值將會與此通道中的上條混控值相乘.
- 
-&quot;R&quot;表示本混控值將會取代此通道中的上條混控
-如果開關關閉此條混控將會被忽略.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.ui" line="101"/>
+        <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
         <translation>與前一行的輸出值相加後輸出       [Add]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="106"/>
+        <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
         <translation>與前一行的輸出值相乘後輸出       [Multiply]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="111"/>
+        <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
         <translatorcomment>與前一行的輸出值相乘後輸出       [Multiply]</translatorcomment>
         <translation>取代前一行的輸出值               [Replace]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="50"/>
+        <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
         <translation>曲線       [Curve]</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.ui" line="35"/>
-        <source>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
-        <translation>用來開啟此條混控的開關
-如果不設定開啟開關則默認此條混控一直​​啟用.</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="51"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="114"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="262"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="263"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerdialog.cpp" line="264"/>
+        <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9088,22 +9042,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixersListWidget</name>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="66"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="70"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="74"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
+        <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
         <source>Ctrl+0</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9111,136 +9065,136 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MixesPanel</name>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="44"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="45"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
         <translation>向上移動此行</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="46"/>
-        <location filename="../modeledit/mixes.cpp" line="440"/>
+        <location filename="../modeledit/mixes.cpp" line="47"/>
+        <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Ctrl+Up</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="47"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="48"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
         <translation>向下移動此行</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="49"/>
-        <location filename="../modeledit/mixes.cpp" line="441"/>
+        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Ctrl+Down</source>
         <translation>Ctrl+Dn</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="50"/>
+        <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
         <translation>清除本頁所有混控</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="159"/>
+        <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
         <translation>無空白混控存儲位置!</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="274"/>
+        <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="286"/>
+        <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
         <translation>添加  (&amp;A)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="430"/>
+        <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>Ctrl+A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
         <translation>編輯  (&amp;E)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="431"/>
+        <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
         <translation>切換高亮  (&amp;T)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="432"/>
+        <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>Ctrl+T</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
         <translation>删除  (&amp;D)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="434"/>
+        <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
         <translation>複製 (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="435"/>
+        <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>Ctrl+C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
         <translation>剪下  (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="436"/>
+        <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>Ctrl+X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
         <translation>貼上  (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="437"/>
+        <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>Ctrl+V</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
         <translation>克隆  (&amp;P)</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="438"/>
+        <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Ctrl+U</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
         <translation>清除混控?</translation>
     </message>
     <message>
-        <location filename="../modeledit/mixes.cpp" line="546"/>
+        <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
         <translation>是否真的刪除所有混控?</translation>
     </message>
@@ -9248,19 +9202,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelData</name>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="444"/>
+        <location filename="../firmwares/modeldata.cpp" line="445"/>
         <source>Model: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="448"/>
+        <location filename="../firmwares/modeldata.cpp" line="449"/>
         <source>Throttle Source</source>
         <translation type="unfinished">設為油門桿   [Thr Source]</translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1507"/>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
         <source>THR</source>
         <translation type="unfinished">油門</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1504"/>
+        <source>TH</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1620"/>
@@ -9308,32 +9267,49 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1724"/>
+        <location filename="../firmwares/modeldata.cpp" line="1723"/>
         <source>NONE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1726"/>
+        <location filename="../firmwares/modeldata.cpp" line="1725"/>
         <source>TOGGLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1728"/>
+        <location filename="../firmwares/modeldata.cpp" line="1727"/>
         <source>2POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1801"/>
-        <source>Inactive</source>
+        <location filename="../firmwares/modeldata.cpp" line="1752"/>
+        <source>SW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1803"/>
-        <source>Active</source>
+        <location filename="../firmwares/modeldata.cpp" line="1754"/>
+        <location filename="../firmwares/modeldata.cpp" line="1890"/>
+        <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/modeldata.cpp" line="1805"/>
+        <location filename="../firmwares/modeldata.cpp" line="1765"/>
+        <source>---</source>
+        <translation type="unfinished">正向  [→]</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1767"/>
+        <source>Group </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1892"/>
+        <source>On</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/modeldata.cpp" line="1750"/>
+        <location filename="../firmwares/modeldata.cpp" line="1894"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9351,65 +9327,60 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>遙控器模擬器</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="75"/>
+        <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
         <translation>設置 Setup</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="79"/>
+        <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
         <translation>直升機 Heli</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="83"/>
-        <source>Flight Modes</source>
-        <translation>飛行模式 FM</translation>
-    </message>
-    <message>
-        <location filename="../modeledit/modeledit.cpp" line="86"/>
+        <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
         <translation>輸入 Inputs</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="89"/>
+        <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
         <translatorcomment>!!!! mixes--&gt;mixer</translatorcomment>
         <translation>混控 Mixer</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="93"/>
+        <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
         <translation>輸出 Outputs</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="96"/>
+        <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
         <translatorcomment>ModelEdit</translatorcomment>
         <translation>曲線 Curves</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="99"/>
+        <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
         <translation>邏輯開關 Logical Sw</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="102"/>
+        <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
         <translation>特殊功能 Special Func</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="106"/>
+        <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
         <translation>回傳設置 Tele</translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="111"/>
-        <location filename="../modeledit/modeledit.cpp" line="115"/>
+        <location filename="../modeledit/modeledit.cpp" line="114"/>
+        <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/modeledit.cpp" line="119"/>
+        <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9463,8 +9434,8 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
-        <source>Flight Modes</source>
-        <translation type="unfinished">飛行模式 FM</translation>
+        <source>%1 Modes</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
@@ -9500,590 +9471,600 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelPrinter</name>
     <message>
-        <location filename="../modelprinter.cpp" line="174"/>
+        <location filename="../modelprinter.cpp" line="176"/>
         <source>Exponential</source>
         <translatorcomment>指微調的步長</translatorcomment>
         <translation>先小後大  [Exp]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="176"/>
+        <location filename="../modelprinter.cpp" line="178"/>
         <source>Extra Fine</source>
         <translation>很小  [Extra Fine]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="178"/>
+        <location filename="../modelprinter.cpp" line="180"/>
         <source>Fine</source>
         <translation>小  [Fine]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="180"/>
+        <location filename="../modelprinter.cpp" line="182"/>
         <source>Medium</source>
         <translation>中等  [Medium]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="182"/>
+        <location filename="../modelprinter.cpp" line="184"/>
         <source>Coarse</source>
         <translation>大  [Coarse]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="184"/>
+        <location filename="../modelprinter.cpp" line="186"/>
         <source>Unknown</source>
         <translatorcomment>Model Printer</translatorcomment>
         <translation>未知[Unknown]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
         <translation type="unfinished">使用遊戲桿</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="141"/>
+        <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="143"/>
+        <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="145"/>
+        <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="147"/>
+        <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
+        <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
         <translation type="unfinished">啟用</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="149"/>
-        <location filename="../modelprinter.cpp" line="289"/>
-        <location filename="../modelprinter.cpp" line="802"/>
+        <location filename="../modelprinter.cpp" line="151"/>
+        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="808"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="157"/>
+        <location filename="../modelprinter.cpp" line="159"/>
         <source>bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="194"/>
-        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="196"/>
+        <location filename="../modelprinter.cpp" line="788"/>
         <source>Mode</source>
         <translation type="unfinished">模式</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="197"/>
-        <location filename="../modelprinter.cpp" line="210"/>
+        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="212"/>
         <source>Channels</source>
         <translation type="unfinished">通道數  [Channels]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="198"/>
-        <location filename="../modelprinter.cpp" line="212"/>
+        <location filename="../modelprinter.cpp" line="200"/>
+        <location filename="../modelprinter.cpp" line="214"/>
         <source>Frame length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="199"/>
+        <location filename="../modelprinter.cpp" line="201"/>
         <source>PPM delay</source>
         <translation type="unfinished">PPM 延遲  [Delay]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="200"/>
-        <location filename="../modelprinter.cpp" line="213"/>
+        <location filename="../modelprinter.cpp" line="202"/>
+        <location filename="../modelprinter.cpp" line="215"/>
         <source>Polarity</source>
         <translation type="unfinished">極性  [Polarity]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="206"/>
+        <location filename="../modelprinter.cpp" line="208"/>
         <source>Protocol</source>
         <translation type="unfinished">遙控器發射協議    [Protocol]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="215"/>
-        <location filename="../modelprinter.cpp" line="638"/>
+        <location filename="../modelprinter.cpp" line="217"/>
+        <location filename="../modelprinter.cpp" line="644"/>
         <source>Delay</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="220"/>
-        <location filename="../modelprinter.cpp" line="849"/>
+        <location filename="../modelprinter.cpp" line="222"/>
+        <location filename="../modelprinter.cpp" line="855"/>
         <source>Receiver</source>
         <translation type="unfinished">接收機設置[Reciever]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="223"/>
+        <location filename="../modelprinter.cpp" line="225"/>
         <source>Radio protocol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="224"/>
+        <location filename="../modelprinter.cpp" line="226"/>
         <source>Subtype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="225"/>
+        <location filename="../modelprinter.cpp" line="227"/>
         <source>Option value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="209"/>
-        <location filename="../modelprinter.cpp" line="228"/>
+        <location filename="../modelprinter.cpp" line="211"/>
+        <location filename="../modelprinter.cpp" line="230"/>
         <source>Sub Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="229"/>
+        <location filename="../modelprinter.cpp" line="231"/>
         <source>RF Output Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="238"/>
+        <location filename="../modelprinter.cpp" line="240"/>
         <source>Raw 12 bits</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="254"/>
+        <location filename="../modelprinter.cpp" line="256"/>
         <source>90</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="256"/>
+        <location filename="../modelprinter.cpp" line="258"/>
         <source>120</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="258"/>
+        <location filename="../modelprinter.cpp" line="260"/>
         <source>120X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="260"/>
+        <location filename="../modelprinter.cpp" line="262"/>
         <source>140</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="262"/>
+        <location filename="../modelprinter.cpp" line="264"/>
         <source>Off</source>
         <translatorcomment>Model Printer</translatorcomment>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="281"/>
-        <location filename="../modelprinter.cpp" line="494"/>
-        <location filename="../modelprinter.cpp" line="776"/>
-        <location filename="../modelprinter.cpp" line="1008"/>
-        <location filename="../modelprinter.cpp" line="1038"/>
+        <location filename="../modelprinter.cpp" line="283"/>
+        <location filename="../modelprinter.cpp" line="498"/>
+        <location filename="../modelprinter.cpp" line="782"/>
+        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1048"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="291"/>
+        <location filename="../modelprinter.cpp" line="293"/>
         <source>3POS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="418"/>
-        <source>MULT!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../modelprinter.cpp" line="447"/>
+        <location filename="../modelprinter.cpp" line="451"/>
         <source>Slow precision(0.00)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight modes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="482"/>
+        <location filename="../modelprinter.cpp" line="486"/>
         <source>Flight mode</source>
         <translation type="unfinished">飛行模式  [Modes]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="507"/>
+        <location filename="../modelprinter.cpp" line="511"/>
         <source>All</source>
         <translation type="unfinished">開啟  [All]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="527"/>
+        <location filename="../modelprinter.cpp" line="531"/>
         <source>Edge</source>
         <translation type="unfinished">邊沿觸發                 EDGE</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>infinite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="533"/>
+        <location filename="../modelprinter.cpp" line="537"/>
         <source>Sticky</source>
         <translation type="unfinished">粘滯鍵                   Sticky</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="536"/>
+        <location filename="../modelprinter.cpp" line="539"/>
+        <source> Persistent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="542"/>
         <source>Timer</source>
         <translation type="unfinished">定時開關                 Timer</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="563"/>
+        <location filename="../modelprinter.cpp" line="569"/>
         <source> missing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="636"/>
+        <location filename="../modelprinter.cpp" line="642"/>
         <source>Duration</source>
         <translation type="unfinished">持續時間  [Duration]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="745"/>
+        <location filename="../modelprinter.cpp" line="751"/>
         <source>Extended Limits</source>
         <translation type="unfinished">舵機上下限擴展
 [Extended Limits]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="747"/>
+        <location filename="../modelprinter.cpp" line="753"/>
         <source>Display Checklist</source>
         <translation type="unfinished">顯示檢查單
 [Checklist]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="749"/>
+        <location filename="../modelprinter.cpp" line="755"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="804"/>
+        <location filename="../modelprinter.cpp" line="810"/>
         <source>Manual</source>
         <translation type="unfinished">手動  [Manual]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="806"/>
+        <location filename="../modelprinter.cpp" line="812"/>
         <source>Auto</source>
         <translation type="unfinished">用關機位置  [Auto]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="816"/>
+        <location filename="../modelprinter.cpp" line="822"/>
         <source>Failsafe Mode</source>
         <translation type="unfinished">失控保護方式 [Failsafe Mode]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="829"/>
-        <location filename="../modelprinter.cpp" line="843"/>
+        <location filename="../modelprinter.cpp" line="835"/>
+        <location filename="../modelprinter.cpp" line="849"/>
         <source>Hold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="831"/>
+        <location filename="../modelprinter.cpp" line="837"/>
         <source>No Pulse</source>
         <translation type="unfinished">不輸出脈衝  [No Pulse]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="841"/>
+        <location filename="../modelprinter.cpp" line="847"/>
         <source>Not set</source>
         <translation type="unfinished">未設置</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="847"/>
+        <location filename="../modelprinter.cpp" line="853"/>
         <source>No pulses</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="858"/>
+        <location filename="../modelprinter.cpp" line="864"/>
         <source>Step</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="859"/>
+        <location filename="../modelprinter.cpp" line="865"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="860"/>
+        <location filename="../modelprinter.cpp" line="866"/>
         <source>Extended</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="863"/>
+        <location filename="../modelprinter.cpp" line="869"/>
         <source>Hats Mode</source>
         <translation type="unfinished">按鍵帽模式</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="887"/>
+        <location filename="../modelprinter.cpp" line="893"/>
         <source>Never</source>
         <translation type="unfinished">從不  [Never]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="889"/>
+        <location filename="../modelprinter.cpp" line="895"/>
         <source>On Change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="891"/>
+        <location filename="../modelprinter.cpp" line="897"/>
         <source>Always</source>
         <translation type="unfinished">一直  [Always]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="901"/>
+        <location filename="../modelprinter.cpp" line="907"/>
         <source>Trims only</source>
         <translation type="unfinished">微調</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="903"/>
+        <location filename="../modelprinter.cpp" line="909"/>
         <source>Keys only</source>
         <translation type="unfinished">導航鍵</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="905"/>
+        <location filename="../modelprinter.cpp" line="911"/>
         <source>Switchable</source>
         <translation type="unfinished">可切換</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="907"/>
+        <location filename="../modelprinter.cpp" line="913"/>
         <source>Global</source>
         <translation type="unfinished">全局</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="929"/>
-        <location filename="../modelprinter.cpp" line="1060"/>
+        <location filename="../modelprinter.cpp" line="935"/>
         <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="930"/>
+        <location filename="../modelprinter.cpp" line="936"/>
         <source>Trim idle only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="931"/>
+        <location filename="../modelprinter.cpp" line="937"/>
         <source>Warning</source>
         <translation type="unfinished">啟用時蜂鳴 [Warning]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="932"/>
+        <location filename="../modelprinter.cpp" line="938"/>
         <source>Reversed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="946"/>
+        <location filename="../modelprinter.cpp" line="942"/>
+        <source>Trim source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="956"/>
         <source>FrSky S.PORT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="948"/>
+        <location filename="../modelprinter.cpp" line="958"/>
         <source>FrSky D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="950"/>
+        <location filename="../modelprinter.cpp" line="960"/>
         <source>FrSky D (cable)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="965"/>
+        <location filename="../modelprinter.cpp" line="975"/>
         <source>Alti</source>
         <translation type="unfinished">高度</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="967"/>
+        <location filename="../modelprinter.cpp" line="977"/>
         <source>Alti+</source>
         <translation type="unfinished">最大高度</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="969"/>
+        <location filename="../modelprinter.cpp" line="979"/>
         <source>VSpeed</source>
         <translation type="unfinished">垂直速度</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="971"/>
-        <location filename="../modelprinter.cpp" line="988"/>
-        <location filename="../modelprinter.cpp" line="1010"/>
+        <location filename="../modelprinter.cpp" line="981"/>
+        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1020"/>
         <source>A1</source>
         <translation type="unfinished">A1  模擬值1</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="973"/>
-        <location filename="../modelprinter.cpp" line="990"/>
-        <location filename="../modelprinter.cpp" line="1012"/>
+        <location filename="../modelprinter.cpp" line="983"/>
+        <location filename="../modelprinter.cpp" line="1000"/>
+        <location filename="../modelprinter.cpp" line="1022"/>
         <source>A2</source>
         <translation type="unfinished">A2  模擬值2</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="992"/>
-        <location filename="../modelprinter.cpp" line="1014"/>
+        <location filename="../modelprinter.cpp" line="1002"/>
+        <location filename="../modelprinter.cpp" line="1024"/>
         <source>A3</source>
         <translation type="unfinished">A3  模擬值3</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="994"/>
-        <location filename="../modelprinter.cpp" line="1016"/>
+        <location filename="../modelprinter.cpp" line="1004"/>
+        <location filename="../modelprinter.cpp" line="1026"/>
         <source>A4</source>
         <translation type="unfinished">A4  模擬值4</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="996"/>
-        <location filename="../modelprinter.cpp" line="1018"/>
+        <location filename="../modelprinter.cpp" line="1006"/>
+        <location filename="../modelprinter.cpp" line="1028"/>
         <source>FAS</source>
         <translation type="unfinished">FAS</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="998"/>
+        <location filename="../modelprinter.cpp" line="1008"/>
         <source>Cells</source>
         <translation type="unfinished">鋰電總電壓</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1070"/>
+        <location filename="../modelprinter.cpp" line="1080"/>
         <source>Max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1040"/>
+        <location filename="../modelprinter.cpp" line="1050"/>
         <source>Numbers</source>
         <translation type="unfinished">數字</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1042"/>
+        <location filename="../modelprinter.cpp" line="1052"/>
         <source>Bars</source>
         <translation type="unfinished">條狀圖</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1044"/>
+        <location filename="../modelprinter.cpp" line="1054"/>
         <source>Script</source>
         <translation type="unfinished">腳本</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1091"/>
+        <location filename="../modelprinter.cpp" line="1101"/>
         <source>Filename</source>
         <translation type="unfinished">文件名</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="1101"/>
+        <location filename="../modelprinter.cpp" line="1111"/>
         <source>Error: Unable to open or read file!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="299"/>
-        <location filename="../modelprinter.cpp" line="321"/>
-        <location filename="../modelprinter.cpp" line="335"/>
+        <location filename="../modelprinter.cpp" line="301"/>
+        <location filename="../modelprinter.cpp" line="323"/>
+        <location filename="../modelprinter.cpp" line="337"/>
         <source>FM%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="303"/>
+        <location filename="../modelprinter.cpp" line="305"/>
         <source>FM%1%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="305"/>
+        <location filename="../modelprinter.cpp" line="307"/>
         <source>FM%1+%2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="430"/>
+        <location filename="../modelprinter.cpp" line="429"/>
         <source>NoTrim</source>
         <translation>不使用微調[Notrim]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="389"/>
-        <location filename="../modelprinter.cpp" line="437"/>
+        <location filename="../modelprinter.cpp" line="391"/>
+        <location filename="../modelprinter.cpp" line="436"/>
         <source>Offset(%1)</source>
         <translation>偏移[Offse](%1)</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="232"/>
+        <location filename="../modelprinter.cpp" line="234"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="235"/>
+        <location filename="../modelprinter.cpp" line="237"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="366"/>
+        <location filename="../modelprinter.cpp" line="368"/>
         <source>Scale(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="369"/>
-        <location filename="../modelprinter.cpp" line="420"/>
+        <location filename="../modelprinter.cpp" line="371"/>
+        <location filename="../modelprinter.cpp" line="419"/>
         <source>Weight(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="378"/>
-        <location filename="../modelprinter.cpp" line="427"/>
+        <location filename="../modelprinter.cpp" line="380"/>
+        <location filename="../modelprinter.cpp" line="426"/>
         <source>Switch(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="383"/>
+        <location filename="../modelprinter.cpp" line="385"/>
         <source>No Trim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="435"/>
+        <location filename="../modelprinter.cpp" line="434"/>
         <source>No DR/Expo</source>
         <translation>不使用 DR/Expo</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="444"/>
+        <location filename="../modelprinter.cpp" line="443"/>
+        <source>Delay precision(0.00)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../modelprinter.cpp" line="446"/>
         <source>Delay(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="450"/>
+        <location filename="../modelprinter.cpp" line="454"/>
         <source>Slow(u%1:d%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="452"/>
+        <location filename="../modelprinter.cpp" line="456"/>
         <source>Warn(%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="473"/>
+        <location filename="../modelprinter.cpp" line="477"/>
         <source>Disabled in all flight modes</source>
         <translation>在所有飛行模式中禁用</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="528"/>
+        <location filename="../modelprinter.cpp" line="532"/>
         <source>instant</source>
         <translation>立刻執行[instant]</translation>
     </message>
     <message>
-        <location filename="../modelprinter.cpp" line="845"/>
+        <location filename="../modelprinter.cpp" line="851"/>
         <source>Custom</source>
         <translation>自定義[Custom]</translation>
     </message>
@@ -10091,27 +10072,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="283"/>
+        <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
         <translation>固定翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="285"/>
+        <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
         <translation>多軸</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="286"/>
+        <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
         <translation>直升機</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="291"/>
+        <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
         <translation>模型名稱:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="294"/>
+        <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
         <translation>模型種類:</translation>
     </message>
@@ -10119,27 +10100,27 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModelsListModel</name>
     <message>
-        <location filename="../modelslist.cpp" line="137"/>
+        <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
         <translation type="unfinished">模型編號        </translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="138"/>
+        <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="139"/>
+        <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="141"/>
+        <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modelslist.cpp" line="634"/>
+        <location filename="../modelslist.cpp" line="666"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
         <translation type="unfinished"></translation>
@@ -10399,285 +10380,290 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModuleData</name>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.h" line="209"/>
+        <location filename="../firmwares/moduledata.h" line="210"/>
         <source>Negative</source>
         <translation type="unfinished">负  [Negative]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="255"/>
+        <location filename="../firmwares/moduledata.cpp" line="59"/>
+        <source>Current firmware board does not match conversion to board</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/moduledata.cpp" line="260"/>
         <source>No Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="256"/>
+        <location filename="../firmwares/moduledata.cpp" line="261"/>
         <source>MLink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="284"/>
+        <location filename="../firmwares/moduledata.cpp" line="289"/>
         <source>Trainer Port</source>
         <translation type="unfinished">教練功能  [Trainer Port]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>Internal Radio System</source>
         <translation type="unfinished">內置高頻頭  [Internal RF]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="288"/>
+        <location filename="../firmwares/moduledata.cpp" line="293"/>
         <source>External Radio Module</source>
         <translation type="unfinished">外置高頻頭  [External RF]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="290"/>
+        <location filename="../firmwares/moduledata.cpp" line="295"/>
         <source>Extra Radio System</source>
         <translation type="unfinished">附加高頻頭  [Extra RF]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="292"/>
+        <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Radio System</source>
         <translation type="unfinished">高頻頭  [Radio System]</translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="299"/>
+        <location filename="../firmwares/moduledata.cpp" line="304"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="300"/>
+        <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="301"/>
+        <location filename="../firmwares/moduledata.cpp" line="306"/>
         <source>Silverlit C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="302"/>
+        <location filename="../firmwares/moduledata.cpp" line="307"/>
         <source>CTP1009</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>LP45</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSM2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="303"/>
+        <location filename="../firmwares/moduledata.cpp" line="308"/>
         <source>DSMX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPM16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="304"/>
+        <location filename="../firmwares/moduledata.cpp" line="309"/>
         <source>PPMsim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky XJT (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="305"/>
+        <location filename="../firmwares/moduledata.cpp" line="310"/>
         <source>FrSky DJT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="306"/>
+        <location filename="../firmwares/moduledata.cpp" line="311"/>
         <source>Crossfire</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="307"/>
+        <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>Multi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="308"/>
+        <location filename="../firmwares/moduledata.cpp" line="313"/>
         <source>FrSky R9M</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="309"/>
+        <location filename="../firmwares/moduledata.cpp" line="314"/>
         <source>FrSky R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="310"/>
+        <location filename="../firmwares/moduledata.cpp" line="315"/>
         <source>FrSky R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="311"/>
+        <location filename="../firmwares/moduledata.cpp" line="316"/>
         <source>SBUS output at VBat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCESS ISRM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="312"/>
+        <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>FrSky ACCST ISRM D16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="313"/>
+        <location filename="../firmwares/moduledata.cpp" line="318"/>
         <source>FrSky ACCESS R9M 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="314"/>
+        <location filename="../firmwares/moduledata.cpp" line="319"/>
         <source>FrSky ACCESS R9M Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="315"/>
+        <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>FrSky ACCESS R9M Lite Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D16)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (D8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="316"/>
+        <location filename="../firmwares/moduledata.cpp" line="321"/>
         <source>FrSky XJT lite (LR12)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS2A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="317"/>
+        <location filename="../firmwares/moduledata.cpp" line="322"/>
         <source>Flysky AFHDS3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="318"/>
+        <location filename="../firmwares/moduledata.cpp" line="323"/>
         <source>Ghost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="319"/>
+        <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>Lemon-Rx DSMP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>10mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
-        <location filename="../firmwares/moduledata.cpp" line="331"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
+        <location filename="../firmwares/moduledata.cpp" line="336"/>
         <source>100mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>500mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="329"/>
+        <location filename="../firmwares/moduledata.cpp" line="334"/>
         <source>Auto &lt;= 1W - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 8CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>25mW - 16CH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>200mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="330"/>
+        <location filename="../firmwares/moduledata.cpp" line="335"/>
         <source>500mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="332"/>
+        <location filename="../firmwares/moduledata.cpp" line="337"/>
         <source>100mW - 16CH (no telemetry)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>25 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>100 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>500 mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>1 W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/moduledata.cpp" line="335"/>
+        <location filename="../firmwares/moduledata.cpp" line="340"/>
         <source>2 W</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10685,58 +10671,58 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>ModulePanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="277"/>
+        <location filename="../modeledit/setup.cpp" line="278"/>
         <source>external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="278"/>
+        <location filename="../modeledit/setup.cpp" line="279"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="280"/>
+        <location filename="../modeledit/setup.cpp" line="281"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="407"/>
+        <location filename="../modeledit/setup.cpp" line="408"/>
         <source>Value</source>
         <translatorcomment>自定義回傳中使用</translatorcomment>
         <translation>設為</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="408"/>
+        <location filename="../modeledit/setup.cpp" line="409"/>
         <source>Hold</source>
         <translation>保持 [Hold]</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="409"/>
+        <location filename="../modeledit/setup.cpp" line="410"/>
         <source>No Pulse</source>
         <translation>不輸出脈衝  [No Pulse]</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="698"/>
+        <location filename="../modeledit/setup.cpp" line="699"/>
         <source>Bind on channel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="785"/>
+        <location filename="../modeledit/setup.cpp" line="786"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="793"/>
+        <location filename="../modeledit/setup.cpp" line="794"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -10744,456 +10730,456 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultiModelPrinter</name>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
         <translation>輸入</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="403"/>
+        <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
         <translation>比例  [Weight]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="404"/>
+        <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
         <translation>縱向循環螺距  [Long]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="409"/>
+        <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
         <translation>橫向循環螺距  [Lateral]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="414"/>
+        <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
         <translation>總距  [Collective]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="426"/>
+        <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
         <translation>飛行模式  [Modes]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="504"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
         <translation>飛行模式  [Modes]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="431"/>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
         <translation>啟用開關  [Switch]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="313"/>
+        <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="319"/>
+        <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
         <translation type="unfinished">模型圖片  [Medel Image]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="321"/>
+        <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
         <translation type="unfinished">油門</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="322"/>
+        <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="323"/>
+        <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="324"/>
+        <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
         <translation type="unfinished">開關位置警告  [Switch Positions]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="326"/>
+        <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
         <translation type="unfinished">旋鈕位置警告  [Pot Positions]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="328"/>
+        <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
         <translation type="unfinished">Time  當前時間</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
         <translation type="unfinished">倒數報數</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
         <translation type="unfinished">模式</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
-        <location filename="../multimodelprinter.cpp" line="988"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
+        <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
         <translation type="unfinished">開始通道  [CH]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="363"/>
+        <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="375"/>
+        <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="394"/>
+        <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
         <translation type="unfinished">直升機</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="397"/>
+        <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="398"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="981"/>
+        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="399"/>
+        <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
         <translation type="unfinished">運算方式  [Function]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="769"/>
+        <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
         <translation type="unfinished">遙控器發射協議    [Protocol]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="777"/>
+        <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="780"/>
+        <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="783"/>
+        <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="790"/>
+        <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
         <translation type="unfinished">高度計</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="792"/>
-        <location filename="../multimodelprinter.cpp" line="795"/>
+        <location filename="../multimodelprinter.cpp" line="793"/>
+        <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
         <translation type="unfinished">Vario 傳感器</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="800"/>
+        <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="802"/>
+        <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="803"/>
+        <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="805"/>
+        <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="806"/>
+        <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="807"/>
+        <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="814"/>
+        <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
         <translation type="unfinished">頂部橫條</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="816"/>
+        <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
         <translation type="unfinished">電壓傳感器</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="817"/>
+        <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
         <translation type="unfinished">高度傳感器</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="822"/>
+        <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="823"/>
+        <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="968"/>
+        <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
         <translation>可自定義開關</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="970"/>
+        <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="995"/>
+        <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="1002"/>
+        <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="733"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="905"/>
+        <location filename="../multimodelprinter.cpp" line="734"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
         <translation type="unfinished">參數</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="859"/>
+        <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="891"/>
+        <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="921"/>
+        <location filename="../multimodelprinter.cpp" line="922"/>
         <source>GF%1</source>
         <translation type="unfinished">GF%1</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="932"/>
+        <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="952"/>
+        <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="463"/>
-        <location filename="../multimodelprinter.cpp" line="587"/>
+        <location filename="../multimodelprinter.cpp" line="464"/>
+        <location filename="../multimodelprinter.cpp" line="588"/>
         <source>GV%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="467"/>
+        <location filename="../multimodelprinter.cpp" line="468"/>
         <source>RE%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
         <translation>通道</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="317"/>
-        <location filename="../multimodelprinter.cpp" line="472"/>
-        <location filename="../multimodelprinter.cpp" line="837"/>
-        <location filename="../multimodelprinter.cpp" line="974"/>
+        <location filename="../multimodelprinter.cpp" line="318"/>
+        <location filename="../multimodelprinter.cpp" line="473"/>
+        <location filename="../multimodelprinter.cpp" line="838"/>
+        <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
         <translation>名稱  [Name]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="482"/>
+        <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="497"/>
+        <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="530"/>
+        <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
         <translation type="unfinished">輸出 Outputs</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
         <translation type="unfinished">舵機中位 [Subtrim]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="535"/>
+        <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
         <translation type="unfinished">曲線       [Curve]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="537"/>
+        <location filename="../multimodelprinter.cpp" line="538"/>
         <source>PPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="539"/>
+        <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
         <translation type="unfinished">直線</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="764"/>
+        <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
         <translation type="unfinished">回傳設置 Tele</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="487"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="488"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
         <translation>舵機下限  [Min]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="339"/>
+        <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="431"/>
+        <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="460"/>
+        <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="492"/>
-        <location filename="../multimodelprinter.cpp" line="533"/>
+        <location filename="../multimodelprinter.cpp" line="493"/>
+        <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
         <translation>舵機上限  [Max]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="581"/>
+        <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
         <translation>全局變量  [Global Variables]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="602"/>
+        <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
         <translation>輸入</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="632"/>
+        <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
         <translation>混控  [Mixers]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="692"/>
+        <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
         <translation>多點曲線  [Curves]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="714"/>
+        <location filename="../multimodelprinter.cpp" line="715"/>
         <source>L%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="721"/>
+        <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
         <translation>邏輯開關  [Logical Sw]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="745"/>
+        <location filename="../multimodelprinter.cpp" line="746"/>
         <source>SF%1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="756"/>
+        <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
         <translation>特殊功能  [Special Func]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="477"/>
+        <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
         <translation>單位  [Unit]</translation>
     </message>
     <message>
-        <location filename="../multimodelprinter.cpp" line="775"/>
+        <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
         <translation>RSSI 警告  [RF Quality Alarms]</translation>
     </message>
@@ -11201,7 +11187,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>Multiprotocols</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="740"/>
+        <location filename="../modeledit/setup.cpp" line="741"/>
         <source>Servo update rate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11209,22 +11195,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>MultirotorPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="926"/>
+        <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
         <translation>油門通道  [Throttle]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="928"/>
+        <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
         <translation>偏航通道  [Yaw]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="930"/>
+        <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
         <translation>仰俯通道  [Pitch]:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="932"/>
+        <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
         <translation>滾轉通道  [Roll]:</translation>
     </message>
@@ -11232,22 +11218,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OpenTxEepromInterface</name>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="316"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="358"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="324"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="366"/>
         <source> ... plus %1 errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="393"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="435"/>
         <source>Cannot write radio settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="447"/>
         <source>Cannot write model %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11255,17 +11241,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OptionsPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="957"/>
+        <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
         <translation>油門切斷  [Throttle Cut]</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="958"/>
+        <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
         <translation>油門計時器  [Throttle Timer]</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="959"/>
+        <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
         <translation>飛行計時器  [Flight Timer]</translation>
     </message>
@@ -11273,40 +11259,40 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>OtxFormat</name>
     <message>
-        <location filename="../storage/otx.cpp" line="31"/>
+        <location filename="../storage/otx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">打開文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="42"/>
+        <location filename="../storage/otx.cpp" line="43"/>
         <source>Error opening OpenTX archive %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="57"/>
+        <location filename="../storage/otx.cpp" line="58"/>
         <source>Error initializing OpenTX archive writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="78"/>
+        <location filename="../storage/otx.cpp" line="79"/>
         <source>Error creating OpenTX file %1:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="83"/>
+        <location filename="../storage/otx.cpp" line="84"/>
         <source>Error creating OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="110"/>
+        <location filename="../storage/otx.cpp" line="111"/>
         <source>Error adding %1 to OpenTX archive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/otx.cpp" line="73"/>
+        <location filename="../storage/otx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
         <translation type="unfinished">寫入文件錯誤 %1:
@@ -11336,17 +11322,17 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
         <translation>打印到文件</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="62"/>
+        <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
         <translation>打印文檔</translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../printdialog.cpp" line="70"/>
+        <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11373,12 +11359,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
-        <location filename="../progressdialog.cpp" line="90"/>
+        <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../progressdialog.cpp" line="85"/>
+        <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
@@ -11394,22 +11380,22 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../helpers.cpp" line="246"/>
+        <location filename="../helpers.cpp" line="236"/>
         <source>WARNING</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="247"/>
+        <location filename="../helpers.cpp" line="237"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/firmwareinterface.cpp" line="389"/>
+        <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../warnings.h" line="95"/>
+        <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11417,24 +11403,24 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioData</name>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="153"/>
+        <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="318"/>
+        <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="320"/>
-        <location filename="../firmwares/radiodata.cpp" line="322"/>
+        <location filename="../firmwares/radiodata.cpp" line="321"/>
+        <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodata.cpp" line="324"/>
-        <location filename="../firmwares/radiodata.cpp" line="326"/>
+        <location filename="../firmwares/radiodata.cpp" line="325"/>
+        <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11442,97 +11428,107 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioDataConversionState</name>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="112"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="119"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="126"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
+        <source>unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="165"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
+        <source>[XSP]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
         <translation type="unfinished">功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="178"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
         <translation type="unfinished">新建配置文件</translation>
     </message>
     <message>
-        <location filename="../firmwares/radiodataconversionstate.cpp" line="192"/>
+        <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11540,30 +11536,30 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioInterface</name>
     <message>
-        <location filename="../radiointerface.cpp" line="68"/>
+        <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">無法寫入文件 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="201"/>
+        <location filename="../radiointerface.cpp" line="202"/>
         <source>Unable to find radio SD card!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="216"/>
+        <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="223"/>
+        <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../radiointerface.cpp" line="140"/>
-        <location filename="../radiointerface.cpp" line="185"/>
+        <location filename="../radiointerface.cpp" line="141"/>
+        <location filename="../radiointerface.cpp" line="186"/>
         <source>Could not delete temporary file: %1</source>
         <translation type="unfinished">無法刪除臨時文件: %1</translation>
     </message>
@@ -11571,12 +11567,12 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</source>
 <context>
     <name>RadioKnobWidget</name>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="58"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/radioknobwidget.h" line="60"/>
+        <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11672,12 +11668,17 @@ s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="226"/>
-        <source>FM%1</source>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>FM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/radiooutputswidget.cpp" line="235"/>
+        <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
+        <source>DM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
         <source>GV%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11693,360 +11694,460 @@ s</source>
 <context>
     <name>RawSource</name>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="92"/>
+        <location filename="../firmwares/rawsource.cpp" line="94"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="97"/>
-        <location filename="../firmwares/rawsource.cpp" line="107"/>
+        <location filename="../firmwares/rawsource.cpp" line="99"/>
+        <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmR</source>
-        <translation type="unfinished">TrmR  方向微調</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmE</source>
-        <translation type="unfinished">TrmE  升降微調</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmT</source>
-        <translation type="unfinished">TrmT  油門微調</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>TrmA</source>
-        <translation type="unfinished">TrmA  副翼微調</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm5</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Rud</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm6</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ele</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm7</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Thr</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="136"/>
-        <source>Trm8</source>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <source>Trim Ail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 7</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="141"/>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 8</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim ST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim TH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="145"/>
+        <source>Trim 4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="140"/>
+        <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
         <translation type="unfinished">Batt  控電電壓</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
         <translation type="unfinished">Time  當前時間</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="144"/>
+        <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="147"/>
+        <location filename="../firmwares/rawsource.cpp" line="156"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="166"/>
+        <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="170"/>
+        <location filename="../firmwares/rawsource.cpp" line="177"/>
         <source>LUA%1%2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="185"/>
+        <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="188"/>
+        <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
         <translation type="unfinished">MAX   最大</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="210"/>
+        <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
         <translation type="unfinished">CYC%1  循環螺距</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="213"/>
+        <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="254"/>
+        <location filename="../firmwares/rawsource.cpp" line="265"/>
         <source>sm%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawsource.cpp" line="356"/>
-        <source>SRC</source>
+        <location filename="../firmwares/rawsource.cpp" line="268"/>
+        <source>GR%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="400"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawsource.cpp" line="412"/>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <location filename="../constants.h" line="97"/>
+        <source>-</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RawSwitch</name>
     <message>
-        <location filename="../constants.h" line="88"/>
+        <location filename="../constants.h" line="92"/>
         <source>↑</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="89"/>
+        <location filename="../constants.h" line="93"/>
         <source>↓</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="90"/>
+        <location filename="../constants.h" line="94"/>
         <source>-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../constants.h" line="91"/>
+        <location filename="../constants.h" line="95"/>
         <source>!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="51"/>
+        <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="61"/>
+        <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="40"/>
-        <source>Rud+</source>
+        <location filename="../firmwares/rawswitch.cpp" line="41"/>
+        <source>Trim Rud-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="41"/>
-        <source>Ele+</source>
+        <source>Trim Rud+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr-</source>
+        <source>Trim Ele-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
-        <source>Thr+</source>
+        <source>Trim Ele+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail-</source>
+        <source>Trim Thr-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
-        <source>Ail+</source>
+        <source>Trim Thr+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5-</source>
+        <source>Trim Ail-</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
-        <source>T5+</source>
+        <source>Trim Ail+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="45"/>
-        <source>T6+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="46"/>
-        <source>T7+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/rawswitch.cpp" line="47"/>
-        <source>T8+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="126"/>
+        <source>Trim T5-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="45"/>
+        <location filename="../firmwares/rawswitch.cpp" line="56"/>
+        <source>Trim T5+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="46"/>
+        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <source>Trim T6+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="47"/>
+        <location filename="../firmwares/rawswitch.cpp" line="58"/>
+        <source>Trim T7+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="48"/>
+        <location filename="../firmwares/rawswitch.cpp" line="59"/>
+        <source>Trim T8+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="52"/>
+        <source>Trim ST+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="53"/>
+        <source>Trim TH+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="54"/>
+        <source>Trim T3+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="55"/>
+        <source>Trim T4+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="56"/>
-        <location filename="../firmwares/rawswitch.cpp" line="123"/>
+        <location filename="../firmwares/rawswitch.cpp" line="68"/>
+        <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
         <translation type="unfinished">啟用</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
         <translation type="unfinished">THs  油門激活</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
         <translation type="unfinished">TH%  油門比例</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="57"/>
+        <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
         <translation type="unfinished">THt  油門計時</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="129"/>
+        <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
         <translation type="unfinished">One  單次</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="132"/>
+        <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="141"/>
+        <location filename="../firmwares/rawswitch.cpp" line="155"/>
         <source>----</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="153"/>
+        <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
         <translation type="unfinished">回傳設置 Tele</translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="156"/>
+        <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/rawswitch.cpp" line="209"/>
-        <source>SW</source>
+        <location filename="../firmwares/rawswitch.cpp" line="223"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/rawswitch.cpp" line="240"/>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+</context>
+<context>
+    <name>RepoAssets</name>
+    <message>
+        <location filename="../updates/repoassets.cpp" line="181"/>
+        <source>Generic asset build not implemented</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RudderPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="656"/>
+        <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
         <translatorcomment>RudderPage</translatorcomment>
         <translation>没有方向舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="657"/>
+        <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
         <translatorcomment>RudderPage</translatorcomment>
         <translation>有方向舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="666"/>
+        <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
         <translation>&lt;br&gt;方向舵通道:</translation>
     </message>
@@ -12054,20 +12155,20 @@ s</source>
 <context>
     <name>SdcardFormat</name>
     <message>
-        <location filename="../storage/sdcard.cpp" line="38"/>
+        <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">打開文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="51"/>
+        <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/sdcard.cpp" line="77"/>
+        <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12075,319 +12176,334 @@ s</source>
 <context>
     <name>SensorData</name>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="132"/>
+        <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="135"/>
+        <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="136"/>
+        <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
         <translation type="unfinished">對象</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="140"/>
-        <location filename="../firmwares/sensordata.cpp" line="154"/>
+        <location filename="../firmwares/sensordata.cpp" line="141"/>
+        <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="145"/>
+        <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="157"/>
+        <location filename="../firmwares/sensordata.cpp" line="158"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="158"/>
+        <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
         <translation type="unfinished">Alt  高度</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="162"/>
+        <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="165"/>
+        <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
         <translation type="unfinished">精確度</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="170"/>
+        <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
         <translation type="unfinished">比例</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="171"/>
+        <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="172"/>
+        <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
         <translation type="unfinished">自動偏移</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="175"/>
+        <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
         <translation type="unfinished">旋翼數</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="176"/>
+        <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
         <translation type="unfinished">係數</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="181"/>
+        <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
         <translation type="unfinished">過濾器</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="184"/>
+        <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="187"/>
+        <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="189"/>
+        <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="269"/>
+        <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="271"/>
+        <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
         <translation type="unfinished">運算</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="282"/>
+        <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
         <translation type="unfinished">加</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="284"/>
+        <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
         <translation type="unfinished">平均值</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="286"/>
+        <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="288"/>
+        <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="290"/>
+        <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
         <translation type="unfinished">乘以</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="292"/>
+        <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
         <translation type="unfinished">總計</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="294"/>
+        <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
         <translation type="unfinished">鋰電單片電壓</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="296"/>
+        <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
         <translation type="unfinished">消耗</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="298"/>
+        <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="308"/>
+        <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
         <translation type="unfinished">最低</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="310"/>
+        <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
         <translation type="unfinished">第%1片</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="312"/>
+        <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
         <translation type="unfinished">最高</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="314"/>
+        <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
         <translation type="unfinished">每片電壓差</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="349"/>
+        <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
         <translation type="unfinished">原始值 (-)</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="351"/>
-        <location filename="../firmwares/sensordata.cpp" line="397"/>
+        <location filename="../firmwares/sensordata.cpp" line="352"/>
+        <location filename="../firmwares/sensordata.cpp" line="412"/>
         <source>V</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="353"/>
+        <location filename="../firmwares/sensordata.cpp" line="354"/>
         <source>A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="355"/>
+        <location filename="../firmwares/sensordata.cpp" line="356"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="357"/>
+        <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="359"/>
+        <location filename="../firmwares/sensordata.cpp" line="360"/>
         <source>m/s</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="361"/>
+        <location filename="../firmwares/sensordata.cpp" line="362"/>
+        <source>f/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="364"/>
         <source>km/h</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="363"/>
+        <location filename="../firmwares/sensordata.cpp" line="366"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="365"/>
+        <location filename="../firmwares/sensordata.cpp" line="368"/>
         <source>m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="367"/>
+        <location filename="../firmwares/sensordata.cpp" line="370"/>
         <source>f</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="369"/>
+        <location filename="../firmwares/sensordata.cpp" line="372"/>
         <source>°C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="371"/>
+        <location filename="../firmwares/sensordata.cpp" line="374"/>
         <source>°F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="373"/>
+        <location filename="../firmwares/sensordata.cpp" line="376"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="375"/>
+        <location filename="../firmwares/sensordata.cpp" line="378"/>
         <source>mAh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="377"/>
+        <location filename="../firmwares/sensordata.cpp" line="380"/>
         <source>W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="379"/>
+        <location filename="../firmwares/sensordata.cpp" line="382"/>
         <source>mW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="381"/>
+        <location filename="../firmwares/sensordata.cpp" line="384"/>
         <source>dB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="383"/>
+        <location filename="../firmwares/sensordata.cpp" line="386"/>
         <source>rpms</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="385"/>
+        <location filename="../firmwares/sensordata.cpp" line="388"/>
         <source>g</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="387"/>
+        <location filename="../firmwares/sensordata.cpp" line="390"/>
         <source>°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="389"/>
+        <location filename="../firmwares/sensordata.cpp" line="392"/>
         <source>Rad</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="391"/>
+        <location filename="../firmwares/sensordata.cpp" line="394"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="396"/>
+        <source>fl.oz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
         <translation type="unfinished">小时</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="393"/>
+        <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
         <translation type="unfinished">分</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="395"/>
+        <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
         <translation type="unfinished">秒</translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="399"/>
+        <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="401"/>
+        <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="403"/>
+        <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="405"/>
+        <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="445"/>
+        <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/sensordata.cpp" line="36"/>
+        <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12619,87 +12735,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SetupPanel</name>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1579"/>
+        <location filename="../modeledit/setup.cpp" line="1675"/>
         <source>Timer %1</source>
         <translation>計時器[Timer] %1</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="1563"/>
+        <location filename="../modeledit/setup.cpp" line="1659"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>Profile Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2070"/>
+        <location filename="../modeledit/setup.cpp" line="2178"/>
         <source>SD structure path not specified or invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2085"/>
+        <location filename="../modeledit/setup.cpp" line="2193"/>
         <source>Copy</source>
         <translation type="unfinished">複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2086"/>
+        <location filename="../modeledit/setup.cpp" line="2194"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2087"/>
+        <location filename="../modeledit/setup.cpp" line="2195"/>
         <source>Paste</source>
         <translation type="unfinished">貼上</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2088"/>
+        <location filename="../modeledit/setup.cpp" line="2196"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2090"/>
+        <location filename="../modeledit/setup.cpp" line="2198"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2091"/>
+        <location filename="../modeledit/setup.cpp" line="2199"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2092"/>
+        <location filename="../modeledit/setup.cpp" line="2200"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2093"/>
+        <location filename="../modeledit/setup.cpp" line="2201"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2095"/>
+        <location filename="../modeledit/setup.cpp" line="2203"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2130"/>
+        <location filename="../modeledit/setup.cpp" line="2238"/>
         <source>Clear Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2142"/>
+        <location filename="../modeledit/setup.cpp" line="2250"/>
         <source>Clear all Timers. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2164"/>
+        <location filename="../modeledit/setup.cpp" line="2272"/>
         <source>Cut Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/setup.cpp" line="2172"/>
+        <location filename="../modeledit/setup.cpp" line="2280"/>
         <source>Delete Timer. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12707,7 +12823,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimpleTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="776"/>
+        <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
         <translation>升降舵通道:</translation>
     </message>
@@ -12715,204 +12831,204 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatedUIWidget</name>
     <message>
-        <location filename="../simulation/simulateduiwidget.cpp" line="153"/>
+        <location filename="../simulation/simulateduiwidget.cpp" line="158"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="6"/>
+        <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>ENTER</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="7"/>
+        <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="8"/>
+        <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>PG-UP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="9"/>
+        <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>PG-DN</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="10"/>
+        <location filename="../simulation/simulator_strings.h" line="30"/>
         <source>DEL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="11"/>
+        <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>BKSP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="12"/>
+        <location filename="../simulation/simulator_strings.h" line="32"/>
         <source>ESC</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="13"/>
+        <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>INS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="14"/>
+        <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>&lt;font size=+3&gt;+&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="15"/>
+        <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>&lt;font size=+3&gt;-&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="17"/>
+        <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>&lt;font size=+3&gt;&amp;larr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="18"/>
+        <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>&lt;font size=+3&gt;&amp;rarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="19"/>
+        <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>&lt;font size=+3&gt;&amp;uarr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="20"/>
+        <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>&lt;font size=+3&gt;&amp;darr;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="22"/>
+        <location filename="../simulation/simulator_strings.h" line="42"/>
         <source>&lt;font size=+3&gt;&amp;#x2686;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="23"/>
+        <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;&amp;#x21b6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="24"/>
+        <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;#x21b7;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="25"/>
+        <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;#x21c6;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="26"/>
-        <location filename="../simulation/simulator_strings.h" line="29"/>
+        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="49"/>
         <source>&lt;font size=+3&gt;&amp;#x21d3;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="28"/>
+        <location filename="../simulation/simulator_strings.h" line="48"/>
         <source>&lt;font size=+3&gt;&amp;#x21d1;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="30"/>
+        <location filename="../simulation/simulator_strings.h" line="50"/>
         <source>&lt;font size=+3&gt;&amp;#x21d5;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="32"/>
+        <location filename="../simulation/simulator_strings.h" line="52"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/mouse.svg&apos; width=20 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="33"/>
+        <location filename="../simulation/simulator_strings.h" line="53"/>
         <source>&lt;img src=&apos;qrc:/images/simulator/icons/svg/arrow_click.svg&apos; width=18 height=18 /&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="39"/>
+        <location filename="../simulation/simulator_strings.h" line="59"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="40"/>
+        <location filename="../simulation/simulator_strings.h" line="60"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="41"/>
+        <location filename="../simulation/simulator_strings.h" line="61"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="42"/>
+        <location filename="../simulation/simulator_strings.h" line="62"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="43"/>
+        <location filename="../simulation/simulator_strings.h" line="63"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="44"/>
+        <location filename="../simulation/simulator_strings.h" line="64"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="45"/>
+        <location filename="../simulation/simulator_strings.h" line="65"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="46"/>
+        <location filename="../simulation/simulator_strings.h" line="66"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;+&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="47"/>
+        <location filename="../simulation/simulator_strings.h" line="67"/>
         <source>&lt;pre&gt;[ &lt;font size=+2&gt;-&lt;/font&gt; ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="48"/>
+        <location filename="../simulation/simulator_strings.h" line="68"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="49"/>
+        <location filename="../simulation/simulator_strings.h" line="69"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="50"/>
+        <location filename="../simulation/simulator_strings.h" line="70"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="51"/>
+        <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="52"/>
+        <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="53"/>
+        <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulator_strings.h" line="54"/>
+        <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;font size=+3&gt;&amp;#x2261;&lt;/font&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -12920,122 +13036,122 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
 <context>
     <name>SimulatorMain</name>
     <message>
-        <location filename="../simulator.cpp" line="65"/>
+        <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="74"/>
+        <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
         <translation type="unfinished">可用檔案:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>ID: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="78"/>
+        <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="81"/>
+        <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
         <translation type="unfinished">可用的遥控器:</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="116"/>
+        <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
         <translation type="unfinished">用於模擬器的遙控器檔案 ID 或名稱.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="117"/>
+        <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="120"/>
+        <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
         <translation type="unfinished">模擬的遙控器類型 (一般在遙控器檔案中定義).</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="121"/>
+        <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="124"/>
+        <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="125"/>
+        <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="128"/>
+        <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="362"/>
+        <location filename="../simulator.cpp" line="363"/>
         <source>Unknown error during Simulator startup.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="129"/>
+        <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="131"/>
+        <location filename="../simulator.cpp" line="132"/>
         <source>data-source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="132"/>
+        <location filename="../simulator.cpp" line="133"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="134"/>
+        <location filename="../simulator.cpp" line="135"/>
         <source>[data-source]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="172"/>
+        <location filename="../simulator.cpp" line="173"/>
         <source>Error: Profile ID %1 was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="220"/>
+        <location filename="../simulator.cpp" line="221"/>
         <source>Unrecognized startup data source type: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="276"/>
+        <location filename="../simulator.cpp" line="277"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
         <translation type="unfinished">警告: 無法初始化 SDL:
 %1</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="287"/>
+        <location filename="../simulator.cpp" line="288"/>
         <source>ERROR: No simulator libraries available.</source>
         <translation type="unfinished">錯誤:沒有可用的模擬器庫.</translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="332"/>
+        <location filename="../simulator.cpp" line="333"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulator.cpp" line="338"/>
+        <location filename="../simulator.cpp" line="339"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished">錯誤: 未找到遙控器檔案或模擬器韌體.
@@ -13046,7 +13162,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <name>SimulatorMainWindow</name>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
-        <source>OpenTx Simulator</source>
+        <source>EdgeTX Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -13195,74 +13311,74 @@ Profile ID: [%1]; Radio ID: [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="68"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="69"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="107"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="108"/>
         <source>Alt+T</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="279"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="280"/>
         <source>Radio Outputs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="283"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="284"/>
         <source>F2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="288"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="289"/>
         <source>Telemetry Simulator</source>
         <translation type="unfinished">回傳模擬器</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="292"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="293"/>
         <source>F4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="297"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="298"/>
         <source>Trainer Simulator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="301"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="302"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="306"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="307"/>
         <source>Debug Output</source>
         <translation type="unfinished">Debug 輸出</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="310"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="311"/>
         <source>F6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="480"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="481"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="482"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="483"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="484"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="485"/>
         <source>&lt;tr&gt;&lt;td&gt;&lt;kbd&gt;%1&lt;/kbd&gt;&lt;/td&gt;&lt;td&gt;%2&lt;/td&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of help text table header.</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatormainwindow.cpp" line="500"/>
+        <location filename="../simulation/simulatormainwindow.cpp" line="501"/>
         <source>Simulator Help</source>
         <translation type="unfinished">模擬器幫助</translation>
     </message>
@@ -13387,32 +13503,32 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="50"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="107"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="306"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
         <source>All files (*.*)</source>
         <translation type="unfinished">所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="307"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="317"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorstartupdialog.cpp" line="328"/>
+        <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13425,67 +13541,72 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished">Companion 模擬器</translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="58"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="59"/>
         <source>Radio Simulator (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="293"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="322"/>
         <source>Could not determine startup data source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="298"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="327"/>
         <source>Could not load data, possibly wrong format.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="299"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="328"/>
         <source>Data Load Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="357"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="386"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="358"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="387"/>
         <source>Simulator Startup Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="418"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="447"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="424"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="453"/>
         <source>Error saving data: could not get data from simulator interface.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="449"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="478"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="450"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="479"/>
         <source>Data Save Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="808"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="837"/>
         <source>Radio firmware error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="813"/>
-        <source> - Flight Mode %1 (#%2)</source>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Flight Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/simulatorwidget.cpp" line="710"/>
+        <location filename="../simulation/simulatorwidget.cpp" line="842"/>
+        <source>Drive Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Cannot open joystick, joystick disabled</source>
         <translation type="unfinished">無法打開遊戲桿, 遊戲桿功能禁用</translation>
     </message>
@@ -13512,17 +13633,17 @@ The default is configured in the chosen Radio Profile.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="84"/>
+        <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
         <translation>開機圖片庫 - 第%1頁/共%2頁</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="116"/>
+        <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
         <translation>圖片庫 %1 中的圖片無效</translation>
     </message>
     <message>
-        <location filename="../splashlibrarydialog.cpp" line="122"/>
+        <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
         <translation>在圖片庫中沒有找到有效的圖片, 請檢查你的設置</translation>
     </message>
@@ -13530,7 +13651,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>StandardPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="206"/>
+        <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
         <translation>通道 %1</translation>
     </message>
@@ -13538,7 +13659,7 @@ The default is configured in the chosen Radio Profile.</source>
 <context>
     <name>Storage</name>
     <message>
-        <location filename="../storage/storage.cpp" line="85"/>
+        <location filename="../storage/storage.cpp" line="86"/>
         <source>Unable to find file %1!</source>
         <translation type="unfinished">無法找到文件 %1!</translation>
     </message>
@@ -13547,9 +13668,9 @@ The default is configured in the chosen Radio Profile.</source>
     <name>StyleEditDialog</name>
     <message>
         <location filename="../styleeditdialog.ui" line="14"/>
-        <location filename="../styleeditdialog.cpp" line="34"/>
-        <location filename="../styleeditdialog.cpp" line="60"/>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13574,19 +13695,19 @@ The default is configured in the chosen Radio Profile.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="34"/>
+        <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="60"/>
+        <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../styleeditdialog.cpp" line="70"/>
+        <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
         <translation type="unfinished"></translation>
@@ -13595,47 +13716,47 @@ Error: %2</source>
 <context>
     <name>Stylesheet</name>
     <message>
-        <location filename="../helpers_html.cpp" line="154"/>
+        <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="156"/>
+        <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="169"/>
+        <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="174"/>
+        <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="181"/>
+        <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="183"/>
+        <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="188"/>
+        <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="203"/>
+        <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers_html.cpp" line="205"/>
+        <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13643,141 +13764,141 @@ Error: %2</source>
 <context>
     <name>SyncProcess</name>
     <message>
-        <location filename="../process_sync.cpp" line="78"/>
+        <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="163"/>
+        <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="273"/>
+        <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="323"/>
+        <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="325"/>
+        <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="110"/>
+        <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="111"/>
+        <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="177"/>
+        <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="179"/>
+        <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="248"/>
+        <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="249"/>
+        <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="265"/>
+        <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="276"/>
+        <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="279"/>
+        <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="293"/>
+        <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="295"/>
+        <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="297"/>
+        <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="332"/>
+        <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="349"/>
+        <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="354"/>
+        <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="363"/>
+        <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="368"/>
+        <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="377"/>
+        <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="387"/>
+        <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="395"/>
+        <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="389"/>
+        <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../process_sync.cpp" line="398"/>
+        <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -13785,17 +13906,17 @@ Too many errors, giving up.</source>
 <context>
     <name>TailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="730"/>
+        <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
         <translation>方向舵通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="732"/>
+        <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
         <translation>升降舵通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="745"/>
+        <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
         <translation>只剩一個通道可用!&lt;br&gt;可能你需要不使用嚮導來配置模型.</translation>
     </message>
@@ -13803,22 +13924,22 @@ Too many errors, giving up.</source>
 <context>
     <name>TailSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="352"/>
+        <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
         <translation>升降舵和方向舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="354"/>
+        <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
         <translation>只有升降舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="355"/>
+        <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
         <translation>V尾</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="358"/>
+        <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
         <translation>尾翼類型:</translation>
     </message>
@@ -14151,7 +14272,7 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryCustomScreensPanel</name>
     <message>
-        <location filename="../modeledit/telemetry_customscreens.cpp" line="360"/>
+        <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
         <translation type="unfinished">回傳屏幕 %1</translation>
     </message>
@@ -14159,28 +14280,961 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetryPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="507"/>
+        <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
         <translation>低警告</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="508"/>
+        <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
         <translation>緊急警告</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="540"/>
+        <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="543"/>
+        <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
         <translation>Winged Shadow How High (不支持)</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="671"/>
+        <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderCrossfire</name>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">表單</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
+        <source>2RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
+        <source>Sats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
+        <source>RPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
+        <source>RxBt</source>
+        <translation type="unfinished">RxBt  接收機電壓</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="350"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="593"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
+        <source>dBm</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
+        <source>ANT</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VSpd  垂直速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Hdg  航向角</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
+        <source>RSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="410"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1020"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
+        <source>Capa</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
+        <source>0mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
+        <source>10mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
+        <source>25mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
+        <source>50mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
+        <source>100mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
+        <source>250mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
+        <source>500mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
+        <source>1000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
+        <source>2000mW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
+        <source>Bat%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GSpd  GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
+        <source>Yaw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
+        <source>FM</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
+        <source>TPWR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
+        <source>Radians</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
+        <source>TSNR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
+        <source>RFMD</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
+        <source>Battery Monitoring</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
+        <source>Ptch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
+        <source>mAh</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
+        <source>Attitude</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
+        <source>1RSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
+        <source>Curr</source>
+        <translation type="unfinished">Curr  電流</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
+        <source>TRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
+        <source>Roll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
+        <source>Barometer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
+        <source>mw</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt  高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
+        <source>RRSP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
+        <source>Flight Controller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
+        <source>Not a CRSF telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSky</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">表單</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="191"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="278"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1067"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1106"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1575"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1794"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2197"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2218"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2456"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
+        <source>Cels</source>
+        <translation type="unfinished">Cells  鋰電電壓</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
+        <source>Fuel Qty</source>
+        <translation type="unfinished">Fule Qty  油量</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
+        <source>GAlt</source>
+        <translation type="unfinished">GALT  GPS高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
+        <source>VFAS</source>
+        <translation type="unfinished">VFAS  FAS傳感器電壓</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
+        <source>ml</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
+        <source>A4</source>
+        <translation type="unfinished">A4  模擬值4</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
+        <source>ASpd</source>
+        <translation type="unfinished">ASpd  空速</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
+        <source>Volts</source>
+        <translation type="unfinished">V</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
+        <source>Run/Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">Tmp1  温度1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
+        <source>RxBt</source>
+        <translation type="unfinished">RxBt  接收機電壓</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
+        <source>GPS sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
+        <source>km/h</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
+        <source>V / ratio</source>
+        <translation type="unfinished">伏 / 比值          </translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
+        <source>*</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ  Z軸加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
+        <source>dd-MM-yyyy
+hh:mm:ss</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
+        <source>Meters</source>
+        <translation type="unfinished">m</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
+        <source>RAS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX  X軸加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">Tmp2  温度2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
+        <source>RPM</source>
+        <translation type="unfinished">Rpm</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
+        <source>A1</source>
+        <translation type="unfinished">A1  模擬值1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY  Y軸加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VSpd  垂直速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
+        <source>A2</source>
+        <translation type="unfinished">A2  模擬值2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
+        <source>A3</source>
+        <translation type="unfinished">A3  模擬值3</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Fule  燃油</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI  信號強度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Hdg  航向角</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
+        <source>Curr</source>
+        <translation type="unfinished">Curr  電流</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
+        <source>Amps</source>
+        <translation type="unfinished">A</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt  高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
+        <source>Date</source>
+        <translation type="unfinished">Date  日期</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GSpd  GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
+        <source>Not a FrSky S.Port telemetry values file.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TelemetryProviderFrSkyHub</name>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
+        <source>Form</source>
+        <translation type="unfinished">表單</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
+        <source>Fuel</source>
+        <translation type="unfinished">Fule  燃油</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
+        <source>RPM</source>
+        <translation type="unfinished">Rpm</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
+        <source>G</source>
+        <translation type="unfinished">G</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
+        <source>Baro</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
+        <source>Tmp2</source>
+        <translation type="unfinished">Tmp2  温度2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
+        <source>Run</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
+        <source>VSpd</source>
+        <translation type="unfinished">VSpd  垂直速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
+        <source>Hdg</source>
+        <translation type="unfinished">Hdg  航向角</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
+        <source>°C</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
+        <source>V</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
+        <source>Date</source>
+        <translation type="unfinished">Date  日期</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
+        <source>m/s</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
+        <source>A2</source>
+        <translation type="unfinished">A2  模擬值2</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
+        <source>AccX</source>
+        <translation type="unfinished">AccX  X軸加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
+        <source>Accel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
+        <source>Batt</source>
+        <translation type="unfinished">Batt  控電電壓</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
+        <source>GAlt</source>
+        <translation type="unfinished">GALT  GPS高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
+        <source>A1</source>
+        <translation type="unfinished">A1  模擬值1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
+        <source>Temp</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
+        <source>RSSI</source>
+        <translation type="unfinished">RSSI  信號強度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
+        <source>VFAS</source>
+        <translation type="unfinished">VFAS  FAS傳感器電壓</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
+        <source>Tmp1</source>
+        <translation type="unfinished">Tmp1  温度1</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
+        <source>%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
+        <source>Alt</source>
+        <translation type="unfinished">Alt  高度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
+        <source>AccZ</source>
+        <translation type="unfinished">AccZ  Z軸加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
+        <source>Degrees</source>
+        <translation type="unfinished">°</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
+        <source>m</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
+        <source>Curr</source>
+        <translation type="unfinished">Curr  電流</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
+        <source>A</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
+        <source>Load Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
+        <source>Save Telemetry Values</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
+        <source>GSpd</source>
+        <translation type="unfinished">GSpd  GPS速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
+        <source>GPS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
+        <source>knots</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
+        <source>Lat,Lon
+(dec.deg.)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
+        <source>GPS Sim</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
+        <source>25.9973,-97.1572</source>
+        <translation type="unfinished">25.9973,-97.1572</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
+        <source>AccY</source>
+        <translation type="unfinished">AccY  Y軸加速度</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
+        <source>MultiModule</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
+        <source>TRSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
+        <source>RQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
+        <source>TQly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
+        <source>dB</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
+        <source>Stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <source>Save Telemetry</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>.tlm Files (*.tlm)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
+        <source>Unable to open file for writing.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
+        <source>Open Telemetry File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
+        <source>Unable to open file for reading.
+%1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
+        <source>Not a FrSky Hub telemetry values file.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -14297,72 +15351,72 @@ Too many errors, giving up.</source>
 <context>
     <name>TelemetrySensorPanel</name>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="56"/>
+        <location filename="../modeledit/telemetry.cpp" line="58"/>
         <source>TELE%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="65"/>
+        <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="252"/>
+        <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
         <translation type="unfinished">複製</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="253"/>
+        <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="254"/>
+        <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
         <translation type="unfinished">貼上</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="255"/>
+        <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
         <translation type="unfinished">清除</translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="257"/>
+        <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="258"/>
+        <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="259"/>
+        <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="260"/>
+        <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="262"/>
+        <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="305"/>
+        <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="324"/>
+        <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/telemetry.cpp" line="335"/>
+        <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14385,425 +15439,151 @@ Too many errors, giving up.</source>
         <translation>模擬</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="153"/>
-        <source>dB</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1418"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1391"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1397"/>
-        <source>Run</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1425"/>
-        <source>GPS sim</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1432"/>
-        <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1964"/>
-        <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1971"/>
-        <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2157"/>
-        <source>25.9973,-97.1572</source>
-        <translation type="unfinished">25.9973,-97.1572</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2308"/>
-        <source>*</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2839"/>
+        <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
         <translation>重播 SD Log 文件</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2862"/>
+        <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2935"/>
+        <location filename="../simulation/telemetrysimu.ui" line="187"/>
         <source>|&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2963"/>
+        <location filename="../simulation/telemetrysimu.ui" line="215"/>
         <source>&lt;|</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2997"/>
+        <location filename="../simulation/telemetrysimu.ui" line="249"/>
         <source>&gt;</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3031"/>
+        <location filename="../simulation/telemetrysimu.ui" line="283"/>
         <source>&lt;-</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3062"/>
+        <location filename="../simulation/telemetrysimu.ui" line="314"/>
         <source>X</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3117"/>
+        <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation type="unfinished">1/5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3133"/>
+        <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
         <translation type="unfinished">5x</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3145"/>
+        <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
         <translation>現在沒有載入任何 log 文件</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3161"/>
+        <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3164"/>
+        <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3177"/>
+        <location filename="../simulation/telemetrysimu.ui" line="482"/>
+        <source>Internal Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="493"/>
+        <location filename="../simulation/telemetrysimu.ui" line="601"/>
+        <source>None</source>
+        <translation type="unfinished">无</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="498"/>
+        <location filename="../simulation/telemetrysimu.ui" line="606"/>
+        <source>CRSF / ELRS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="503"/>
+        <location filename="../simulation/telemetrysimu.ui" line="611"/>
+        <source>FrSky Hub</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="508"/>
+        <location filename="../simulation/telemetrysimu.ui" line="616"/>
+        <source>FrSky S.Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="590"/>
+        <source>External Module</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3180"/>
+        <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2878"/>
+        <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
         <translation>載入</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="3098"/>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
         <source>Row # 
 Timestamp</source>
         <translation>行數
 時間戳</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1046"/>
-        <source>RxBt</source>
-        <translation>RxBt  接收機電壓</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="171"/>
-        <location filename="../simulation/telemetrysimu.ui" line="475"/>
-        <location filename="../simulation/telemetrysimu.ui" line="907"/>
-        <source>V / ratio</source>
-        <translation>伏 / 比值          </translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="562"/>
-        <source>RAS</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="718"/>
-        <location filename="../simulation/telemetrysimu.ui" line="814"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1025"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1206"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1695"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1729"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1750"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1825"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1864"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2097"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2136"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2269"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2684"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1732"/>
-        <source>VFAS</source>
-        <translation>VFAS  FAS傳感器電壓</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2202"/>
-        <source>Lat,Lon
-(dec.deg.)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1556"/>
-        <source>dd-MM-yyyy
-hh:mm:ss</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1957"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2118"/>
-        <source>Volts</source>
-        <translation>V</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="778"/>
-        <source>RSSI</source>
-        <translation>RSSI  信號強度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2100"/>
-        <source>Curr</source>
-        <translation>Curr  電流</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2061"/>
-        <source>Amps</source>
-        <translation>A</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2687"/>
-        <source>Cels</source>
-        <translation>Cells  鋰電電壓</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="580"/>
-        <source>A1</source>
-        <translation>A1  模擬值1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1317"/>
-        <source>A2</source>
-        <translation>A2  模擬值2</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2139"/>
-        <source>ASpd</source>
-        <translation>ASpd  空速</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2016"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2079"/>
-        <source>km/h</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="700"/>
-        <source>A3</source>
-        <translation>A3  模擬值3</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1828"/>
-        <source>GAlt</source>
-        <translation>GALT  GPS高度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="628"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1846"/>
-        <source>Meters</source>
-        <translation>m</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="412"/>
-        <source>A4</source>
-        <translation>A4  模擬值4</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1867"/>
-        <source>GSpd</source>
-        <translation>GSpd  GPS速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="721"/>
-        <source>Tmp1</source>
-        <translation>Tmp1  温度1</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1698"/>
-        <source>Hdg</source>
-        <translation>Hdg  航向角</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2705"/>
-        <source>Degrees</source>
-        <translation>°</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1209"/>
-        <source>Tmp2</source>
-        <translation>Tmp2  温度2</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="189"/>
-        <location filename="../simulation/telemetrysimu.ui" line="796"/>
-        <source>°C</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2272"/>
-        <source>Date</source>
-        <translation>Date  日期</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="520"/>
-        <location filename="../simulation/telemetrysimu.ui" line="1161"/>
-        <source>RPM</source>
-        <translation>Rpm</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1753"/>
-        <source>GPS</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="430"/>
-        <source>Fuel</source>
-        <translation>Fule  燃油</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1299"/>
-        <source>%</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2443"/>
-        <source>AccX</source>
-        <translation>AccX  X軸加速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1538"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2251"/>
-        <location filename="../simulation/telemetrysimu.ui" line="2723"/>
-        <source>G</source>
-        <translation>G</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="980"/>
-        <source>Fuel Qty</source>
-        <translation>Fule Qty  油量</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="339"/>
-        <source>ml</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="2290"/>
-        <source>AccY</source>
-        <translation>AccY  Y軸加速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="817"/>
-        <source>VSpd</source>
-        <translation>VSpd  垂直速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1143"/>
-        <source>m/s</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1885"/>
-        <source>AccZ</source>
-        <translation>AccZ  Z軸加速度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.ui" line="1028"/>
-        <source>Alt</source>
-        <translation>Alt  高度</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Bad GPS Format</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="164"/>
-        <source>Must be decimal latitude,longitude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
         <translation>Log 文件</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="834"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
         <translation>LOG文件 (*.csv)</translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="855"/>
+        <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
         <translation>錯誤 無效的文件</translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1152"/>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1158"/>
-        <source>Unable to open file for writing.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1242"/>
-        <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1249"/>
-        <source>Unable to open file for reading.
-%1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/telemetrysimu.cpp" line="1392"/>
-        <source>Stop</source>
-        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThrottlePage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="398"/>
+        <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
         <translation>使用油門通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="399"/>
+        <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
         <translation>不使用油門通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="406"/>
+        <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
         <translation>&lt;br&gt;油門通道:</translation>
     </message>
@@ -14829,138 +15609,138 @@ hh:mm:ss</source>
 <context>
     <name>TimerData</name>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="27"/>
+        <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="28"/>
+        <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
         <translation type="unfinished">計時器[Timer] %1</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="53"/>
+        <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="106"/>
+        <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
         <translation type="unfinished">静音  [Silent]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="108"/>
+        <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
         <translation type="unfinished">蜂鳴  [Beeps]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="110"/>
+        <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
         <translation type="unfinished">語音  [Voice]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="112"/>
+        <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
         <translation type="unfinished">震動  [Haptic]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="114"/>
+        <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="116"/>
+        <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="127"/>
+        <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
         <translation type="unfinished">5s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="129"/>
+        <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
         <translation type="unfinished">10s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="131"/>
+        <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
         <translation type="unfinished">20s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="133"/>
+        <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
         <translation type="unfinished">30s</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
         <translation type="unfinished">關機不記憶  [Not persistent]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="144"/>
+        <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
         <translation type="unfinished">關機記憶 隨Flight重設  [Flight]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="146"/>
+        <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
         <translation type="unfinished">飛行  [Flight]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
         <translation type="unfinished">關機記憶 手動重設  [manual reset]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="148"/>
+        <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="171"/>
+        <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="173"/>
+        <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
         <translation type="unfinished">啟用</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="175"/>
+        <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
         <translation type="unfinished">開始通道  [CH]</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="177"/>
+        <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
         <translation type="unfinished">THs  油門激活</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="179"/>
+        <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
         <translation type="unfinished">TH%  油門比例</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="181"/>
+        <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
         <translation type="unfinished">THt  油門計時</translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/timerdata.cpp" line="189"/>
+        <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
         <translation type="unfinished"></translation>
     </message>
@@ -14968,22 +15748,22 @@ hh:mm:ss</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="949"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="951"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+=  (相加)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="953"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:=   (取代)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="942"/>
+        <location filename="../firmwares/generalsettings.cpp" line="962"/>
         <source>CH%1</source>
         <translation type="unfinished">通道%1</translation>
     </message>
@@ -14991,27 +15771,27 @@ hh:mm:ss</source>
 <context>
     <name>TrainerPanel</name>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="48"/>
+        <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
         <translation type="unfinished">模式</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="49"/>
+        <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="50"/>
+        <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="76"/>
+        <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
         <translation type="unfinished">係數</translation>
     </message>
     <message>
-        <location filename="../generaledit/trainer.cpp" line="90"/>
+        <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
         <translation type="unfinished">校準</translation>
     </message>
@@ -15022,6 +15802,210 @@ hh:mm:ss</source>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
         <translation>教練功能模擬</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateCloudBuild</name>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="34"/>
+        <source>CloudBuild</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="54"/>
+        <source>waiting</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="56"/>
+        <source>in progress</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="58"/>
+        <source>success</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="60"/>
+        <source>error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="62"/>
+        <source>timeout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="64"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="66"/>
+        <source>unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="113"/>
+        <source>Radio profile language &apos;%1&apos; not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="128"/>
+        <source>fai_mode values do not contain CHOICE and YES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="160"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="165"/>
+        <source>Install</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="168"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="174"/>
+        <source>Expected %1 asset for install but %2 found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="205"/>
+        <source>Firmware not found in %1 using filter %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="211"/>
+        <source>Write the updated firmware to the radio now ?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="228"/>
+        <location filename="../updates/updatecloudbuild.cpp" line="229"/>
+        <source>Building firmware for: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="235"/>
+        <source>Failed to create directory %1!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="252"/>
+        <source>Unexpected format for build targets meta data</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="260"/>
+        <source>No build support for target %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="270"/>
+        <source>Build target %1 has no valid tags</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="276"/>
+        <source>No flag entries found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="323"/>
+        <source>Submit build request</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="329"/>
+        <source>Failed to initiate build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="334"/>
+        <source>Unexpected response format when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="344"/>
+        <source>Build error: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="348"/>
+        <source>Process status not returned when submitting build job</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="358"/>
+        <source>Build finish status: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="372"/>
+        <source>Build cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="380"/>
+        <source>Build timeout. Retry later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="410"/>
+        <source>Submit get build status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="419"/>
+        <source>Build status unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="451"/>
+        <source>Build status contains %1 artifacts when only 1 expected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="461"/>
+        <source>Build status does not contain download url</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="466"/>
+        <source>Build status does not contain firmware artifact</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="471"/>
+        <source>Build status firmware artifact not in expected format</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="477"/>
+        <source>Build status does not contain artifacts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatecloudbuild.cpp" line="491"/>
+        <source>Waiting for build to finish...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -15048,47 +16032,47 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="88"/>
+        <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="91"/>
+        <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="94"/>
+        <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="114"/>
+        <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="121"/>
+        <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="125"/>
+        <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="126"/>
+        <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="134"/>
+        <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatecompanion.cpp" line="140"/>
+        <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15101,22 +16085,42 @@ hh:mm:ss</source>
         <translation type="unfinished">韌體類型</translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="60"/>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>Write firmware to radio: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>true</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="56"/>
+        <source>false</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="69"/>
+        <location filename="../updates/updatefirmware.cpp" line="64"/>
+        <source>Asset filter applied: %1 Assets found: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="100"/>
+        <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatefirmware.cpp" line="106"/>
+        <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15124,285 +16128,317 @@ hh:mm:ss</source>
 <context>
     <name>UpdateInterface</name>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="61"/>
+        <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="179"/>
+        <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="244"/>
-        <location filename="../updates/updateinterface.cpp" line="381"/>
-        <location filename="../updates/updateinterface.cpp" line="441"/>
-        <location filename="../updates/updateinterface.cpp" line="479"/>
+        <location filename="../updates/updateinterface.cpp" line="137"/>
+        <location filename="../updates/updateinterface.cpp" line="289"/>
+        <location filename="../updates/updateinterface.cpp" line="452"/>
+        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="257"/>
+        <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="923"/>
-        <location filename="../updates/updateinterface.cpp" line="927"/>
+        <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="930"/>
-        <source>%1 preparation failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="935"/>
-        <source>%1 download failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="940"/>
-        <source>%1 decompress failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="945"/>
-        <source>%1 copy to destination failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="951"/>
-        <source>Failed to save release settings</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="956"/>
-        <source>%1 start async failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="961"/>
-        <source>%1 housekeeping failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="965"/>
-        <location filename="../updates/updateinterface.cpp" line="968"/>
-        <source>%1 update successful</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="620"/>
+        <location filename="../updates/updateinterface.cpp" line="699"/>
+        <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
         <translation type="unfinished">未知</translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="128"/>
+        <location filename="../updates/updateinterface.cpp" line="121"/>
+        <source>Building assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="124"/>
+        <source>Unable to build flagged assets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="482"/>
+        <location filename="../updates/updateinterface.cpp" line="419"/>
+        <source>Copying files to destination</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="422"/>
+        <source>Unable to copy files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="431"/>
+        <source>Decompressing files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="434"/>
+        <source>Unable to decompress flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <source>Downloading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="545"/>
+        <source>Unable to download flagged files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="486"/>
+        <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="771"/>
+        <location filename="../updates/updateinterface.cpp" line="719"/>
+        <source>Update cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="875"/>
+        <source>%1 start async %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="884"/>
+        <location filename="../updates/updateinterface.cpp" line="929"/>
+        <source>%1 preparation %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="893"/>
+        <source>%1 copy to destination %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="902"/>
+        <source>%1 decompress %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="911"/>
+        <source>%1 download %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="920"/>
+        <source>%1 housekeeping %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="938"/>
+        <source>%1 save release settings %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="776"/>
+        <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="781"/>
+        <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="408"/>
+        <location filename="../updates/updateinterface.cpp" line="1161"/>
+        <location filename="../updates/updateinterface.cpp" line="1164"/>
+        <source>%1 update %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1179"/>
+        <source>failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1181"/>
+        <source>successful</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="1183"/>
+        <source>cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="409"/>
+        <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="426"/>
+        <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="264"/>
+        <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="268"/>
+        <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="171"/>
-        <location filename="../updates/updateinterface.cpp" line="291"/>
+        <location filename="../updates/updateinterface.cpp" line="205"/>
+        <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="175"/>
-        <location filename="../updates/updateinterface.cpp" line="295"/>
+        <location filename="../updates/updateinterface.cpp" line="209"/>
+        <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="176"/>
-        <location filename="../updates/updateinterface.cpp" line="299"/>
+        <location filename="../updates/updateinterface.cpp" line="210"/>
+        <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="214"/>
-        <location filename="../updates/updateinterface.cpp" line="340"/>
+        <location filename="../updates/updateinterface.cpp" line="252"/>
+        <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="221"/>
-        <location filename="../updates/updateinterface.cpp" line="346"/>
+        <location filename="../updates/updateinterface.cpp" line="259"/>
+        <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="225"/>
-        <location filename="../updates/updateinterface.cpp" line="350"/>
+        <location filename="../updates/updateinterface.cpp" line="263"/>
+        <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="236"/>
-        <location filename="../updates/updateinterface.cpp" line="356"/>
+        <location filename="../updates/updateinterface.cpp" line="275"/>
+        <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="159"/>
+        <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="163"/>
+        <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="217"/>
+        <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="231"/>
+        <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="642"/>
+        <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="649"/>
+        <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="662"/>
+        <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="496"/>
+        <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="453"/>
-        <source>Downloading assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="456"/>
-        <source>Unable to download flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="465"/>
-        <source>Decompressing assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="468"/>
-        <source>Unable to decompress flagged assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="363"/>
-        <source>Copying to destination</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="366"/>
-        <source>Unable to copy assets</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updateinterface.cpp" line="509"/>
+        <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="520"/>
+        <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="523"/>
+        <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="530"/>
+        <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="533"/>
-        <location filename="../updates/updateinterface.cpp" line="542"/>
+        <location filename="../updates/updateinterface.cpp" line="613"/>
+        <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="540"/>
+        <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateinterface.cpp" line="703"/>
+        <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15418,63 +16454,90 @@ hh:mm:ss</source>
 <context>
     <name>UpdateNetwork</name>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="94"/>
+        <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="97"/>
+        <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="99"/>
+        <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="114"/>
+        <location filename="../updates/updatenetwork.cpp" line="218"/>
+        <source>Download cancelled by user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="132"/>
-        <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="142"/>
-        <source>Invalid URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="146"/>
-        <source>URL: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="159"/>
-        <source>Network error has occurred. Error code: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="163"/>
-        <source>Ssl library version: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../updates/updatenetwork.cpp" line="213"/>
-        <source>Unable to download %1. Error:%2
+        <location filename="../updates/updatenetwork.cpp" line="297"/>
+        <source>Unable to download %1. GET error:%2
 %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatenetwork.cpp" line="235"/>
+        <location filename="../updates/updatenetwork.cpp" line="322"/>
+        <source>POST error: %2
+%3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="366"/>
+        <location filename="../updates/updatenetwork.cpp" line="382"/>
+        <source>Failed to open %1 for writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="408"/>
+        <source>Download cancelled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="101"/>
+        <source>Unable to open the download file %1 for writing. Error: %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="93"/>
+        <source>Downloading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="266"/>
+        <source>Invalid URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="270"/>
+        <source>URL: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="67"/>
+        <source>Network error has occurred. Error code: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="72"/>
+        <source>Ssl library version: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
         <translation type="unfinished"></translation>
@@ -15567,32 +16630,32 @@ hh:mm:ss</source>
 <context>
     <name>UpdateParameters</name>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updateparameters.cpp" line="78"/>
+        <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15605,22 +16668,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="52"/>
+        <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="59"/>
+        <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="62"/>
+        <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdcard.cpp" line="108"/>
+        <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15633,22 +16696,22 @@ hh:mm:ss</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="61"/>
+        <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="78"/>
+        <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="85"/>
+        <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesounds.cpp" line="107"/>
+        <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15672,17 +16735,17 @@ hh:mm:ss</source>
 <context>
     <name>Updates</name>
     <message>
-        <location filename="../updates/updates.cpp" line="74"/>
+        <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="87"/>
+        <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="88"/>
+        <location filename="../updates/updates.cpp" line="89"/>
         <source>Updates available for:
   - %1
 
@@ -15690,37 +16753,37 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="108"/>
+        <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="124"/>
+        <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="126"/>
+        <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="129"/>
+        <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updates.cpp" line="141"/>
+        <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15836,32 +16899,32 @@ Process now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="232"/>
+        <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="260"/>
+        <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="265"/>
+        <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="270"/>
+        <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="276"/>
+        <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../updates/updatesdialog.cpp" line="310"/>
+        <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15869,32 +16932,32 @@ Process now?</source>
 <context>
     <name>UserInterfacePanel</name>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="49"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="97"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="106"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="110"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="114"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
         <translation type="unfinished">信息</translation>
     </message>
     <message>
-        <location filename="../modeledit/colorcustomscreens.cpp" line="137"/>
+        <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
         <translation type="unfinished">頂部橫條</translation>
     </message>
@@ -15902,12 +16965,12 @@ Process now?</source>
 <context>
     <name>VTailPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="703"/>
+        <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
         <translation>第一個V尾通道:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="705"/>
+        <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
         <translation>第二個V尾通道:</translation>
     </message>
@@ -15915,55 +16978,55 @@ Process now?</source>
 <context>
     <name>VirtualJoystickWidget</name>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="401"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="402"/>
-        <source>Hold Vertical stick position.</source>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
+        <source>Hold Vertical position.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="406"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
+        <source>Prevent Vertical movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
+        <source>Prevent Horizontal movement.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
+        <source>Hold Horizontal position.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
         <translation>固定 Y</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="407"/>
-        <source>Prevent Vertical movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="411"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
         <translation>固定 X</translation>
     </message>
     <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="412"/>
-        <source>Prevent Horizontal movement of stick.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="416"/>
+        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="417"/>
-        <source>Hold Horizontal stick position.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WingtypeSelectionPage</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="332"/>
+        <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
         <translation>標準機翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="334"/>
+        <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
         <translation>飛翼 / 三角翼</translation>
     </message>
@@ -15971,22 +17034,22 @@ Process now?</source>
 <context>
     <name>WizMix</name>
     <message>
-        <location filename="../wizarddata.cpp" line="79"/>
+        <location filename="../wizarddata.cpp" line="80"/>
         <source>Flaps Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="80"/>
+        <location filename="../wizarddata.cpp" line="81"/>
         <source>Flaps Dn</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="84"/>
+        <location filename="../wizarddata.cpp" line="85"/>
         <source>AirbkOff</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../wizarddata.cpp" line="85"/>
+        <location filename="../wizarddata.cpp" line="86"/>
         <source>AirbkOn</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15994,273 +17057,273 @@ Process now?</source>
 <context>
     <name>WizardDialog</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="31"/>
+        <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
         <translation>模型嚮導</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
         <translation>模型種類</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="33"/>
+        <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
         <translation>輸入模型名稱和模型種類.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
         <translation>油門</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="34"/>
+        <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
         <translation>你的模型裝有馬達或引擎嗎?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
         <translation>機翼類型</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="35"/>
+        <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
         <translation>你的模型是是標準機翼, 還是飛翼/三角翼?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
         <translation>副翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="36"/>
+        <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
         <translation>你的模型有副翼嗎?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
         <translation>襟翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="37"/>
+        <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
         <translation>你的模型有襟翼嗎?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
         <translation>空氣剎車</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="38"/>
+        <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
         <translation>你的模型有空氣剎車嗎?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
         <translation>飛翼 / 三角翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="39"/>
+        <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
         <translation>指定升降副翼通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
         <translation>方向舵</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="40"/>
+        <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
         <translation>你的模型有方向舵嗎?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
         <translation>尾翼類型</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="41"/>
+        <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
         <translation>選擇你的飛機裝置何種尾翼類型.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
         <translation>尾翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="42"/>
         <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
         <translation>選擇尾翼通道.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="43"/>
+        <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
         <translation>V尾</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="44"/>
+        <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
         <translation>選擇升降舵通道.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
         <translation>傾斜盤</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="45"/>
+        <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
         <translation>你的直升機使用何種十字盤?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
         <translation>鎖尾陀螺儀</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="46"/>
+        <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
         <translation>你的直升機裝有感度可調的鎖尾陀螺嗎?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
         <translation>旋翼類型</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="47"/>
+        <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
         <translation>你的直升機有副翼嗎?</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
         <translation>直升機</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="48"/>
         <location filename="../wizarddialog.cpp" line="49"/>
+        <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
         <translation>選擇你的直升機的控制通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
         <translation>多軸</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="50"/>
+        <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
         <translation>選擇你的多旋翼的控制通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
         <translation>模型選項</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="51"/>
+        <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="52"/>
+        <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
         <translation>飛機通電後, 請人工檢查每個舵面的運動方向, 如果舵面運動方向錯誤請將此舵機設置成反向. 第一次通電前請卸下螺旋槳. &lt;br&gt;經常把不用的的模型配置刪除是好習慣!</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="75"/>
+        <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
         <translation>請輸入模型名字和模型種類.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="78"/>
+        <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
         <translation>選擇電調或油門舵機插在哪個通道上.&lt;br&gt;&lt;br&gt;Spektrum接收機:通道1, Futaba接收機: 通道3</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="82"/>
+        <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
         <translation>大多數固定翼的控制舵面分別安裝在機翼和尾翼上. 飛翼或三角翼只有一個機翼. 一般固定翼的主機翼上的舵面控制飛機繞縱軸的滾轉, 這些舵面叫做副翼.&lt;br&gt;飛翼機翼後緣的舵面控制飛機繞縱軸的滾轉和繞橫軸的仰俯. 這些舵面叫做升降副翼. </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="87"/>
+        <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
         <translation>模型使用一個或兩個通道來控制副翼.&lt;br&gt;如果使用一個通道, 則需要使用Y線來控制兩個副翼舵機.&lt;br&gt;&lt;br&gt;副翼通道 - Spektrum接收機: 通道2, Futaba接收機: 通道1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="93"/>
+        <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
         <translation>此嚮導假定你使用開關來控制襟翼. 如果你使用旋鈕控制襟翼, 你可以在嚮導完成後手動更改配置.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="97"/>
+        <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
         <translation>空氣剎車在高級滑翔機中用來降低空速, 它們很少見於普通固定翼中.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="101"/>
+        <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
         <translation>模型使用2個通道控制升降副翼 &lt;br&gt;選擇這兩個通道</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="105"/>
+        <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
         <translation>選擇方向舵通道.&lt;br&gt;&lt;br&gt;Spektrum接收機: 通道4, Futaba接收機: 通道4</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="109"/>
+        <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
         <translation>選擇你的飛機的尾翼類型.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="112"/>
-        <location filename="../wizarddialog.cpp" line="117"/>
+        <location filename="../wizarddialog.cpp" line="113"/>
+        <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>選擇方向舵或升降舵通道.&lt;br&gt;&lt;br&gt;方向舵: Spektrum接收機: 通道4, Futaba接收機: 通道4&lt;br&gt;升降舵: Spektrum接收機: 通道3, Futaba接收機: 通道2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="122"/>
+        <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
         <translation>選擇升降舵通道.&lt;br&gt;&lt;br&gt;Spektrum接收機: 通道3, Futaba接收機: 通道2</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="126"/>
-        <location filename="../wizarddialog.cpp" line="129"/>
-        <location filename="../wizarddialog.cpp" line="132"/>
-        <location filename="../wizarddialog.cpp" line="135"/>
-        <location filename="../wizarddialog.cpp" line="138"/>
-        <location filename="../wizarddialog.cpp" line="148"/>
-        <location filename="../wizarddialog.cpp" line="151"/>
+        <location filename="../wizarddialog.cpp" line="127"/>
+        <location filename="../wizarddialog.cpp" line="130"/>
+        <location filename="../wizarddialog.cpp" line="133"/>
+        <location filename="../wizarddialog.cpp" line="136"/>
+        <location filename="../wizarddialog.cpp" line="139"/>
+        <location filename="../wizarddialog.cpp" line="149"/>
+        <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
         <translation>TBD.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="141"/>
+        <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
         <translation>選擇你的多旋翼的控制通道.&lt;br&gt;&lt;br&gt;油门 - Spektrum: 通道1, Futaba: 通道3&lt;br&gt;偏航 - Spektrum: 通道4, Futaba: 通道4&lt;br&gt;仰俯 - Spektrum: 通道3, Futaba: 通道2&lt;br&gt;滚转  - Spektrum: 通道2, Futaba: 通道1</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="154"/>
+        <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
         <translation>當前頁面沒有幫助信息.</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="157"/>
+        <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
         <translation>模型嚮導幫助</translation>
     </message>
@@ -16268,37 +17331,37 @@ Process now?</source>
 <context>
     <name>WizardPrinter</name>
     <message>
-        <location filename="../wizarddialog.cpp" line="1028"/>
+        <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
         <translation>固定翼</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1030"/>
+        <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
         <translation>多軸</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1032"/>
+        <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
         <translation>直升機</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1054"/>
+        <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
         <translation>模型名稱:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1055"/>
+        <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
         <translation>模型種類:</translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1057"/>
+        <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
         <translation>選項: </translation>
     </message>
     <message>
-        <location filename="../wizarddialog.cpp" line="1069"/>
+        <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
         <translation>通道 %1: </translation>
     </message>
@@ -16306,46 +17369,46 @@ Process now?</source>
 <context>
     <name>YamlFormat</name>
     <message>
-        <location filename="../storage/yaml.cpp" line="34"/>
+        <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
         <translation type="unfinished">打開文件錯誤 %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="48"/>
+        <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="64"/>
+        <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="74"/>
+        <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="92"/>
-        <location filename="../storage/yaml.cpp" line="96"/>
+        <location filename="../storage/yaml.cpp" line="93"/>
+        <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="110"/>
+        <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="114"/>
+        <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../storage/yaml.cpp" line="117"/>
+        <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -16353,16 +17416,19 @@ Process now?</source>
 <context>
     <name>YamlGeneralSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="366"/>
-        <source>Warning: Radio settings file version %1 is not supported by this version of Companion!
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="373"/>
+        <source>Warning: File version %1 is not supported by this version of Companion!
 
-Model and radio settings may be corrupted if you continue.
-
-I acknowledge and accept the consequences.</source>
+Model and radio settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="397"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
+        <source>Read Radio Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
         <source>Warning: Radio settings file is missing the board entry!
 
 Current firmware profile board will be used.
@@ -16371,10 +17437,25 @@ Do you wish to continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="408"/>
+        <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YamlModelSettings</name>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1273"/>
+        <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
+
+Model settings may be corrupted if you continue.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1276"/>
+        <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -16481,18 +17562,18 @@ v4.1版電路板應為m2560</translation>
         <translation>使用高級控制項</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="43"/>
+        <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
         <translation>DFU-UTIL 配置</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="51"/>
+        <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
         <translation>SAM-BA 配置</translation>
     </message>
     <message>
-        <location filename="../burnconfigdialog.cpp" line="137"/>
-        <location filename="../burnconfigdialog.cpp" line="147"/>
+        <location filename="../burnconfigdialog.cpp" line="138"/>
+        <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
         <translation>選擇位置</translation>
     </message>
@@ -16530,7 +17611,7 @@ v4.1版電路板應為m2560</translation>
         <translation type="unfinished">開始通道  [CH]</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="311"/>
+        <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
         <translation>下一步</translation>
     </message>
@@ -16540,59 +17621,59 @@ v4.1版電路板應為m2560</translation>
         <translation>確定</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="157"/>
-        <location filename="../simulation/joystickdialog.cpp" line="183"/>
+        <location filename="../simulation/joystickdialog.cpp" line="158"/>
+        <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="217"/>
+        <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
         <translation type="unfinished">找不到遊戲桿</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="255"/>
+        <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
         <translation>找不到遊戲桿.</translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="300"/>
+        <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="310"/>
+        <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="315"/>
+        <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="327"/>
+        <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="331"/>
+        <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="335"/>
+        <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../simulation/joystickdialog.cpp" line="376"/>
+        <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
Summary of changes:
- run `companion_translations` job to refresh companion translations files
- flag `en` translations as complete, as they are the source translations anyway